### PR TITLE
Use LLVM Yaml Traits for config

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -1,10 +1,23 @@
 #pragma once
 
+#include "llvm/Support/YAMLTraits.h"
+
 #include <string>
 #include <vector>
 
 static int MutangDefaultTimeout = 3000;
 
+// We need these forward declarations to make our config friends with the
+// mapping traits.
+namespace Mutang {
+class Config;
+}
+namespace llvm {
+namespace yaml {
+template<typename T>
+struct MappingTraits;
+}
+}
 namespace Mutang {
 
 class Config {
@@ -16,7 +29,21 @@ class Config {
   int maxDistance;
   std::string cacheDirectory;
 
+  friend llvm::yaml::MappingTraits<Mutang::Config>;
 public:
+  // Constructor initializes defaults.
+  // TODO: Refactoring into constants.
+  Config() :
+    bitcodePaths(),
+    fork(true),
+    dryRun(false),
+    useCache(true),
+    timeout(MutangDefaultTimeout),
+    maxDistance(128),
+    cacheDirectory("/tmp/mutang_cache")
+  {
+  }
+
   Config(const std::vector<std::string> &paths,
          bool fork,
          bool dryrun,
@@ -63,5 +90,5 @@ public:
   }
 
 };
-
 }
+

--- a/include/ConfigParser.h
+++ b/include/ConfigParser.h
@@ -2,22 +2,38 @@
 
 #include "Config.h"
 
+#include "llvm/Support/YAMLTraits.h"
+
+#ifndef YAML_STRING_SEQUENCE
+#define YAML_STRING_SEQUENCE
+LLVM_YAML_IS_SEQUENCE_VECTOR(std::string)
+#endif
+
 namespace llvm {
-
 namespace yaml {
-
-class Stream;
-
+class Input;
+template <>
+struct MappingTraits<Mutang::Config>
+{
+  static void mapping(IO& io, Mutang::Config& config)
+  {
+    io.mapOptional("bitcode_files", config.bitcodePaths);
+    io.mapOptional("fork", config.fork);
+    io.mapOptional("dry_run", config.dryRun);
+    io.mapOptional("use_cache", config.useCache);
+    io.mapOptional("timeout", config.timeout);
+    io.mapOptional("max_distance", config.maxDistance);
+    io.mapOptional("cache_directory", config.cacheDirectory);
+  }
+};
 }
-
 }
 
 namespace Mutang {
 
 class ConfigParser {
 public:
-  std::unique_ptr<Config> loadConfig(llvm::yaml::Stream &stream);
-  std::unique_ptr<Config> loadConfig(const char *filename);
+  Config loadConfig(llvm::yaml::Input &input);
+  Config loadConfig(const char *filename);
 };
-
 }

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -37,14 +37,15 @@ llvm_add_library(mutang
   ${MUTANG_INCLUDE_DIR}/Toolchain
 
   LINK_LIBS
-  LLVMAsmPrinter
   LLVMAsmParser
+  LLVMAsmPrinter
   LLVMBitReader
   LLVMCodeGen
   LLVMCore
   LLVMExecutionEngine
   LLVMMCJIT
   LLVMObject
+  LLVMObjectYAML
   LLVMOrcJIT
   LLVMRuntimeDyld
   LLVMSupport

--- a/lib/ConfigParser.cpp
+++ b/lib/ConfigParser.cpp
@@ -1,5 +1,5 @@
-#include "ConfigParser.h"
 #include "Config.h"
+#include "ConfigParser.h"
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/SourceMgr.h"
@@ -10,114 +10,28 @@
 using namespace llvm;
 using namespace Mutang;
 
-std::unique_ptr<Config> ConfigParser::loadConfig(const char *filename) {
-  SourceMgr sourceManager;
-
+Config ConfigParser::loadConfig(const char *filename) {
   auto bufferOrError = MemoryBuffer::getFile(filename);
 
   if (!bufferOrError) {
-    printf("can't read config file '%s'\n", filename);
-    exit(1);
+    printf("Can't read config file '%s'\n", filename);
   }
 
   auto buffer = bufferOrError->get();
+  llvm::yaml::Input yin(buffer->getBuffer());
 
-  yaml::Stream yamlBuffer(buffer->getMemBufferRef(), sourceManager);
+  Config config;
+  yin >> config;
 
-  return loadConfig(yamlBuffer);
-}
-
-std::unique_ptr<Config> ConfigParser::loadConfig(yaml::Stream &stream) {
-  /// Fork is enabled by default
-  bool fork = true;
-  bool dryRun = false;
-  bool useCache = true;
-  int timeout = MutangDefaultTimeout;
-  int maxDistance = 128;
-  std::string cacheDirectory = "/tmp/mutang_cache";
-  auto paths = std::vector<std::string>();
-
-  yaml::Node *rootNode = stream.begin()->getRoot();
-  assert(rootNode && "Expected config file to be a valid yaml document");
-
-  auto mappingNode = dyn_cast<yaml::MappingNode>(rootNode);
-
-  for (auto &keyValue : *mappingNode) {
-    auto key = dyn_cast<yaml::ScalarNode>(keyValue.getKey());
-
-    if (key->getRawValue().equals(StringRef("bitcode_files"))) {
-      auto values = dyn_cast<yaml::SequenceNode>(keyValue.getValue());
-
-      for (auto &value : *values) {
-        auto bitcodePath = dyn_cast<yaml::ScalarNode>(&value);
-        assert(bitcodePath && "bitcode_files should contain strings (scalars)");
-        paths.push_back(bitcodePath->getRawValue().str());
-      }
-    }
-
-    else if (key->getRawValue().equals(StringRef("fork"))) {
-      auto value = dyn_cast<yaml::ScalarNode>(keyValue.getValue());
-
-      if (value->getRawValue().equals(StringRef("true"))) {
-        fork = true;
-      } else {
-        fork = false;
-      }
-    }
-
-    else if (key->getRawValue().equals(StringRef("dryRun"))) {
-      auto value = dyn_cast<yaml::ScalarNode>(keyValue.getValue());
-
-      if (value->getRawValue().equals(StringRef("true"))) {
-        dryRun = true;
-      } else {
-        dryRun = false;
-      }
-    }
-
-    else if (key->getRawValue().equals(StringRef("use_cache"))) {
-      auto value = dyn_cast<yaml::ScalarNode>(keyValue.getValue());
-
-      if (value->getRawValue().equals(StringRef("true"))) {
-        useCache = true;
-      } else {
-        useCache = false;
-      }
-    }
-
-    else if (key->getRawValue().equals(StringRef("timeout"))) {
-      auto value = dyn_cast<yaml::ScalarNode>(keyValue.getValue());
-
-      std::string timeoutStringValue = value->getRawValue().str();
-
-      int timeoutValue = ::atoi(timeoutStringValue.c_str());
-
-      assert(timeoutValue > 0 &&
-             "ConfigParser error: timeout value was provided but we could not resolve it to a meaningful value.");
-
-      timeout = timeoutValue;
-    }
-
-    else if (key->getRawValue().equals(StringRef("maxDistance"))) {
-      auto value = dyn_cast<yaml::ScalarNode>(keyValue.getValue());
-
-      std::string timeoutStringValue = value->getRawValue().str();
-
-      int distance = ::atoi(timeoutStringValue.c_str());
-
-      assert(distance > 0 &&
-             "ConfigParser error: distance should be more than zero.");
-
-      maxDistance = distance;
-    }
-
-    else if (key->getRawValue().equals(StringRef("cache_directory"))) {
-      auto value = dyn_cast<yaml::ScalarNode>(keyValue.getValue());
-
-      cacheDirectory = value->getRawValue().str();
-    }
+  if (yin.error()) {
+    printf("Failed to parse YAML file: '%s'", filename);
   }
 
-  return make_unique<Config>(paths, fork, dryRun, useCache, timeout,
-                             maxDistance, cacheDirectory);
+  return config;
+}
+
+Config ConfigParser::loadConfig(yaml::Input &input) {
+  Config config;
+  input >> config;
+  return config;
 }

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -1,6 +1,6 @@
-#include "Driver.h"
-#include "ConfigParser.h"
 #include "Config.h"
+#include "ConfigParser.h"
+#include "Driver.h"
 #include "ModuleLoader.h"
 #include "MutationPoint.h"
 #include "SQLiteReporter.h"
@@ -16,8 +16,8 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/SourceMgr.h"
-#include "llvm/Support/YAMLParser.h"
 #include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/YAMLParser.h"
 
 #include <ctime>
 #include <string>
@@ -33,10 +33,10 @@ int debug_main(int argc, char *argv[]) {
   ModuleLoader Loader(Ctx);
 
   GoogleTestFinder TestFinder;
-  Toolchain toolchain(*config.get());
+  Toolchain toolchain(config);
   GoogleTestRunner Runner(toolchain.targetMachine());
 
-  Driver D(*config.get(), Loader, TestFinder, Runner, toolchain);
+  Driver D(config, Loader, TestFinder, Runner, toolchain);
 
   if (strcmp(argv[2], "-print-test-names") == 0) {
     D.debug_PrintTestNames();
@@ -63,7 +63,7 @@ int main(int argc, char *argv[]) {
 
   LLVMContext Ctx;
   ModuleLoader Loader(Ctx);
-  Toolchain toolchain(*config.get());
+  Toolchain toolchain(config);
 
 #if 1
   GoogleTestFinder TestFinder;
@@ -73,12 +73,12 @@ int main(int argc, char *argv[]) {
   SimpleTestRunner Runner(toolchain.targetMachine());
 #endif
 
-  Driver driver(*config.get(), Loader, TestFinder, Runner, toolchain);
+  Driver driver(config, Loader, TestFinder, Runner, toolchain);
   auto results = driver.Run();
 
   SQLiteReporter reporter;
   reporter.reportResults(results);
   /// It does crash at the very moment
   /// llvm_shutdown();
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/unittests/ConfigParserTests.cpp
+++ b/unittests/ConfigParserTests.cpp
@@ -10,174 +10,153 @@ using namespace Mutang;
 using namespace llvm;
 
 TEST(ConfigParser, loadConfig_BitcodeFiles) {
-    SourceMgr SM;
-    yaml::Stream Stream(
+    yaml::Input Input(
                         "bitcode_files:\n"
                         "  - foo.bc\n"
-                        "  - bar.bc\n", SM);
+                        "  - bar.bc\n");
 
     ConfigParser Parser;
-    auto Cfg = Parser.loadConfig(Stream);
+    auto Cfg = Parser.loadConfig(Input);
 
-    ASSERT_EQ(2U, Cfg->getBitcodePaths().size());
-    ASSERT_EQ("foo.bc", *(Cfg->getBitcodePaths().begin()));
-    ASSERT_EQ("bar.bc", *(Cfg->getBitcodePaths().end() - 1));
-    ASSERT_EQ("bar.bc", *(Cfg->getBitcodePaths().end() - 1));
+    ASSERT_EQ(2U, Cfg.getBitcodePaths().size());
+    ASSERT_EQ("foo.bc", *(Cfg.getBitcodePaths().begin()));
+    ASSERT_EQ("bar.bc", *(Cfg.getBitcodePaths().end() - 1));
+    ASSERT_EQ("bar.bc", *(Cfg.getBitcodePaths().end() - 1));
 }
 
 TEST(ConfigParser, loadConfig_Fork_True) {
-  SourceMgr SM;
-  yaml::Stream Stream(
-                      "fork: true\n", SM);
-
+  yaml::Input Input(
+                      "fork: true\n");
   ConfigParser Parser;
-  auto Cfg = Parser.loadConfig(Stream);
+  auto Cfg = Parser.loadConfig(Input);
 
-  ASSERT_EQ(true, Cfg->getFork());
+  ASSERT_EQ(true, Cfg.getFork());
 }
 
 TEST(ConfigParser, loadConfig_Fork_False) {
-  SourceMgr SM;
-  yaml::Stream Stream("fork: false\n", SM);
+  yaml::Input Input("fork: false\n");
 
   ConfigParser Parser;
-  auto Cfg = Parser.loadConfig(Stream);
+  auto Cfg = Parser.loadConfig(Input);
 
-  ASSERT_EQ(false, Cfg->getFork());
+  ASSERT_EQ(false, Cfg.getFork());
 }
 
 TEST(ConfigParser, loadConfig_Fork_Unspecified) {
-  SourceMgr SM;
-
   /// Surprisingly enough, yaml library crashes on empty string so
   /// providing 'bitcode_files:' with content just to overcome the assert.
-  yaml::Stream Stream("bitcode_files:\n"
+  yaml::Input Input("bitcode_files:\n"
                       "  - foo.bc\n"
-                      "  - bar.bc\n", SM);
+                      "  - bar.bc\n");
 
   ConfigParser Parser;
-  auto Cfg = Parser.loadConfig(Stream);
+  auto Cfg = Parser.loadConfig(Input);
 
-  ASSERT_EQ(true, Cfg->getFork());
+  ASSERT_EQ(true, Cfg.getFork());
 }
 
 TEST(ConfigParser, loadConfig_Timeout_Unspecified) {
-  SourceMgr SM;
-
   /// Surprisingly enough, yaml library crashes on empty string so
   /// providing 'bitcode_files:' with content just to overcome the assert.
-  yaml::Stream Stream("bitcode_files:\n"
+  yaml::Input Input("bitcode_files:\n"
                       "  - foo.bc\n"
-                      "  - bar.bc\n", SM);
+                      "  - bar.bc\n");
 
   ConfigParser Parser;
-  auto Cfg = Parser.loadConfig(Stream);
+  auto Cfg = Parser.loadConfig(Input);
 
-  ASSERT_EQ(MutangDefaultTimeout, Cfg->getTimeout());
+  ASSERT_EQ(MutangDefaultTimeout, Cfg.getTimeout());
 }
 
 TEST(ConfigParser, loadConfig_Timeout_SpecificValue) {
-  SourceMgr SM;
-  yaml::Stream Stream("timeout: 15\n", SM);
+  yaml::Input Input("timeout: 15\n");
 
   ConfigParser Parser;
-  auto Cfg = Parser.loadConfig(Stream);
+  auto Cfg = Parser.loadConfig(Input);
 
-  ASSERT_EQ(15, Cfg->getTimeout());
+  ASSERT_EQ(15, Cfg.getTimeout());
 }
 
 TEST(ConfigParser, loadConfig_DryRun_Unspecified) {
-  SourceMgr SM;
-
   /// Surprisingly enough, yaml library crashes on empty string so
   /// providing 'bitcode_files:' with content just to overcome the assert.
-  yaml::Stream Stream("bitcode_files:\n"
+  yaml::Input Input("bitcode_files:\n"
                       "  - foo.bc\n"
-                      "  - bar.bc\n", SM);
+                      "  - bar.bc\n");
 
   ConfigParser Parser;
-  auto Cfg = Parser.loadConfig(Stream);
+  auto Cfg = Parser.loadConfig(Input);
 
-  ASSERT_FALSE(Cfg->isDryRun());
+  ASSERT_FALSE(Cfg.isDryRun());
 }
 
 TEST(ConfigParser, loadConfig_DryRun_SpecificValue) {
   ConfigParser Parser;
-  SourceMgr SM;
-  yaml::Stream Stream("dryRun: true\n", SM);
-  auto Cfg = Parser.loadConfig(Stream);
-  ASSERT_TRUE(Cfg->isDryRun());
+  yaml::Input Input("dry_run: true\n");
+  auto Cfg = Parser.loadConfig(Input);
+  ASSERT_TRUE(Cfg.isDryRun());
 }
 
 TEST(ConfigParser, loadConfig_UseCache_Unspecified) {
-  SourceMgr SM;
-
   /// Surprisingly enough, yaml library crashes on empty string so
   /// providing 'bitcode_files:' with content just to overcome the assert.
-  yaml::Stream Stream("bitcode_files:\n"
+  yaml::Input Input("bitcode_files:\n"
                       "  - foo.bc\n"
-                      "  - bar.bc\n", SM);
+                      "  - bar.bc\n");
 
   ConfigParser Parser;
-  auto Cfg = Parser.loadConfig(Stream);
-  ASSERT_TRUE(Cfg->getUseCache());
+  auto Cfg = Parser.loadConfig(Input);
+  ASSERT_TRUE(Cfg.getUseCache());
 }
 
 TEST(ConfigParser, loadConfig_UseCache_SpecificValue) {
-  SourceMgr SM;
-  yaml::Stream Stream("use_cache: false\n", SM);
+  yaml::Input Input("use_cache: false\n");
 
   ConfigParser Parser;
-  auto Cfg = Parser.loadConfig(Stream);
-  ASSERT_FALSE(Cfg->getUseCache());
+  auto Cfg = Parser.loadConfig(Input);
+  ASSERT_FALSE(Cfg.getUseCache());
 }
 
 TEST(ConfigParser, loadConfig_MaxDistance_Unspecified) {
-  SourceMgr SM;
-
   /// Surprisingly enough, yaml library crashes on empty string so
   /// providing 'bitcode_files:' with content just to overcome the assert.
-  yaml::Stream Stream("bitcode_files:\n"
+  yaml::Input Input("bitcode_files:\n"
                       "  - foo.bc\n"
-                      "  - bar.bc\n", SM);
+                      "  - bar.bc\n");
 
   ConfigParser Parser;
-  auto Cfg = Parser.loadConfig(Stream);
+  auto Cfg = Parser.loadConfig(Input);
 
-  ASSERT_EQ(128, Cfg->getMaxDistance());
+  ASSERT_EQ(128, Cfg.getMaxDistance());
 }
 
 TEST(ConfigParser, loadConfig_MaxDistance_SpecificValue) {
-  SourceMgr SM;
-  yaml::Stream Stream("maxDistance: 3\n", SM);
+  yaml::Input Input("max_distance: 3\n");
 
   ConfigParser Parser;
-  auto Cfg = Parser.loadConfig(Stream);
+  auto Cfg = Parser.loadConfig(Input);
 
-  ASSERT_EQ(3, Cfg->getMaxDistance());
+  ASSERT_EQ(3, Cfg.getMaxDistance());
 }
 
 TEST(ConfigParser, loadConfig_CacheDirectory_Unspecified) {
-  SourceMgr SM;
-
   /// Surprisingly enough, yaml library crashes on empty string so
   /// providing 'bitcode_files:' with content just to overcome the assert.
-  yaml::Stream Stream("bitcode_files:\n"
+  yaml::Input Input("bitcode_files:\n"
                       "  - foo.bc\n"
-                      "  - bar.bc\n", SM);
+                      "  - bar.bc\n");
 
   ConfigParser Parser;
-  auto Cfg = Parser.loadConfig(Stream);
+  auto Cfg = Parser.loadConfig(Input);
 
-  ASSERT_EQ("/tmp/mutang_cache", Cfg->getCacheDirectory());
+  ASSERT_EQ("/tmp/mutang_cache", Cfg.getCacheDirectory());
 }
 
 TEST(ConfigParser, loadConfig_CacheDirectory_SpecificValue) {
-  SourceMgr SM;
-  yaml::Stream Stream("cache_directory: /var/tmp\n", SM);
+  yaml::Input Input("cache_directory: /var/tmp\n");
 
   ConfigParser Parser;
-  auto Cfg = Parser.loadConfig(Stream);
+  auto Cfg = Parser.loadConfig(Input);
 
-  ASSERT_EQ("/var/tmp", Cfg->getCacheDirectory());
+  ASSERT_EQ("/var/tmp", Cfg.getCacheDirectory());
 }


### PR DESCRIPTION
 - Use [LLVM's YAML I/O](http://llvm.org/docs/YamlIO.html) Library for parsing the configuration file.
 - Consistent options: everything now uses an underscore (e.g. dry_run instead of DryRun).
 - Config is no longer a unique pointer. If something fails you end up with the default config. If this is not the desired behavior, we could pass the config by reference and have the function return a bool or use as a 3rd option we could use the llvm::Expect<T> type. 