### PR TITLE
Make Mutation Operators configurable

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "MutationOperators/AddMutationOperator.h"
+#include "MutationOperators/NegateConditionMutationOperator.h"
+#include "MutationOperators/RemoveVoidFunctionMutationOperator.h"
+
 #include "llvm/Support/YAMLTraits.h"
 
 #include <string>
@@ -28,6 +32,7 @@ class Config {
   int timeout;
   int maxDistance;
   std::string cacheDirectory;
+  std::vector<std::string> mutationOperators;
 
   friend llvm::yaml::MappingTraits<mull::Config>;
 public:
@@ -40,7 +45,12 @@ public:
     useCache(true),
     timeout(MullDefaultTimeout),
     maxDistance(128),
-    cacheDirectory("/tmp/mull_cache")
+    cacheDirectory("/tmp/mull_cache"),
+    mutationOperators({
+      AddMutationOperator::ID,
+      NegateConditionMutationOperator::ID,
+      RemoveVoidFunctionMutationOperator::ID
+    })
   {
   }
 
@@ -50,14 +60,16 @@ public:
          bool cache,
          int timeout,
          int distance,
-         const std::string &cacheDir) :
+         const std::string &cacheDir,
+         std::vector<std::string> mutationOperators) :
     bitcodePaths(paths),
     fork(fork),
     dryRun(dryrun),
     useCache(cache),
     timeout(timeout),
     maxDistance(distance),
-    cacheDirectory(cacheDir)
+    cacheDirectory(cacheDir),
+    mutationOperators(mutationOperators)
   {
   }
 
@@ -89,6 +101,9 @@ public:
     return cacheDirectory;
   }
 
+  const std::vector<std::string> &getMutationOperators() const {
+    return mutationOperators;
+  }
 };
 }
 

--- a/include/ConfigParser.h
+++ b/include/ConfigParser.h
@@ -24,6 +24,7 @@ struct MappingTraits<mull::Config>
     io.mapOptional("timeout", config.timeout);
     io.mapOptional("max_distance", config.maxDistance);
     io.mapOptional("cache_directory", config.cacheDirectory);
+    io.mapOptional("mutation_operators", config.mutationOperators);
   }
 };
 }

--- a/include/Driver.h
+++ b/include/Driver.h
@@ -4,6 +4,7 @@
 #include "TestResult.h"
 #include "ForkProcessSandbox.h"
 #include "Context.h"
+#include "MutationOperators/MutationOperator.h"
 
 #include "Toolchain/Toolchain.h"
 
@@ -55,6 +56,9 @@ public:
   void debug_PrintTestNames();
   void debug_PrintTesteeNames();
   void debug_PrintMutationPoints();
+  
+  static std::vector<std::unique_ptr<MutationOperator>> mutationOperators
+    (std::vector<std::string> mutationOperatorStrings);
 
 private:
   /// Returns cached object files for all modules excerpt one provided

--- a/include/GoogleTest/GoogleTestFinder.h
+++ b/include/GoogleTest/GoogleTestFinder.h
@@ -28,7 +28,7 @@ class GoogleTestFinder : public TestFinder {
 
   std::vector<std::unique_ptr<MutationOperator>> mutationOperators;
 public:
-  explicit GoogleTestFinder();
+  GoogleTestFinder(std::vector<std::unique_ptr<MutationOperator>> mutationOperators);
 
   std::vector<std::unique_ptr<Test>> findTests(Context &Ctx) override;
   std::vector<std::unique_ptr<Testee>> findTestees(Test *Test,

--- a/include/MutationOperators/AddMutationOperator.h
+++ b/include/MutationOperators/AddMutationOperator.h
@@ -1,4 +1,4 @@
-#pragma mark
+#pragma once
 
 #include "MutationOperators/MutationOperator.h"
 
@@ -11,16 +11,19 @@ class MutationPointAddress;
 class MutationOperatorFilter;
 
 class AddMutationOperator : public MutationOperator {
+
 public:
+  static const std::string ID;
+
   std::vector<MutationPoint *> getMutationPoints(const Context &context,
                                                  llvm::Function *function,
                                                  MutationOperatorFilter &filter) override;
 
   std::string uniqueID() override {
-    return "add_mutation_operator";
+    return ID;
   }
   std::string uniqueID() const override {
-    return "add_mutation_operator";
+    return ID;
   }
 
   bool canBeApplied(llvm::Value &V) override;
@@ -29,3 +32,4 @@ public:
 };
 
 }
+

--- a/include/MutationOperators/NegateConditionMutationOperator.h
+++ b/include/MutationOperators/NegateConditionMutationOperator.h
@@ -1,4 +1,4 @@
-#pragma mark
+#pragma once
 
 #include "MutationOperators/MutationOperator.h"
 
@@ -15,16 +15,18 @@ namespace mull {
   class NegateConditionMutationOperator : public MutationOperator {
 
   public:
+    static const std::string ID;
+
     static llvm::CmpInst::Predicate negatedCmpInstPredicate(llvm::CmpInst::Predicate predicate);
     std::vector<MutationPoint *> getMutationPoints(const Context &context,
                                                    llvm::Function *function,
                                                    MutationOperatorFilter &filter) override;
 
     std::string uniqueID() override {
-      return "negate_mutation_operator";
+      return ID;
     }
     std::string uniqueID() const override {
-      return "negate_mutation_operator";
+      return ID;
     }
 
     bool canBeApplied(llvm::Value &V) override;

--- a/include/MutationOperators/RemoveVoidFunctionMutationOperator.h
+++ b/include/MutationOperators/RemoveVoidFunctionMutationOperator.h
@@ -1,4 +1,4 @@
-#pragma mark
+#pragma once
 
 #include "MutationOperators/MutationOperator.h"
 
@@ -15,15 +15,17 @@ namespace mull {
   class RemoveVoidFunctionMutationOperator : public MutationOperator {
 
   public:
+    static const std::string ID;
+
     std::vector<MutationPoint *> getMutationPoints(const Context &context,
                                                    llvm::Function *function,
                                                    MutationOperatorFilter &filter) override;
 
     std::string uniqueID() override {
-      return "remove_void_function_mutation_operator";
+      return ID;
     }
     std::string uniqueID() const override {
-      return "remove_void_function_mutation_operator";
+      return ID;
     }
 
     bool canBeApplied(llvm::Value &V) override;

--- a/lib/Driver.cpp
+++ b/lib/Driver.cpp
@@ -190,6 +190,26 @@ std::unique_ptr<Result> Driver::Run() {
   return result;
 }
 
+std::vector<std::unique_ptr<MutationOperator>> Driver::mutationOperators
+  (std::vector<std::string> mutationOperatorStrings) {
+    std::vector<std::unique_ptr<MutationOperator>> mutationOperators;
+    for (auto mutation : mutationOperatorStrings) {
+      if (mutation == AddMutationOperator::ID) {
+        mutationOperators.emplace_back(make_unique<AddMutationOperator>());
+      }
+      else if (mutation == NegateConditionMutationOperator::ID) {
+        mutationOperators.emplace_back(make_unique<NegateConditionMutationOperator>());
+      }
+      else if (mutation == RemoveVoidFunctionMutationOperator::ID) {
+        mutationOperators.emplace_back(make_unique<RemoveVoidFunctionMutationOperator>());
+      }
+      else {
+        Logger::error() << "Unknown Mutation Operator: " << mutation << "\n";
+      }
+    }
+    return mutationOperators;
+}
+
 std::vector<llvm::object::ObjectFile *> Driver::AllButOne(llvm::Module *One) {
   std::vector<llvm::object::ObjectFile *> Objects;
 

--- a/lib/GoogleTest/GoogleTestFinder.cpp
+++ b/lib/GoogleTest/GoogleTestFinder.cpp
@@ -48,12 +48,9 @@ public:
   };
 };
 
-GoogleTestFinder::GoogleTestFinder() : TestFinder() {
-  /// FIXME: should come from outside
-  mutationOperators.emplace_back(make_unique<AddMutationOperator>());
-  mutationOperators.emplace_back(make_unique<NegateConditionMutationOperator>());
-  mutationOperators.emplace_back(make_unique<RemoveVoidFunctionMutationOperator>());
-}
+GoogleTestFinder::GoogleTestFinder(
+    std::vector<std::unique_ptr<MutationOperator>> mutationOperators)
+    : TestFinder(), mutationOperators(std::move(mutationOperators)) {}
 
 /// The algorithm is the following:
 ///

--- a/lib/MutationOperators/AddMutationOperator.cpp
+++ b/lib/MutationOperators/AddMutationOperator.cpp
@@ -16,6 +16,8 @@
 using namespace llvm;
 using namespace mull;
 
+const std::string AddMutationOperator::ID = "add_mutation_operator";
+
 static int GetFunctionIndex(llvm::Function *function) {
   auto PM = function->getParent();
 

--- a/lib/MutationOperators/NegateConditionMutationOperator.cpp
+++ b/lib/MutationOperators/NegateConditionMutationOperator.cpp
@@ -16,6 +16,9 @@
 using namespace llvm;
 using namespace mull;
 
+const std::string NegateConditionMutationOperator::ID =
+  "negate_mutation_operator";
+
 ///
 /// Comparison instructions emitted for explicit and implicit comparisons
 /// We should only apply mutations on explicit comparisons.

--- a/lib/MutationOperators/RemoveVoidFunctionMutationOperator.cpp
+++ b/lib/MutationOperators/RemoveVoidFunctionMutationOperator.cpp
@@ -15,6 +15,9 @@
 using namespace llvm;
 using namespace mull;
 
+const std::string RemoveVoidFunctionMutationOperator::ID =
+  "remove_void_function_mutation_operator";
+
 static int GetFunctionIndex(llvm::Function *function) {
   auto PM = function->getParent();
 

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -73,8 +73,10 @@ int debug_main() {
 
   LLVMContext Ctx;
   ModuleLoader Loader(Ctx);
-
-  GoogleTestFinder TestFinder;
+  
+  auto mutationOperators = Driver::mutationOperators(config.getMutationOperators());
+  
+  GoogleTestFinder TestFinder(std::move(mutationOperators));
   Toolchain toolchain(config);
   GoogleTestRunner Runner(toolchain.targetMachine());
 
@@ -112,7 +114,8 @@ int main(int argc, char *argv[]) {
   Toolchain toolchain(config);
 
 #if 1
-  GoogleTestFinder TestFinder;
+  auto mutationOperators = Driver::mutationOperators(config.getMutationOperators());
+  GoogleTestFinder TestFinder(std::move(mutationOperators));
   GoogleTestRunner Runner(toolchain.targetMachine());
 #else
   SimpleTestFinder TestFinder;

--- a/unittests/ConfigParserTests.cpp
+++ b/unittests/ConfigParserTests.cpp
@@ -25,8 +25,8 @@ TEST(ConfigParser, loadConfig_BitcodeFiles) {
 }
 
 TEST(ConfigParser, loadConfig_Fork_True) {
-  yaml::Input Input(
-                      "fork: true\n");
+  yaml::Input Input("fork: true\n");
+
   ConfigParser Parser;
   auto Cfg = Parser.loadConfig(Input);
 
@@ -43,11 +43,7 @@ TEST(ConfigParser, loadConfig_Fork_False) {
 }
 
 TEST(ConfigParser, loadConfig_Fork_Unspecified) {
-  /// Surprisingly enough, yaml library crashes on empty string so
-  /// providing 'bitcode_files:' with content just to overcome the assert.
-  yaml::Input Input("bitcode_files:\n"
-                      "  - foo.bc\n"
-                      "  - bar.bc\n");
+  yaml::Input Input("");
 
   ConfigParser Parser;
   auto Cfg = Parser.loadConfig(Input);
@@ -56,11 +52,7 @@ TEST(ConfigParser, loadConfig_Fork_Unspecified) {
 }
 
 TEST(ConfigParser, loadConfig_Timeout_Unspecified) {
-  /// Surprisingly enough, yaml library crashes on empty string so
-  /// providing 'bitcode_files:' with content just to overcome the assert.
-  yaml::Input Input("bitcode_files:\n"
-                      "  - foo.bc\n"
-                      "  - bar.bc\n");
+  yaml::Input Input("");
 
   ConfigParser Parser;
   auto Cfg = Parser.loadConfig(Input);
@@ -78,11 +70,7 @@ TEST(ConfigParser, loadConfig_Timeout_SpecificValue) {
 }
 
 TEST(ConfigParser, loadConfig_DryRun_Unspecified) {
-  /// Surprisingly enough, yaml library crashes on empty string so
-  /// providing 'bitcode_files:' with content just to overcome the assert.
-  yaml::Input Input("bitcode_files:\n"
-                      "  - foo.bc\n"
-                      "  - bar.bc\n");
+  yaml::Input Input("");
 
   ConfigParser Parser;
   auto Cfg = Parser.loadConfig(Input);
@@ -98,11 +86,7 @@ TEST(ConfigParser, loadConfig_DryRun_SpecificValue) {
 }
 
 TEST(ConfigParser, loadConfig_UseCache_Unspecified) {
-  /// Surprisingly enough, yaml library crashes on empty string so
-  /// providing 'bitcode_files:' with content just to overcome the assert.
-  yaml::Input Input("bitcode_files:\n"
-                      "  - foo.bc\n"
-                      "  - bar.bc\n");
+  yaml::Input Input("");
 
   ConfigParser Parser;
   auto Cfg = Parser.loadConfig(Input);
@@ -118,11 +102,7 @@ TEST(ConfigParser, loadConfig_UseCache_SpecificValue) {
 }
 
 TEST(ConfigParser, loadConfig_MaxDistance_Unspecified) {
-  /// Surprisingly enough, yaml library crashes on empty string so
-  /// providing 'bitcode_files:' with content just to overcome the assert.
-  yaml::Input Input("bitcode_files:\n"
-                      "  - foo.bc\n"
-                      "  - bar.bc\n");
+  yaml::Input Input("");
 
   ConfigParser Parser;
   auto Cfg = Parser.loadConfig(Input);
@@ -140,11 +120,7 @@ TEST(ConfigParser, loadConfig_MaxDistance_SpecificValue) {
 }
 
 TEST(ConfigParser, loadConfig_CacheDirectory_Unspecified) {
-  /// Surprisingly enough, yaml library crashes on empty string so
-  /// providing 'bitcode_files:' with content just to overcome the assert.
-  yaml::Input Input("bitcode_files:\n"
-                      "  - foo.bc\n"
-                      "  - bar.bc\n");
+  yaml::Input Input("");
 
   ConfigParser Parser;
   auto Cfg = Parser.loadConfig(Input);
@@ -159,4 +135,39 @@ TEST(ConfigParser, loadConfig_CacheDirectory_SpecificValue) {
   auto Cfg = Parser.loadConfig(Input);
 
   ASSERT_EQ("/var/tmp", Cfg.getCacheDirectory());
+}
+
+TEST(ConfigParser, loadConfig_MutationOperators_SpecificValue) {
+  const char *configYAML = R"YAML(
+mutation_operators:
+- add_mutation_operator
+- negate_mutation_operator
+- remove_void_function_mutation_operator
+)YAML";
+
+  yaml::Input Input(configYAML);
+
+  ConfigParser Parser;
+  auto Cfg = Parser.loadConfig(Input);
+
+  auto mutationOperators = Cfg.getMutationOperators();
+  ASSERT_EQ(3U, mutationOperators.size());
+  ASSERT_EQ(AddMutationOperator::ID, mutationOperators[0]);
+  ASSERT_EQ(NegateConditionMutationOperator::ID, mutationOperators[1]);
+  ASSERT_EQ(RemoveVoidFunctionMutationOperator::ID, mutationOperators[2]);
+}
+
+TEST(ConfigParser, loadConfig_MutationOperators_Unspecified) {
+  const char *configYAML = "";
+
+  yaml::Input Input(configYAML);
+
+  ConfigParser Parser;
+  auto Cfg = Parser.loadConfig(Input);
+
+  auto mutationOperators = Cfg.getMutationOperators();
+  ASSERT_EQ(3U, mutationOperators.size());
+  ASSERT_EQ(AddMutationOperator::ID, mutationOperators[0]);
+  ASSERT_EQ(NegateConditionMutationOperator::ID, mutationOperators[1]);
+  ASSERT_EQ(RemoveVoidFunctionMutationOperator::ID, mutationOperators[2]);
 }

--- a/unittests/DriverTests.cpp
+++ b/unittests/DriverTests.cpp
@@ -96,7 +96,7 @@ TEST(Driver, SimpleTest_AddMutationOperator) {
   int distance = 10;
   std::string cacheDirectory = "/tmp/mull_cache";
   Config config(ModulePaths, doFork, dryRun, useCache, MullDefaultTimeout,
-                distance, cacheDirectory);
+                distance, cacheDirectory, {});
 
   FakeModuleLoader loader;
 
@@ -150,7 +150,7 @@ TEST(Driver, SimpleTest_NegateConditionMutationOperator) {
   int distance = 10;
   std::string cacheDirectory = "/tmp/mull_cache";
   Config config(ModulePaths, doFork, dryRun, useCache, MullDefaultTimeout,
-                distance, cacheDirectory);
+                distance, cacheDirectory, {});
 
   std::vector<std::unique_ptr<MutationOperator>> mutationOperators;
   mutationOperators.emplace_back(make_unique<NegateConditionMutationOperator>());
@@ -195,7 +195,7 @@ TEST(Driver, SimpleTest_RemoveVoidFunctionMutationOperator) {
   int distance = 10;
   std::string cacheDirectory = "/tmp/mull_cache";
   Config config(ModulePaths, doFork, dryRun, useCache, MullDefaultTimeout,
-                distance, cacheDirectory);
+                distance, cacheDirectory, {});
 
   std::vector<std::unique_ptr<MutationOperator>> mutationOperators;
   mutationOperators.emplace_back(make_unique<RemoveVoidFunctionMutationOperator>());
@@ -240,7 +240,7 @@ TEST(Driver, SimpleTest_TesteePathCalculation) {
   int distance = 10;
   std::string cacheDirectory = "/tmp/mull_cache";
   Config config(ModulePaths, doFork, dryRun, useCache, MullDefaultTimeout,
-                distance, cacheDirectory);
+                distance, cacheDirectory, {});
 
   std::vector<std::unique_ptr<MutationOperator>> mutationOperators;
   mutationOperators.emplace_back(make_unique<AddMutationOperator>());


### PR DESCRIPTION
#39
- [x] First need to merge #88
- [x] Handle validation of a config input
- [x] Propagate the valid config values of `getMutationOperators` to `GoogleTestFinder`.
- [x] Adjust mull-driver target to `GoogleTestFinder` constructor