### PR TITLE
Update code to work against newer LLVM.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ cd ~/Projects/LLVM
 
 git clone http://llvm.org/git/llvm.git
 cd llvm
-git checkout 106bb1fe2db88fe77458ec594c461c8428588dab
+git checkout dc30ded6fb9526aba31a86b97e8f69fc9baece00
 
 git clone https://github.com/mull-project/mull.git projects/mull
 
@@ -37,5 +37,5 @@ Update to LLVM's trunk should be a recurrent task, but first we need to get
 experience of living in a downstream world.
 
 Current code is being developed against LLVM commit:
-[106bb1fe2db88fe77458ec594c461c8428588dab](https://github.com/llvm-mirror/llvm/commit/106bb1fe2db88fe77458ec594c461c8428588dab).
+[dc30ded6fb9526aba31a86b97e8f69fc9baece00](https://github.com/llvm-mirror/llvm/commit/dc30ded6fb9526aba31a86b97e8f69fc9baece00).
 

--- a/lib/GoogleTest/GoogleTestFinder.cpp
+++ b/lib/GoogleTest/GoogleTestFinder.cpp
@@ -98,12 +98,12 @@ std::vector<std::unique_ptr<Test>> GoogleTestFinder::findTests(Context &Ctx) {
         continue;
       }
 
-      Type *SeqTy = Ty->getSequentialElementType();
-      if (!SeqTy) {
+      Type *globalType = Ty->getPointerElementType();
+      if (!globalType) {
         continue;
       }
 
-      StructType *STy = dyn_cast<StructType>(SeqTy);
+      StructType *STy = dyn_cast<StructType>(globalType);
       if (!STy) {
         continue;
       }

--- a/lib/ModuleLoader.cpp
+++ b/lib/ModuleLoader.cpp
@@ -3,8 +3,7 @@
 #include "Logger.h"
 
 #include "llvm/AsmParser/Parser.h"
-//#include "llvm/Bitcode/BitcodeReader.h"
-#include "llvm/Bitcode/ReaderWriter.h"
+#include "llvm/Bitcode/BitcodeReader.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/MD5.h"


### PR DESCRIPTION
- Updates Mull to work against this LLVM commit:

```
commit dc30ded6fb9526aba31a86b97e8f69fc9baece00
Author: Justin Lebar <jlebar@google.com>
Date:   Wed Jan 18 00:29:53 2017 +0000
```

- Small tweak of GoogleTestFinder was needed:

class.testing::TestInfo functions are no longer under sequential type but pointer type.