### PR TITLE
Use fixtures (google test framework) in ConfigParser unit tests

### DIFF
--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -20,6 +20,8 @@ set(mull_unittests_sources
 
   TestModuleFactory.cpp
   TestModuleFactory.h
+
+  ConfigParserTestFixture.h
 )
 
 if(MULL_SUPPORT_RUST)

--- a/unittests/ConfigParserTestFixture.h
+++ b/unittests/ConfigParserTestFixture.h
@@ -1,0 +1,19 @@
+#include "ConfigParser.h"
+
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace mull;
+
+class ConfigParserTestFixture : public ::testing::Test {
+protected:
+  
+  Config config;
+  
+  void configWithYamlContent(const char *content) {
+    yaml::Input Input(content);
+    ConfigParser Parser;
+    config = Parser.loadConfig(Input);
+  }
+  
+};

--- a/unittests/ConfigParserTests.cpp
+++ b/unittests/ConfigParserTests.cpp
@@ -1,168 +1,98 @@
-#include "ConfigParser.h"
-#include "Config.h"
+#include "ConfigParserTestFixture.h"
 
-#include "llvm/Support/SourceMgr.h"
-#include "llvm/Support/YAMLParser.h"
-
-#include "gtest/gtest.h"
-
-using namespace mull;
-using namespace llvm;
-
-TEST(ConfigParser, loadConfig_BitcodeFiles) {
-    yaml::Input Input(
-                        "bitcode_files:\n"
-                        "  - foo.bc\n"
-                        "  - bar.bc\n");
-
-    ConfigParser Parser;
-    auto Cfg = Parser.loadConfig(Input);
-
-    ASSERT_EQ(2U, Cfg.getBitcodePaths().size());
-    ASSERT_EQ("foo.bc", *(Cfg.getBitcodePaths().begin()));
-    ASSERT_EQ("bar.bc", *(Cfg.getBitcodePaths().end() - 1));
-    ASSERT_EQ("bar.bc", *(Cfg.getBitcodePaths().end() - 1));
+TEST_F(ConfigParserTestFixture, loadConfig_BitcodeFiles) {
+  const char *configYAML = "bitcode_files:\n"
+                           "  - foo.bc\n"
+                           "  - bar.bc\n";
+  configWithYamlContent(configYAML);
+  
+  ASSERT_EQ(2U, config.getBitcodePaths().size());
+  ASSERT_EQ("foo.bc", *(config.getBitcodePaths().begin()));
+  ASSERT_EQ("bar.bc", *(config.getBitcodePaths().end() - 1));
+  ASSERT_EQ("bar.bc", *(config.getBitcodePaths().end() - 1));
 }
 
-TEST(ConfigParser, loadConfig_Fork_True) {
-  yaml::Input Input("fork: true\n");
-
-  ConfigParser Parser;
-  auto Cfg = Parser.loadConfig(Input);
-
-  ASSERT_EQ(true, Cfg.getFork());
+TEST_F(ConfigParserTestFixture, loadConfig_Fork_True) {
+  configWithYamlContent("fork: true\n");
+  ASSERT_EQ(true, config.getFork());
 }
 
-TEST(ConfigParser, loadConfig_Fork_False) {
-  yaml::Input Input("fork: false\n");
-
-  ConfigParser Parser;
-  auto Cfg = Parser.loadConfig(Input);
-
-  ASSERT_EQ(false, Cfg.getFork());
+TEST_F(ConfigParserTestFixture, loadConfig_Fork_False) {
+  configWithYamlContent("fork: false\n");
+  ASSERT_EQ(false, config.getFork());
 }
 
-TEST(ConfigParser, loadConfig_Fork_Unspecified) {
-  yaml::Input Input("");
-
-  ConfigParser Parser;
-  auto Cfg = Parser.loadConfig(Input);
-
-  ASSERT_EQ(true, Cfg.getFork());
+TEST_F(ConfigParserTestFixture, loadConfig_Fork_Unspecified) {
+  configWithYamlContent("");
+  ASSERT_EQ(true, config.getFork());
 }
 
-TEST(ConfigParser, loadConfig_Timeout_Unspecified) {
-  yaml::Input Input("");
-
-  ConfigParser Parser;
-  auto Cfg = Parser.loadConfig(Input);
-
-  ASSERT_EQ(MullDefaultTimeoutMilliseconds, Cfg.getTimeout());
+TEST_F(ConfigParserTestFixture, loadConfig_Timeout_Unspecified) {
+  configWithYamlContent("");
+  ASSERT_EQ(MullDefaultTimeoutMilliseconds, config.getTimeout());
 }
 
-TEST(ConfigParser, loadConfig_Timeout_SpecificValue) {
-  yaml::Input Input("timeout: 15\n");
-
-  ConfigParser Parser;
-  auto Cfg = Parser.loadConfig(Input);
-
-  ASSERT_EQ(15, Cfg.getTimeout());
+TEST_F(ConfigParserTestFixture, loadConfig_Timeout_SpecificValue) {
+  configWithYamlContent("timeout: 15\n");
+  ASSERT_EQ(15, config.getTimeout());
 }
 
-TEST(ConfigParser, loadConfig_DryRun_Unspecified) {
-  yaml::Input Input("");
-
-  ConfigParser Parser;
-  auto Cfg = Parser.loadConfig(Input);
-
-  ASSERT_FALSE(Cfg.isDryRun());
+TEST_F(ConfigParserTestFixture, loadConfig_DryRun_Unspecified) {
+  configWithYamlContent("");
+  ASSERT_FALSE(config.isDryRun());
 }
 
-TEST(ConfigParser, loadConfig_DryRun_SpecificValue) {
-  ConfigParser Parser;
-  yaml::Input Input("dry_run: true\n");
-  auto Cfg = Parser.loadConfig(Input);
-  ASSERT_TRUE(Cfg.isDryRun());
+TEST_F(ConfigParserTestFixture, loadConfig_DryRun_SpecificValue) {
+  configWithYamlContent("dry_run: true\n");
+  ASSERT_TRUE(config.isDryRun());
 }
 
-TEST(ConfigParser, loadConfig_UseCache_Unspecified) {
-  yaml::Input Input("");
-
-  ConfigParser Parser;
-  auto Cfg = Parser.loadConfig(Input);
-  ASSERT_TRUE(Cfg.getUseCache());
+TEST_F(ConfigParserTestFixture, loadConfig_UseCache_Unspecified) {
+  configWithYamlContent("");
+  ASSERT_TRUE(config.getUseCache());
 }
 
-TEST(ConfigParser, loadConfig_UseCache_SpecificValue) {
-  yaml::Input Input("use_cache: false\n");
-
-  ConfigParser Parser;
-  auto Cfg = Parser.loadConfig(Input);
-  ASSERT_FALSE(Cfg.getUseCache());
+TEST_F(ConfigParserTestFixture, loadConfig_UseCache_SpecificValue) {
+  configWithYamlContent("use_cache: false\n");
+  ASSERT_FALSE(config.getUseCache());
 }
 
-TEST(ConfigParser, loadConfig_MaxDistance_Unspecified) {
-  yaml::Input Input("");
-
-  ConfigParser Parser;
-  auto Cfg = Parser.loadConfig(Input);
-
-  ASSERT_EQ(128, Cfg.getMaxDistance());
+TEST_F(ConfigParserTestFixture, loadConfig_MaxDistance_Unspecified) {
+  configWithYamlContent("fork: true\n");
+  ASSERT_EQ(128, config.getMaxDistance());
 }
 
-TEST(ConfigParser, loadConfig_MaxDistance_SpecificValue) {
-  yaml::Input Input("max_distance: 3\n");
-
-  ConfigParser Parser;
-  auto Cfg = Parser.loadConfig(Input);
-
-  ASSERT_EQ(3, Cfg.getMaxDistance());
+TEST_F(ConfigParserTestFixture, loadConfig_MaxDistance_SpecificValue) {
+  configWithYamlContent("max_distance: 3\n");
+  ASSERT_EQ(3, config.getMaxDistance());
 }
 
-TEST(ConfigParser, loadConfig_CacheDirectory_Unspecified) {
-  yaml::Input Input("");
-
-  ConfigParser Parser;
-  auto Cfg = Parser.loadConfig(Input);
-
-  ASSERT_EQ("/tmp/mull_cache", Cfg.getCacheDirectory());
+TEST_F(ConfigParserTestFixture, loadConfig_CacheDirectory_Unspecified) {
+  configWithYamlContent("");
+  ASSERT_EQ("/tmp/mull_cache", config.getCacheDirectory());
 }
 
-TEST(ConfigParser, loadConfig_CacheDirectory_SpecificValue) {
-  yaml::Input Input("cache_directory: /var/tmp\n");
-
-  ConfigParser Parser;
-  auto Cfg = Parser.loadConfig(Input);
-
-  ASSERT_EQ("/var/tmp", Cfg.getCacheDirectory());
+TEST_F(ConfigParserTestFixture, loadConfig_CacheDirectory_SpecificValue) {
+  configWithYamlContent("cache_directory: /var/tmp\n");
+  ASSERT_EQ("/var/tmp", config.getCacheDirectory());
 }
 
-TEST(ConfigParser, loadConfig_MutationOperators_SpecificValue) {
+TEST_F(ConfigParserTestFixture, loadConfig_MutationOperators_SpecificValue) {
   const char *configYAML = R"YAML(
 mutation_operators:
-- add_mutation_operator
-- negate_mutation_operator
-)YAML";
-
-  yaml::Input Input(configYAML);
-
-  ConfigParser Parser;
-  auto Cfg = Parser.loadConfig(Input);
-
-  auto mutationOperators = Cfg.getMutationOperators();
+  - add_mutation_operator
+  - negate_mutation_operator
+  )YAML";
+  configWithYamlContent(configYAML);
+  
+  auto mutationOperators = config.getMutationOperators();
   ASSERT_EQ(2U, mutationOperators.size());
   ASSERT_EQ(AddMutationOperator::ID, mutationOperators[0]);
   ASSERT_EQ(NegateConditionMutationOperator::ID, mutationOperators[1]);
 }
 
-TEST(ConfigParser, loadConfig_MutationOperators_Unspecified) {
-  const char *configYAML = "";
-
-  yaml::Input Input(configYAML);
-
-  ConfigParser Parser;
-  auto Cfg = Parser.loadConfig(Input);
-
-  auto mutationOperators = Cfg.getMutationOperators();
+TEST_F(ConfigParserTestFixture, loadConfig_MutationOperators_Unspecified) {
+  configWithYamlContent("");
+  auto mutationOperators = config.getMutationOperators();
   ASSERT_EQ(0U, mutationOperators.size());
 }


### PR DESCRIPTION
The plan was to use `TEST_F` instead of `TEST`  everywhere possible. However it wen't ok only for `ConfigParserTest`. For other tests I'm facing problems, can't figure out how to resolve them for now.  I'll keep working on other tests later.
