### PR TITLE
Configure test framework from a config file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ if(MULL_SUPPORT_RUST)
   include(${rust_cmake_path})
 
   message(STATUS "Mull.Rust> Rust lib path: ${mull_rust_libpath}")
+  add_definitions(-DMULL_SUPPORT_RUST=1)
 endif()
 
 add_subdirectory(tools)

--- a/include/Config.h
+++ b/include/Config.h
@@ -27,6 +27,7 @@ namespace mull {
 
 class Config {
   std::string projectName;
+  std::string testFramework;
   std::vector<std::string> bitcodePaths;
   std::vector<std::string> mutationOperators;
   std::vector<std::string> dynamicLibraries;
@@ -43,6 +44,7 @@ public:
   // TODO: Refactoring into constants.
   Config() :
     projectName(""),
+    testFramework("GoogleTest"),
     bitcodePaths(),
     mutationOperators(
       // Yaml::Traits stops reading mutation_operators from config.yaml
@@ -65,6 +67,7 @@ public:
   }
 
   Config(const std::string &project,
+         const std::string &testFramework,
          const std::vector<std::string> &paths,
          const std::vector<std::string> mutationOperators,
          const std::vector<std::string> libraries,
@@ -75,6 +78,7 @@ public:
          int distance,
          const std::string &cacheDir) :
     projectName(project),
+    testFramework(testFramework),
     bitcodePaths(paths),
     mutationOperators(mutationOperators),
     dynamicLibraries(libraries),
@@ -89,6 +93,10 @@ public:
 
   const std::string &getProjectName() const {
     return projectName;
+  }
+
+  const std::string &getTestFramework() const {
+    return testFramework;
   }
 
   const std::vector<std::string> &getBitcodePaths() const {
@@ -129,10 +137,11 @@ public:
 
   void dump() const {
     Logger::debug() << "Config>\n"
-    << "\tproject_name: " << getProjectName() << '\n'
-    << "\tdistance: " << getMaxDistance() << '\n'
-    << "\tdry_run: " << isDryRun() << '\n'
-    << "\tfork: " << getFork() << '\n';
+    << "\t" << "project_name: " << getProjectName() << '\n'
+    << "\t" << "test_framework: " << getTestFramework() << '\n'
+    << "\t" << "distance: " << getMaxDistance() << '\n'
+    << "\t" << "dry_run: " << isDryRun() << '\n'
+    << "\t" << "fork: " << getFork() << '\n';
 
     if (getMutationOperators().size() > 0) {
       Logger::debug() << "\tmutation_operators: " << '\n';

--- a/include/ConfigParser.h
+++ b/include/ConfigParser.h
@@ -18,6 +18,7 @@ struct MappingTraits<mull::Config>
   static void mapping(IO& io, mull::Config& config)
   {
     io.mapOptional("project_name", config.projectName);
+    io.mapOptional("test_framework", config.testFramework);
     io.mapOptional("bitcode_files", config.bitcodePaths);
     io.mapOptional("mutation_operators", config.mutationOperators);
     io.mapOptional("dynamic_libraries", config.dynamicLibraries);

--- a/unittests/DriverTests.cpp
+++ b/unittests/DriverTests.cpp
@@ -89,16 +89,21 @@ TEST(Driver, SimpleTest_AddMutationOperator) {
   /// TestRunner and TestFinder based on the Config
   /// Then Run all the tests using driver
 
-  std::string projectName("");
+  std::string projectName = "some_project";
+  std::string testFramework = "SimpleTest";
+
   std::vector<std::string> ModulePaths({ "foo", "bar" });
   bool doFork = false;
   bool dryRun = false;
   bool useCache = false;
   int distance = 10;
   std::string cacheDirectory = "/tmp/mull_cache";
+
   Config config(projectName,
+                testFramework,
                 ModulePaths,
-                {}, {},
+                {},
+                {},
                 doFork,
                 dryRun,
                 useCache,
@@ -147,7 +152,9 @@ TEST(Driver, SimpleTest_NegateConditionMutationOperator) {
   /// TestRunner and TestFinder based on the Config
   /// Then Run all the tests using driver
 
-  std::string projectName("");
+  std::string projectName = "some_project";
+  std::string testFramework = "SimpleTest";
+
   std::vector<std::string> ModulePaths({
     "simple_test/negate_condition/tester",
     "simple_test/negate_condition/testee"
@@ -158,9 +165,18 @@ TEST(Driver, SimpleTest_NegateConditionMutationOperator) {
   bool useCache = false;
   int distance = 10;
   std::string cacheDirectory = "/tmp/mull_cache";
-  Config config(projectName, ModulePaths, {}, {}, doFork, dryRun,
-                useCache, MullDefaultTimeoutMilliseconds,
-                distance, cacheDirectory);
+
+  Config config(projectName,
+                testFramework,
+                ModulePaths,
+                {},
+                {},
+                doFork,
+                dryRun,
+                useCache,
+                MullDefaultTimeoutMilliseconds,
+                distance,
+                cacheDirectory);
 
   std::vector<std::unique_ptr<MutationOperator>> mutationOperators;
   mutationOperators.emplace_back(make_unique<NegateConditionMutationOperator>());
@@ -194,7 +210,9 @@ TEST(Driver, SimpleTest_NegateConditionMutationOperator) {
 }
 
 TEST(Driver, SimpleTest_RemoveVoidFunctionMutationOperator) {
-  std::string projectName("");
+  std::string projectName = "some_project";
+  std::string testFramework = "SimpleTest";
+
   std::vector<std::string> ModulePaths({
     "simple_test/remove_void_function/tester",
     "simple_test/remove_void_function/testee"
@@ -205,9 +223,18 @@ TEST(Driver, SimpleTest_RemoveVoidFunctionMutationOperator) {
   bool useCache = false;
   int distance = 10;
   std::string cacheDirectory = "/tmp/mull_cache";
-  Config config(projectName, ModulePaths, {}, {}, doFork, dryRun,
-                useCache, MullDefaultTimeoutMilliseconds,
-                distance, cacheDirectory);
+
+  Config config(projectName,
+                testFramework,
+                ModulePaths,
+                {},
+                {},
+                doFork,
+                dryRun,
+                useCache,
+                MullDefaultTimeoutMilliseconds,
+                distance,
+                cacheDirectory);
 
   std::vector<std::unique_ptr<MutationOperator>> mutationOperators;
   mutationOperators.emplace_back(make_unique<RemoveVoidFunctionMutationOperator>());
@@ -241,7 +268,9 @@ TEST(Driver, SimpleTest_RemoveVoidFunctionMutationOperator) {
 }
 
 TEST(Driver, SimpleTest_TesteePathCalculation) {
-  std::string projectName("");
+  std::string projectName = "some_project";
+  std::string testFramework = "SimpleTest";
+
   std::vector<std::string> ModulePaths({
     "simple_test/testee_path_calculation/tester",
     "simple_test/testee_path_calculation/testee"
@@ -252,9 +281,18 @@ TEST(Driver, SimpleTest_TesteePathCalculation) {
   bool useCache = false;
   int distance = 10;
   std::string cacheDirectory = "/tmp/mull_cache";
-  Config config(projectName, ModulePaths, {}, {}, doFork, dryRun,
-                useCache, MullDefaultTimeoutMilliseconds,
-                distance, cacheDirectory);
+
+  Config config(projectName,
+                testFramework,
+                ModulePaths,
+                {},
+                {},
+                doFork,
+                dryRun,
+                useCache,
+                MullDefaultTimeoutMilliseconds,
+                distance,
+                cacheDirectory);
 
   std::vector<std::unique_ptr<MutationOperator>> mutationOperators;
   mutationOperators.emplace_back(make_unique<AddMutationOperator>());

--- a/unittests/Rust/Driver_Rust_Test.cpp
+++ b/unittests/Rust/Driver_Rust_Test.cpp
@@ -55,14 +55,17 @@ TEST(Driver_Rust, AddMutationOperator) {
   /// TestRunner and TestFinder based on the Config
   /// Then Run all the tests using driver
 
-  std::string projectName("");
+  std::string projectName("some-project");
+  std::string testFramework("Rust");
   std::vector<std::string> ModulePaths({ "rust" });
   bool doFork = true;
   bool dryRun = false;
   bool useCache = false;
   int distance = 10;
   std::string cacheDirectory = "/tmp/mull_cache";
+
   Config config(projectName,
+                testFramework,
                 ModulePaths,
                 {},
                 {},

--- a/unittests/SQLiteReporterTest.cpp
+++ b/unittests/SQLiteReporterTest.cpp
@@ -114,6 +114,8 @@ TEST(SQLiteReporter, integrationTest) {
 
 TEST(SQLiteReporter, integrationTest_Config) {
   std::string projectName("Integration Test");
+  std::string testFramework = "SimpleTest";
+
   std::vector<std::string> bitcodePaths({
     "tester.bc",
     "testee.bc"
@@ -135,7 +137,7 @@ TEST(SQLiteReporter, integrationTest_Config) {
   int timeout = 42;
   int distance = 10;
   std::string cacheDirectory = "/a/cache";
-  Config config(projectName, bitcodePaths, operators, dylibs,
+  Config config(projectName, testFramework, bitcodePaths, operators, dylibs,
                 doFork, dryRun, useCache, timeout, distance,
                 cacheDirectory);
 


### PR DESCRIPTION
1) Most probably Rust classes should be enabled via a preprocessor so this PR must also be extended with `#ifdefs`. Or Rust driver can take its driver and go as a separate target. **Maybe the whole test framework can go as a separate target?**

**decided to go with #ifdefs for now**

2) I don't like that `if/elseif` chain hanging in `main()` however the problem is that we are creating a pair of `finder/runner` based on the string input. Maybe this pair could be encapsulated behind umbrella class for a test framework like: `TestFramework` or smth like that?

**not decided but is not blocking this**

3) I have removed `debug_main` to remove redundancy and duplication. Our logger is now always set to the maximum `error` so the behavior should be preserved (didn't test yet).

