### PR TITLE
Cleanup: remove deprecated method applyMutation.

### DIFF
--- a/include/MutationPoint.h
+++ b/include/MutationPoint.h
@@ -53,7 +53,7 @@ class MutationPoint {
   llvm::Value *OriginalValue;
   MullModule *module;
   std::string uniqueIdentifier;
-//  llvm::object::OwningBinary<llvm::object::ObjectFile> mutatedBinary;
+
 public:
   MutationPoint(MutationOperator *op,
                 MutationPointAddress Address,
@@ -69,8 +69,7 @@ public:
   MutationPointAddress getAddress() const;
   llvm::Value *getOriginalValue() const;
 
-  void applyMutation(llvm::Module *M) __attribute__((deprecated));
-  llvm::object::OwningBinary<llvm::object::ObjectFile> applyMutation(Compiler &compiler);
+  std::unique_ptr<llvm::Module> cloneModuleAndApplyMutation();
 
   std::string getUniqueIdentifier();
   std::string getUniqueIdentifier() const;

--- a/lib/Context.cpp
+++ b/lib/Context.cpp
@@ -13,7 +13,12 @@ void Context::addModule(std::unique_ptr<MullModule> module) {
     }
   }
 
-  moduleRegistry.insert(std::make_pair(module->getModule()->getModuleIdentifier(),
+  std::string identifier = module->getModule()->getModuleIdentifier();
+
+  assert(moduleWithIdentifier(identifier) == nullptr &&
+         "Attempt to add a module which has been added already!");
+
+  moduleRegistry.insert(std::make_pair(identifier,
                                        module.get()));
   Modules.emplace_back(std::move(module));
 }

--- a/lib/Driver.cpp
+++ b/lib/Driver.cpp
@@ -151,7 +151,10 @@ std::unique_ptr<Result> Driver::Run() {
         } else {
           ObjectFile *mutant = toolchain.cache().getObject(*mutationPoint);
           if (mutant == nullptr) {
-            auto owningObject = mutationPoint->applyMutation(toolchain.compiler());
+            auto ownedModule = mutationPoint->cloneModuleAndApplyMutation();
+
+            auto owningObject = toolchain.compiler().compileModule(ownedModule.get());
+
             mutant = owningObject.getBinary();
             toolchain.cache().putObject(std::move(owningObject), *mutationPoint);
           }

--- a/lib/MutationOperators/AddMutationOperator.cpp
+++ b/lib/MutationOperators/AddMutationOperator.cpp
@@ -202,7 +202,7 @@ llvm::Value *AddMutationOperator::applyMutation(Module *M,
   Instruction *replacement = BinaryOperator::Create(Instruction::Sub,
                                                     binaryOperator->getOperand(0),
                                                     binaryOperator->getOperand(1),
-                                                    binaryOperator->getName());
+                                                    "sub");
   assert(replacement);
   if (binaryOperator->hasNoUnsignedWrap()) {
     replacement->setHasNoUnsignedWrap();

--- a/lib/MutationOperators/AddMutationOperator.cpp
+++ b/lib/MutationOperators/AddMutationOperator.cpp
@@ -202,7 +202,7 @@ llvm::Value *AddMutationOperator::applyMutation(Module *M,
   Instruction *replacement = BinaryOperator::Create(Instruction::Sub,
                                                     binaryOperator->getOperand(0),
                                                     binaryOperator->getOperand(1),
-                                                    "sub");
+                                                    binaryOperator->getName());
   assert(replacement);
   if (binaryOperator->hasNoUnsignedWrap()) {
     replacement->setHasNoUnsignedWrap();

--- a/lib/MutationPoint.cpp
+++ b/lib/MutationPoint.cpp
@@ -48,16 +48,13 @@ Value *MutationPoint::getOriginalValue() const {
   return OriginalValue;
 }
 
-void MutationPoint::applyMutation(llvm::Module *M) {
-  mutationOperator->applyMutation(M, Address, *OriginalValue);
-}
-
-llvm::object::OwningBinary<llvm::object::ObjectFile>
-MutationPoint::applyMutation(Compiler &compiler) {
+std::unique_ptr<llvm::Module>
+MutationPoint::cloneModuleAndApplyMutation() {
   auto copyForMutation = CloneModule(module->getModule());
+
   mutationOperator->applyMutation(copyForMutation.get(), Address, *OriginalValue);
 
-  return compiler.compileModule(copyForMutation.get());
+  return copyForMutation;
 }
 
 std::string MutationPoint::getUniqueIdentifier() {

--- a/lib/SimpleTest/SimpleTestFinder.cpp
+++ b/lib/SimpleTest/SimpleTestFinder.cpp
@@ -221,7 +221,8 @@ SimpleTestFinder::findMutationPoints(const Context &context,
 
           MutationPointAddress Address(FIndex, BBIndex, IIndex);
 
-          Logger::info() << "Found Mutation point at address: " << FIndex << ' '
+          Logger::info() << "SimpleTestFinder> Found Mutation point at address: "
+                         << FIndex << ' '
                          << BBIndex << ' ' << IIndex << '\n';
 
           auto module = context.moduleWithIdentifier(

--- a/unittests/MutationPointTests.cpp
+++ b/unittests/MutationPointTests.cpp
@@ -93,7 +93,7 @@ TEST(MutationPoint, SimpleTest_AddOperator_applyMutation) {
   Function *mutatedTestee = ownedMutatedModule->getFunction("count_letters");
   ASSERT_TRUE(mutatedTestee != nullptr);
 
-  Instruction *mutatedInstruction = getFirstNamedInstruction(*mutatedTestee, "sub");
+  Instruction *mutatedInstruction = getFirstNamedInstruction(*mutatedTestee, "add");
   ASSERT_TRUE(mutatedInstruction != nullptr);
 
   ASSERT_TRUE(isa<BinaryOperator>(mutatedInstruction));

--- a/unittests/MutationPointTests.cpp
+++ b/unittests/MutationPointTests.cpp
@@ -4,7 +4,9 @@
 #include "MutationOperators/AddMutationOperator.h"
 #include "MutationOperators/NegateConditionMutationOperator.h"
 #include "TestModuleFactory.h"
+#include "Toolchain/Compiler.h"
 
+#include "llvm/ExecutionEngine/ExecutionEngine.h"
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/LLVMContext.h"
@@ -80,18 +82,22 @@ TEST(MutationPoint, SimpleTest_AddOperator_applyMutation) {
 
   std::string ReplacedInstructionName = MP->getOriginalValue()->getName().str();
 
-  MP->applyMutation(Testee->getParent());
+  std::unique_ptr<TargetMachine> targetMachine(
+    EngineBuilder().selectTarget(Triple(), "", "",
+    SmallVector<std::string, 1>()));
+  
+  Compiler compiler(*targetMachine.get());
 
-  // After mutation applied on instruction it should be erased
-  Instruction *OldInstruction = cast<BinaryOperator>(MP->getOriginalValue());
-  ASSERT_EQ(nullptr, OldInstruction->getParent());
+  auto ownedMutatedModule = MP->cloneModuleAndApplyMutation();
 
-  //  Function *MutatedFunction = Testee;//ModuleWithTestees->getTesteeFunction(Testee->getName());
+  Function *mutatedTestee = ownedMutatedModule->getFunction("count_letters");
+  ASSERT_TRUE(mutatedTestee != nullptr);
 
-  // After mutation we should have new instruction with the same name as an original instruction
-  Instruction *NewInstruction = getFirstNamedInstruction(*Testee, ReplacedInstructionName);
-  ASSERT_TRUE(isa<BinaryOperator>(NewInstruction));
-  ASSERT_EQ(Instruction::Sub, NewInstruction->getOpcode());
+  Instruction *mutatedInstruction = getFirstNamedInstruction(*mutatedTestee, "sub");
+  ASSERT_TRUE(mutatedInstruction != nullptr);
+
+  ASSERT_TRUE(isa<BinaryOperator>(mutatedInstruction));
+  ASSERT_EQ(Instruction::Sub, mutatedInstruction->getOpcode());
 }
 
 TEST(MutationPoint, SimpleTest_NegateConditionOperator_applyMutation) {
@@ -129,13 +135,16 @@ TEST(MutationPoint, SimpleTest_NegateConditionOperator_applyMutation) {
   MutationPointAddress address = MP->getAddress();
 
   ASSERT_EQ(&FunctionInstructionByAddress(*Testee, address), MP->getOriginalValue());
-  MP->applyMutation(Testee->getParent());
 
-  // After mutation applied on instruction it should be erased
-  Instruction *OldInstruction = cast<CmpInst>(MP->getOriginalValue());
-  ASSERT_EQ(nullptr, OldInstruction->getParent());
+  auto ownedMutatedTesteeModule = MP->cloneModuleAndApplyMutation();
 
-  llvm::Instruction &NewInstruction = FunctionInstructionByAddress(*Testee, address);
-  ASSERT_TRUE(isa<ICmpInst>(NewInstruction));
-  ASSERT_EQ(ICmpInst::ICMP_SGE, (cast<CmpInst>(NewInstruction)).getPredicate());
+  Function *mutatedTestee = ownedMutatedTesteeModule->getFunction("max");
+  ASSERT_TRUE(mutatedTestee != nullptr);
+
+  auto &mutatedInstruction = FunctionInstructionByAddress(*mutatedTestee,
+                                                          MP->getAddress());
+  ASSERT_TRUE(CmpInst::classof(&mutatedInstruction));
+
+  auto mutatedCmpInstruction = cast<CmpInst>(&mutatedInstruction);
+  ASSERT_EQ(mutatedCmpInstruction->getPredicate(), CmpInst::Predicate::ICMP_SGE);
 }

--- a/unittests/Rust/RustTestRunnerTest.cpp
+++ b/unittests/Rust/RustTestRunnerTest.cpp
@@ -87,7 +87,10 @@ TEST(RustTestRunner, runTest) {
   auto &mutationPoint = *(mutationPoints.begin());
 
   {
-    auto owningObject = mutationPoint->applyMutation(compiler);
+    auto ownedModule = mutationPoint->cloneModuleAndApplyMutation();
+
+    auto owningObject = compiler.compileModule(ownedModule.get());
+
     auto mutant = owningObject.getBinary();
 
     ObjectFiles.push_back(mutant);
@@ -127,6 +130,7 @@ TEST(RustTestRunner, runTest_twoModules) {
 
   auto ownedModuleWithTests1 = TestModuleFactory.rustModule();
   auto ownedModuleWithTests2 = TestModuleFactory.rustModule();
+  ownedModuleWithTests2->setModuleIdentifier("rust2");
 
   Module *moduleWithTests1 = ownedModuleWithTests1.get();
   Module *moduleWithTests2 = ownedModuleWithTests2.get();
@@ -182,7 +186,10 @@ TEST(RustTestRunner, runTest_twoModules) {
   auto &mutationPoint = *(mutationPoints.begin());
 
   {
-    auto owningObject = mutationPoint->applyMutation(compiler);
+    auto ownedModule = mutationPoint->cloneModuleAndApplyMutation();
+
+    auto owningObject = compiler.compileModule(ownedModule.get());
+
     auto mutant = owningObject.getBinary();
 
     ObjectFiles.push_back(mutant);

--- a/unittests/TestModuleFactory.cpp
+++ b/unittests/TestModuleFactory.cpp
@@ -134,7 +134,7 @@ std::unique_ptr<Module> TestModuleFactory::createTesteeModule() {
 }
 
 std::unique_ptr<Module> TestModuleFactory::createLibCTesterModule() {
-  return createModule("fixture_lib_c_tester_module.ll", "sum");
+  return createModule("fixture_lib_c_tester_module.ll", "test_main");
 }
 
 std::unique_ptr<Module> TestModuleFactory::createLibCTesteeModule() {


### PR DESCRIPTION
- Makes more explicit name: `cloneModuleAndApplyMutation` and moves compilation to be outside of MutationPoint class.
- Fixes libc test fixture identifier.
- A couple of naming improvements in unit tests.