### PR TITLE
Increase Mull's own mutation testing score.

### DIFF
--- a/unittests/GoogleTest/GoogleTestFinderTest.cpp
+++ b/unittests/GoogleTest/GoogleTestFinderTest.cpp
@@ -86,7 +86,7 @@ mutation_operators:
   ASSERT_EQ("HelloTest.testSumOfTestee", Test1->getTestName());
 }
 
-TEST(GoogleTestFinder, FindTestee) {
+TEST(GoogleTestFinder, findTestees) {
   auto ModuleWithTests   = TestModuleFactory.createGoogleTestTesterModule();
   auto ModuleWithTestees = TestModuleFactory.createGoogleTestTesteeModule();
 
@@ -122,6 +122,9 @@ mutation_operators:
 
   Function *Testee = Testees[0]->getTesteeFunction();
   ASSERT_FALSE(Testee->empty());
+
+  ASSERT_EQ(0, Testees[0]->getDistance());
+  ASSERT_EQ(1, Testees[1]->getDistance());
 }
 
 TEST(GoogleTestFinder, findTestees_testeesAsInvokeInstr) {

--- a/unittests/MutationOperators/NegateConditionMutationOperatorTest.cpp
+++ b/unittests/MutationOperators/NegateConditionMutationOperatorTest.cpp
@@ -1,4 +1,5 @@
 
+#include "MutationPoint.h"
 #include "MutationOperators/MutationOperator.h"
 #include "MutationOperators/MutationOperatorFilter.h"
 #include "MutationOperators/NegateConditionMutationOperator.h"
@@ -89,6 +90,9 @@ TEST(NegateConditionMutationOperator, getMutationPoints_no_filter) {
 
   auto mutationPoints = mutationOperator.getMutationPoints(context, function, filter);
   EXPECT_EQ(1U, mutationPoints.size());
+  EXPECT_EQ(0, mutationPoints[0]->getAddress().getFnIndex());
+  EXPECT_EQ(0, mutationPoints[0]->getAddress().getBBIndex());
+  EXPECT_EQ(15, mutationPoints[0]->getAddress().getIIndex());
 }
 
 TEST(NegateConditionMutationOperator, getMutationPoints_filter_to_bool_converion) {

--- a/unittests/MutationPointTests.cpp
+++ b/unittests/MutationPointTests.cpp
@@ -74,6 +74,8 @@ TEST(MutationPoint, SimpleTest_AddOperator_applyMutation) {
   Function *Testee = Testees[1]->getTesteeFunction();
   ASSERT_FALSE(Testee->empty());
 
+  ASSERT_EQ(1, Testees[1]->getDistance());
+
   std::vector<MutationPoint *> MutationPoints = Finder.findMutationPoints(Ctx, *Testee);
   ASSERT_EQ(1U, MutationPoints.size());
 


### PR DESCRIPTION
Only running mutations on distance == 1.

Before:

```
Tests:59
Mutants:109
Survived Mutants:17
Killed Mutants:92
Total time:4m 46s 305ms
Execution Time:1m 59s 95ms
Weakly Killed Mutants:16
Strongly Killed Mutants:76
Max distance:1
Min distance:1
Mean distance:1
Mutation Score:85%
```

After:

```
Tests:59
Mutants:109
Survived Mutants:12
Killed Mutants:97
Total time:2m 26s 436ms
Execution Time:1m 55s 345ms
Weakly Killed Mutants:14
Strongly Killed Mutants:83
Max distance:1
Min distance:1
Mean distance:1
Mutation Score:89%
```
