### PR TITLE
Increase Mull's own mutation score: SQLiteReporterTest.

### DIFF
--- a/lib/SQLiteReporter.cpp
+++ b/lib/SQLiteReporter.cpp
@@ -30,6 +30,7 @@ static void assume(bool condition, const char *assumption) {
   }
 
   Logger::warn() << "Assumption failed: " << assumption << '\n';
+  exit(1);
 }
 
 static std::string vectorToCsv(const std::vector<std::string> &v) {

--- a/lib/SQLiteReporter.cpp
+++ b/lib/SQLiteReporter.cpp
@@ -30,7 +30,6 @@ static void assume(bool condition, const char *assumption) {
   }
 
   Logger::warn() << "Assumption failed: " << assumption << '\n';
-  exit(1);
 }
 
 static std::string vectorToCsv(const std::vector<std::string> &v) {


### PR DESCRIPTION
Before:

```
Tests:59
Mutants:110
Survived Mutants:14
Killed Mutants:96
Total time:3m 19s 118ms
Execution Time:2m 23s 439ms
Weakly Killed Mutants:18
Strongly Killed Mutants:78
Max distance:1
Min distance:1
Mean distance:1
Mutation Score:88%
```

After:

```
Tests:59
Mutants:110
Survived Mutants:12
Killed Mutants:98
Total time:2m 47s 20ms
Execution Time:2m 28s 560ms
Weakly Killed Mutants:13
Strongly Killed Mutants:85
Max distance:1
Min distance:1
Mean distance:1
Mutation Score:90%
```
