### PR TITLE
Fix C99 designated initializer warnings.

### DIFF
--- a/include/Result.h
+++ b/include/Result.h
@@ -5,10 +5,12 @@
 #include <vector>
 
 namespace mull {
-  typedef struct {
+  struct ResultTime {
     const long start;
     const long end;
-  } ResultTime;
+
+    ResultTime(const long start, const long end) : start(start), end(end) {}
+  };
 
   class Result {
     std::vector<std::unique_ptr<TestResult>> testResults;

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -123,10 +123,7 @@ int main(int argc, char *argv[]) {
   const long timeSuiteEnd =
     duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
 
-  ResultTime resultTime = {
-    .start = timeSuiteStart,
-    .end = timeSuiteEnd
-  };
+  ResultTime resultTime(timeSuiteStart, timeSuiteEnd);
 
   SQLiteReporter reporter(config.getProjectName());
   reporter.reportResults(result, config, resultTime);

--- a/unittests/SQLiteReporterTest.cpp
+++ b/unittests/SQLiteReporterTest.cpp
@@ -89,10 +89,7 @@ TEST(SQLiteReporter, integrationTest) {
   std::vector<std::unique_ptr<TestResult>> results;
   results.push_back(std::move(testResult));
 
-  ResultTime resultTime = {
-    .start = 1234,
-    .end = 5678
-  };
+  ResultTime resultTime(1234, 5678);
 
   std::unique_ptr<Result> result = make_unique<Result>(std::move(results),
                                                        std::move(testees));
@@ -218,10 +215,7 @@ TEST(SQLiteReporter, integrationTest_Config) {
   std::vector<std::unique_ptr<TestResult>> testResults;
   std::vector<std::unique_ptr<Testee>> allTestees;
 
-  ResultTime resultTime = {
-    .start = 1234,
-    .end = 5678
-  };
+  ResultTime resultTime(1234, 5678);
 
   std::unique_ptr<Result> result = make_unique<Result>(std::move(testResults),
                                                        std::move(allTestees));
@@ -383,10 +377,7 @@ TEST(SQLiteReporter, do_emitDebugInfo) {
   std::vector<std::unique_ptr<TestResult>> results;
   results.push_back(std::move(testResult));
 
-  ResultTime resultTime = {
-    .start = 1234,
-    .end = 5678
-  };
+  ResultTime resultTime(1234, 5678);
 
   std::unique_ptr<Result> result = make_unique<Result>(std::move(results),
                                                        std::move(testees));
@@ -556,10 +547,7 @@ TEST(SQLiteReporter, do_not_emitDebugInfo) {
   std::vector<std::unique_ptr<TestResult>> results;
   results.push_back(std::move(testResult));
 
-  ResultTime resultTime = {
-    .start = 1234,
-    .end = 5678
-  };
+  ResultTime resultTime(1234, 5678);
 
   std::unique_ptr<Result> result = make_unique<Result>(std::move(results),
                                                        std::move(testees));


### PR DESCRIPTION
> C++ has constructors. If it makes sense to initialize just one member then that can be expressed in the program by implementing an appropriate constructor. This is the sort of abstraction C++ promotes.

https://stackoverflow.com/questions/18731707/why-does-c11-not-support-designated-initializer-list-as-c99