### PR TITLE
[WIP][RFC]: IDE Diagnostics

### DIFF
--- a/include/GoogleTest/GoogleTestFinder.h
+++ b/include/GoogleTest/GoogleTestFinder.h
@@ -23,8 +23,8 @@ class MutationPoint;
 
 class GoogleTestFinder : public TestFinder {
   llvm::StringMap<llvm::Function *> FunctionRegistry;
-  std::vector<std::unique_ptr<MutationPoint>> MutationPoints;
-  std::map<llvm::Function *, std::vector<MutationPoint *>> MutationPointsRegistry;
+  std::vector<std::unique_ptr<IMutationPoint>> MutationPoints;
+  std::map<llvm::Function *, std::vector<IMutationPoint *>> MutationPointsRegistry;
 
   std::vector<std::unique_ptr<MutationOperator>> mutationOperators;
 
@@ -39,8 +39,8 @@ public:
                                                    Context &Ctx,
                                                    int maxDistance) override;
 
-  std::vector<MutationPoint *> findMutationPoints(const Context &context,
-                                                  llvm::Function &F) override;
+  std::vector<IMutationPoint *> findMutationPoints(const Context &context,
+                                                   llvm::Function &F) override;
 };
 
 }

--- a/include/MutationOperators/AddMutationOperator.h
+++ b/include/MutationOperators/AddMutationOperator.h
@@ -21,9 +21,9 @@ class AddMutationOperator : public MutationOperator {
 public:
   static const std::string ID;
 
-  std::vector<MutationPoint *> getMutationPoints(const Context &context,
-                                                 llvm::Function *function,
-                                                 MutationOperatorFilter &filter) override;
+  std::vector<IMutationPoint *> getMutationPoints(const Context &context,
+                                                  llvm::Function *function,
+                                                  MutationOperatorFilter &filter) override;
 
   std::string uniqueID() override {
     return ID;

--- a/include/MutationOperators/AndOrReplacementMutationOperator.h
+++ b/include/MutationOperators/AndOrReplacementMutationOperator.h
@@ -59,9 +59,9 @@ namespace mull {
   public:
     static const std::string ID;
 
-    std::vector<MutationPoint *> getMutationPoints(const Context &context,
-                                                   llvm::Function *function,
-                                                   MutationOperatorFilter &filter) override;
+    std::vector<IMutationPoint *> getMutationPoints(const Context &context,
+                                                    llvm::Function *function,
+                                                    MutationOperatorFilter &filter) override;
 
     std::string uniqueID() override {
       return ID;

--- a/include/MutationOperators/MathDivMutationOperator.h
+++ b/include/MutationOperators/MathDivMutationOperator.h
@@ -15,9 +15,9 @@ class MathDivMutationOperator : public MutationOperator {
 public:
   static const std::string ID;
 
-  std::vector<MutationPoint *> getMutationPoints(const Context &context,
-                                                 llvm::Function *function,
-                                                 MutationOperatorFilter &filter) override;
+  std::vector<IMutationPoint *> getMutationPoints(const Context &context,
+                                                  llvm::Function *function,
+                                                  MutationOperatorFilter &filter) override;
 
   std::string uniqueID() override {
     return ID;

--- a/include/MutationOperators/MathMulMutationOperator.h
+++ b/include/MutationOperators/MathMulMutationOperator.h
@@ -15,9 +15,9 @@ class MathMulMutationOperator : public MutationOperator {
 public:
   static const std::string ID;
 
-  std::vector<MutationPoint *> getMutationPoints(const Context &context,
-                                                 llvm::Function *function,
-                                                 MutationOperatorFilter &filter) override;
+  std::vector<IMutationPoint *> getMutationPoints(const Context &context,
+                                                  llvm::Function *function,
+                                                  MutationOperatorFilter &filter) override;
 
   std::string uniqueID() override {
     return ID;

--- a/include/MutationOperators/MathSubMutationOperator.h
+++ b/include/MutationOperators/MathSubMutationOperator.h
@@ -21,9 +21,9 @@ class MathSubMutationOperator : public MutationOperator {
 public:
   static const std::string ID;
 
-  std::vector<MutationPoint *> getMutationPoints(const Context &context,
-                                                 llvm::Function *function,
-                                                 MutationOperatorFilter &filter) override;
+  std::vector<IMutationPoint *> getMutationPoints(const Context &context,
+                                                  llvm::Function *function,
+                                                  MutationOperatorFilter &filter) override;
 
   std::string uniqueID() override {
     return ID;

--- a/include/MutationOperators/MutationOperator.h
+++ b/include/MutationOperators/MutationOperator.h
@@ -14,22 +14,24 @@ namespace llvm {
 namespace mull {
 
 class Context;
-class MutationPoint;
+class IMutationPoint;
 class MutationPointAddress;
 class MutationOperatorFilter;
 
 class MutationOperator {
 public:
-  virtual std::vector<MutationPoint *> getMutationPoints(const Context &context,
-                                                         llvm::Function *function,
-                                                         MutationOperatorFilter &filter) = 0;
+  virtual std::vector<IMutationPoint *> getMutationPoints(const Context &context,
+                                                          llvm::Function *function,
+                                                          MutationOperatorFilter &filter) = 0;
 
   /// FIXME: Renmae to 'getUniqueIdentifier'
   virtual std::string uniqueID() = 0;
   virtual std::string uniqueID() const = 0;
 
   virtual bool canBeApplied(llvm::Value &V) = 0;
-  virtual llvm::Value *applyMutation(llvm::Module *M, MutationPointAddress address, llvm::Value &OriginalValue) = 0;
+  virtual llvm::Value *applyMutation(llvm::Module *M,
+                                     MutationPointAddress address,
+                                     llvm::Value &OriginalValue) = 0;
   virtual ~MutationOperator() {}
 };
 

--- a/include/MutationOperators/NegateConditionMutationOperator.h
+++ b/include/MutationOperators/NegateConditionMutationOperator.h
@@ -8,19 +8,26 @@
 
 namespace mull {
 
-  class MutationPoint;
+  class NegateConditionMutationPoint;
   class MutationPointAddress;
   class MutationOperatorFilter;
 
   class NegateConditionMutationOperator : public MutationOperator {
 
+    virtual bool canBeApplied(llvm::Value &V,
+                              llvm::CmpInst::Predicate *outPredicate,
+                              llvm::CmpInst::Predicate *outNegatedPredicate);
+
   public:
     static const std::string ID;
 
     static llvm::CmpInst::Predicate negatedCmpInstPredicate(llvm::CmpInst::Predicate predicate);
-    std::vector<MutationPoint *> getMutationPoints(const Context &context,
-                                                   llvm::Function *function,
-                                                   MutationOperatorFilter &filter) override;
+    std::vector<IMutationPoint *> getMutationPoints(const Context &context,
+                                                    llvm::Function *function,
+                                                    MutationOperatorFilter &filter) override;
+
+    llvm::Value *applyMutation2(llvm::Module *M,
+                                NegateConditionMutationPoint *mp);
 
     std::string uniqueID() override {
       return ID;

--- a/include/MutationOperators/RemoveVoidFunctionMutationOperator.h
+++ b/include/MutationOperators/RemoveVoidFunctionMutationOperator.h
@@ -17,9 +17,9 @@ namespace mull {
   public:
     static const std::string ID;
 
-    std::vector<MutationPoint *> getMutationPoints(const Context &context,
-                                                   llvm::Function *function,
-                                                   MutationOperatorFilter &filter) override;
+    std::vector<IMutationPoint *> getMutationPoints(const Context &context,
+                                                    llvm::Function *function,
+                                                    MutationOperatorFilter &filter) override;
 
     std::string uniqueID() override {
       return ID;

--- a/include/MutationPoint.h
+++ b/include/MutationPoint.h
@@ -47,7 +47,30 @@ public:
   }
 };
 
-class MutationPoint {
+class IMutationPoint {
+
+public:
+
+  virtual MutationOperator *getOperator() = 0;
+  virtual MutationOperator *getOperator() const = 0;
+
+  virtual MutationPointAddress getAddress() = 0;
+  virtual MutationPointAddress getAddress() const = 0;
+
+  virtual llvm::Value *getOriginalValue() = 0;
+  virtual llvm::Value *getOriginalValue() const = 0;
+
+  virtual std::unique_ptr<llvm::Module> cloneModuleAndApplyMutation() = 0;
+
+  virtual std::string getUniqueIdentifier() = 0;
+  virtual std::string getUniqueIdentifier() const = 0;
+
+  virtual std::string getDiagnostics() = 0;
+
+  virtual ~IMutationPoint() {};
+};
+
+class MutationPoint: public IMutationPoint {
   MutationOperator *mutationOperator;
   MutationPointAddress Address;
   llvm::Value *OriginalValue;
@@ -73,6 +96,8 @@ public:
 
   std::string getUniqueIdentifier();
   std::string getUniqueIdentifier() const;
+
+  std::string getDiagnostics();
 };
 
 }

--- a/include/SimpleTest/SimpleTestFinder.h
+++ b/include/SimpleTest/SimpleTestFinder.h
@@ -24,7 +24,7 @@ class SimpleTestFinder : public TestFinder {
 
   std::vector<std::unique_ptr<MutationPoint>> MutationPoints;
   std::vector<std::unique_ptr<MutationOperator>> mutationOperators;
-  std::map<llvm::Function *, std::vector<MutationPoint *>> MutationPointsRegistry;
+  std::map<llvm::Function *, std::vector<IMutationPoint *>> MutationPointsRegistry;
 
 public:
   SimpleTestFinder(std::vector<std::unique_ptr<MutationOperator>> mutationOperators);
@@ -35,8 +35,8 @@ public:
                                                    Context &Ctx,
                                                    int distance) override;
 
-  std::vector<MutationPoint *> findMutationPoints(const Context &context,
-                                                  llvm::Function &F) override;
+  std::vector<IMutationPoint *> findMutationPoints(const Context &context,
+                                                   llvm::Function &F) override;
 };
 
 }

--- a/include/TestFinder.h
+++ b/include/TestFinder.h
@@ -22,9 +22,9 @@ public:
                                                            Context &Ctx,
                                                            int maxDistance) = 0;
 
-  virtual std::vector<MutationPoint *> findMutationPoints(const Context &context,
-                                                          llvm::Function &F) {
-    return std::vector<MutationPoint *>();
+  virtual std::vector<IMutationPoint *> findMutationPoints(const Context &context,
+                                                           llvm::Function &F) {
+    return std::vector<IMutationPoint *>();
   }
 
   virtual ~TestFinder() {}

--- a/include/TestResult.h
+++ b/include/TestResult.h
@@ -35,14 +35,14 @@ struct ExecutionResult {
 
 class MutationResult {
   ExecutionResult Result;
-  MutationPoint *MutPoint;
+  IMutationPoint *MutPoint;
   Testee *testee;
 
 public:
-  MutationResult(ExecutionResult R, mull::MutationPoint *MP, Testee *testee);
+  MutationResult(ExecutionResult R, mull::IMutationPoint *MP, Testee *testee);
 
   ExecutionResult getExecutionResult()  { return Result; }
-  MutationPoint* getMutationPoint()     { return MutPoint; }
+  IMutationPoint* getMutationPoint()     { return MutPoint; }
   int getMutationDistance()             { return testee->getDistance(); }
   Testee *getTestee()                    { return testee; }
 };

--- a/include/Toolchain/ObjectCache.h
+++ b/include/Toolchain/ObjectCache.h
@@ -7,7 +7,7 @@
 
 namespace mull {
   class MullModule;
-  class MutationPoint;
+  class IMutationPoint;
 
   class ObjectCache {
     std::map<std::string, llvm::object::OwningBinary<llvm::object::ObjectFile>> inMemoryCache;
@@ -18,13 +18,13 @@ namespace mull {
     ObjectCache(bool useCache, const std::string &cacheDir);
 
     llvm::object::ObjectFile *getObject(const MullModule &module);
-    llvm::object::ObjectFile *getObject(const MutationPoint &mutationPoint);
+    llvm::object::ObjectFile *getObject(const IMutationPoint &mutationPoint);
 
     void putObject(llvm::object::OwningBinary<llvm::object::ObjectFile> object,
                    const MullModule &module);
 
     void putObject(llvm::object::OwningBinary<llvm::object::ObjectFile> object,
-                   const MutationPoint &mutationPoint);
+                   const IMutationPoint &mutationPoint);
 
   private:
     llvm::object::ObjectFile *getObject(const std::string &identifier);

--- a/lib/Driver.cpp
+++ b/lib/Driver.cpp
@@ -175,7 +175,25 @@ std::unique_ptr<Result> Driver::Run() {
                  "Expect to see valid TestResult");
         }
 
+        if (result.Status != Passed) {
+          Instruction *instruction =
+            dyn_cast<Instruction>(mutationPoint->getOriginalValue());
+
+          std::string fileNameOrNil = "no-debug-info";
+          std::string lineOrNil = "0";
+          std::string columnOrNil = "0";
+
+          if (instruction->getMetadata(0)) {
+            fileNameOrNil = instruction->getDebugLoc()->getFilename().str();
+            lineOrNil = std::to_string(instruction->getDebugLoc()->getLine());
+            columnOrNil = std::to_string(instruction->getDebugLoc()->getColumn());
+
+            errs() << "\n";
+            errs() << fileNameOrNil << ":" << lineOrNil << ":" << columnOrNil << ": " << "warning: " << mutationPoint->getDiagnostics() << "\n";
+          }
+        }
         auto MutResult = make_unique<MutationResult>(result, mutationPoint, testee.get());
+
         Result->addMutantResult(std::move(MutResult));
       }
 

--- a/lib/GoogleTest/GoogleTestFinder.cpp
+++ b/lib/GoogleTest/GoogleTestFinder.cpp
@@ -360,7 +360,7 @@ GoogleTestFinder::findTestees(Test *Test,
   return testees;
 }
 
-std::vector<MutationPoint *>
+std::vector<IMutationPoint *>
 GoogleTestFinder::findMutationPoints(const Context &context,
                                      llvm::Function &testee) {
 
@@ -368,12 +368,12 @@ GoogleTestFinder::findMutationPoints(const Context &context,
     return MutationPointsRegistry.at(&testee);
   }
 
-  std::vector<MutationPoint *> points;
+  std::vector<IMutationPoint *> points;
 
   for (auto &mutationOperator : mutationOperators) {
     for (auto point : mutationOperator->getMutationPoints(context, &testee, filter)) {
       points.push_back(point);
-      MutationPoints.emplace_back(std::unique_ptr<MutationPoint>(point));
+      MutationPoints.emplace_back(std::unique_ptr<IMutationPoint>(point));
     }
   }
 

--- a/lib/MutationOperators/AddMutationOperator.cpp
+++ b/lib/MutationOperators/AddMutationOperator.cpp
@@ -121,14 +121,14 @@ AddMutationOperator::replacementForAddWithOverflow(llvm::Function *addFunction,
   return replacementFunction;
 }
 
-std::vector<MutationPoint *>
+std::vector<IMutationPoint *>
 AddMutationOperator::getMutationPoints(const Context &context,
                                        llvm::Function *function,
                                        MutationOperatorFilter &filter) {
   int functionIndex = GetFunctionIndex(function);
   int basicBlockIndex = 0;
 
-  std::vector<MutationPoint *> mutationPoints;
+  std::vector<IMutationPoint *> mutationPoints;
 
   for (auto &basicBlock : function->getBasicBlockList()) {
 

--- a/lib/MutationOperators/AndOrReplacementMutationOperator.cpp
+++ b/lib/MutationOperators/AndOrReplacementMutationOperator.cpp
@@ -34,14 +34,14 @@ static int GetFunctionIndex(llvm::Function *function) {
   return FIndex;
 }
 
-std::vector<MutationPoint *>
+std::vector<IMutationPoint *>
 AndOrReplacementMutationOperator::getMutationPoints(const Context &context,
                                                     llvm::Function *function,
                                                     MutationOperatorFilter &filter) {
   int functionIndex = GetFunctionIndex(function);
   int basicBlockIndex = 0;
 
-  std::vector<MutationPoint *> mutationPoints;
+  std::vector<IMutationPoint *> mutationPoints;
 
   for (auto &basicBlock : function->getBasicBlockList()) {
     int instructionIndex = 0;

--- a/lib/MutationOperators/MathDivMutationOperator.cpp
+++ b/lib/MutationOperators/MathDivMutationOperator.cpp
@@ -33,14 +33,14 @@ static int GetFunctionIndex(llvm::Function *function) {
   return FIndex;
 }
 
-std::vector<MutationPoint *>
+std::vector<IMutationPoint *>
 MathDivMutationOperator::getMutationPoints(const Context &context,
                                            llvm::Function *function,
                                            MutationOperatorFilter &filter) {
   int functionIndex = GetFunctionIndex(function);
   int basicBlockIndex = 0;
 
-  std::vector<MutationPoint *> mutationPoints;
+  std::vector<IMutationPoint *> mutationPoints;
 
   for (auto &basicBlock : function->getBasicBlockList()) {
 

--- a/lib/MutationOperators/MathMulMutationOperator.cpp
+++ b/lib/MutationOperators/MathMulMutationOperator.cpp
@@ -33,14 +33,14 @@ static int GetFunctionIndex(llvm::Function *function) {
   return FIndex;
 }
 
-std::vector<MutationPoint *>
+std::vector<IMutationPoint *>
 MathMulMutationOperator::getMutationPoints(const Context &context,
                                            llvm::Function *function,
                                            MutationOperatorFilter &filter) {
   int functionIndex = GetFunctionIndex(function);
   int basicBlockIndex = 0;
 
-  std::vector<MutationPoint *> mutationPoints;
+  std::vector<IMutationPoint *> mutationPoints;
 
   for (auto &basicBlock : function->getBasicBlockList()) {
 

--- a/lib/MutationOperators/MathSubMutationOperator.cpp
+++ b/lib/MutationOperators/MathSubMutationOperator.cpp
@@ -121,14 +121,14 @@ MathSubMutationOperator::replacementForSubWithOverflow(llvm::Function *testeeFun
   return replacementFunction;
 }
 
-std::vector<MutationPoint *>
+std::vector<IMutationPoint *>
 MathSubMutationOperator::getMutationPoints(const Context &context,
                                            llvm::Function *function,
                                            MutationOperatorFilter &filter) {
   int functionIndex = GetFunctionIndex(function);
   int basicBlockIndex = 0;
 
-  std::vector<MutationPoint *> mutationPoints;
+  std::vector<IMutationPoint *> mutationPoints;
 
   for (auto &basicBlock : function->getBasicBlockList()) {
 

--- a/lib/MutationOperators/RemoveVoidFunctionMutationOperator.cpp
+++ b/lib/MutationOperators/RemoveVoidFunctionMutationOperator.cpp
@@ -32,14 +32,14 @@ static int GetFunctionIndex(llvm::Function *function) {
   return FIndex;
 }
 
-std::vector<MutationPoint *>
+std::vector<IMutationPoint *>
 RemoveVoidFunctionMutationOperator::getMutationPoints(const Context &context,
-                                                   llvm::Function *function,
-                                                   MutationOperatorFilter &filter) {
+                                                      llvm::Function *function,
+                                                      MutationOperatorFilter &filter) {
   int functionIndex = GetFunctionIndex(function);
   int basicBlockIndex = 0;
 
-  std::vector<MutationPoint *> mutationPoints;
+  std::vector<IMutationPoint *> mutationPoints;
 
   for (auto &basicBlock : function->getBasicBlockList()) {
 

--- a/lib/MutationPoint.cpp
+++ b/lib/MutationPoint.cpp
@@ -65,3 +65,7 @@ std::string MutationPoint::getUniqueIdentifier() {
 std::string MutationPoint::getUniqueIdentifier() const {
   return uniqueIdentifier;
 }
+
+std::string MutationPoint::getDiagnostics() {
+  return "TODO: Diagnostics";
+}

--- a/lib/SimpleTest/SimpleTestFinder.cpp
+++ b/lib/SimpleTest/SimpleTestFinder.cpp
@@ -188,10 +188,10 @@ SimpleTestFinder::findTestees(Test *Test, Context &Ctx, int maxDistance) {
   return testees;
 }
 
-std::vector<MutationPoint *>
+std::vector<IMutationPoint *>
 SimpleTestFinder::findMutationPoints(const Context &context,
                                      llvm::Function &F) {
-  std::vector<MutationPoint *> MutPoints;
+  std::vector<IMutationPoint *> MutPoints;
 
   Module *PM = F.getParent();
 

--- a/lib/TestResult.cpp
+++ b/lib/TestResult.cpp
@@ -4,7 +4,7 @@
 using namespace mull;
 
 MutationResult::MutationResult(ExecutionResult R,
-                               MutationPoint *MP,
+                               IMutationPoint *MP,
                                Testee *testee) :
   Result(R), MutPoint(MP), testee(testee) {}
 

--- a/lib/Toolchain/ObjectCache.cpp
+++ b/lib/Toolchain/ObjectCache.cpp
@@ -94,7 +94,7 @@ ObjectFile *ObjectCache::getObject(const MullModule &module) {
   return getObject(module.getUniqueIdentifier());
 }
 
-ObjectFile *ObjectCache::getObject(const MutationPoint &mutationPoint) {
+ObjectFile *ObjectCache::getObject(const IMutationPoint &mutationPoint) {
   return getObject(mutationPoint.getUniqueIdentifier());
 }
 
@@ -131,6 +131,6 @@ void ObjectCache::putObject(OwningBinary<ObjectFile> object,
 }
 
 void ObjectCache::putObject(OwningBinary<ObjectFile> object,
-                            const MutationPoint &mutationPoint) {
+                            const IMutationPoint &mutationPoint) {
   putObject(std::move(object), mutationPoint.getUniqueIdentifier());
 }

--- a/unittests/GoogleTest/GoogleTestFinderTest.cpp
+++ b/unittests/GoogleTest/GoogleTestFinderTest.cpp
@@ -247,12 +247,12 @@ mutation_operators:
   ASSERT_FALSE(Testee->empty());
   ASSERT_EQ(Testee->getName().str(), "_ZN6Testee3sumEii");
 
-  std::vector<MutationPoint *> MutationPoints =
+  std::vector<IMutationPoint *> MutationPoints =
     Finder.findMutationPoints(Ctx, *Testee);
   
   ASSERT_EQ(1U, MutationPoints.size());
 
-  MutationPoint *MP = MutationPoints[0];
+  IMutationPoint *MP = MutationPoints[0];
 
   MutationPointAddress MPA = MP->getAddress();
   ASSERT_EQ(MPA.getFnIndex(), 0);
@@ -309,7 +309,7 @@ mutation_operators:
                                                {},
                                                { "Testee.cpp" });
 
-  std::vector<MutationPoint *> mutationPoints =
+  std::vector<IMutationPoint *> mutationPoints =
     finderWithExcludedLocations.findMutationPoints(Ctx, *Testee);
 
   ASSERT_EQ(0U, mutationPoints.size());

--- a/unittests/MutationPointTests.cpp
+++ b/unittests/MutationPointTests.cpp
@@ -81,10 +81,12 @@ TEST(MutationPoint, SimpleTest_AddOperator_applyMutation) {
 
   ASSERT_EQ(1, Testees[1]->getDistance());
 
-  std::vector<MutationPoint *> MutationPoints = Finder.findMutationPoints(Ctx, *Testee);
+  std::vector<IMutationPoint *> MutationPoints =
+    Finder.findMutationPoints(Ctx, *Testee);
+
   ASSERT_EQ(1U, MutationPoints.size());
 
-  MutationPoint *MP = (*(MutationPoints.begin()));
+  IMutationPoint *MP = (*(MutationPoints.begin()));
   ASSERT_TRUE(isa<BinaryOperator>(MP->getOriginalValue()));
 
   std::string ReplacedInstructionName = MP->getOriginalValue()->getName().str();
@@ -133,10 +135,10 @@ TEST(MutationPoint, SimpleTest_MathSubOperator_applyMutation) {
 
   ASSERT_EQ(1, Testees[1]->getDistance());
 
-  std::vector<MutationPoint *> MutationPoints = Finder.findMutationPoints(Ctx, *Testee);
+  std::vector<IMutationPoint *> MutationPoints = Finder.findMutationPoints(Ctx, *Testee);
   ASSERT_EQ(1U, MutationPoints.size());
 
-  MutationPoint *MP = (*(MutationPoints.begin()));
+  IMutationPoint *MP = (*(MutationPoints.begin()));
   MutationPointAddress address = MP->getAddress();
   ASSERT_TRUE(isa<BinaryOperator>(MP->getOriginalValue()));
 
@@ -193,10 +195,11 @@ TEST(MutationPoint, SimpleTest_MathMulOperator_applyMutation) {
 
   ASSERT_EQ(1, Testees[1]->getDistance());
 
-  std::vector<MutationPoint *> MutationPoints = Finder.findMutationPoints(Ctx, *Testee);
+  std::vector<IMutationPoint *> MutationPoints =
+    Finder.findMutationPoints(Ctx, *Testee);
   ASSERT_EQ(1U, MutationPoints.size());
 
-  MutationPoint *MP = (*(MutationPoints.begin()));
+  IMutationPoint *MP = (*(MutationPoints.begin()));
   MutationPointAddress address = MP->getAddress();
   ASSERT_TRUE(isa<BinaryOperator>(MP->getOriginalValue()));
 
@@ -244,7 +247,8 @@ TEST(MutationPoint, SimpleTest_MathDivOperator_applyMutation) {
 
   auto &Test = *(Tests.begin());
 
-  std::vector<std::unique_ptr<Testee>> Testees = Finder.findTestees(Test.get(), Ctx, 4);
+  std::vector<std::unique_ptr<Testee>> Testees =
+    Finder.findTestees(Test.get(), Ctx, 4);
 
   ASSERT_EQ(2U, Testees.size());
 
@@ -253,10 +257,11 @@ TEST(MutationPoint, SimpleTest_MathDivOperator_applyMutation) {
 
   ASSERT_EQ(1, Testees[1]->getDistance());
 
-  std::vector<MutationPoint *> MutationPoints = Finder.findMutationPoints(Ctx, *Testee);
+  std::vector<IMutationPoint *> MutationPoints =
+    Finder.findMutationPoints(Ctx, *Testee);
   ASSERT_EQ(1U, MutationPoints.size());
 
-  MutationPoint *MP = (*(MutationPoints.begin()));
+  IMutationPoint *MP = (*(MutationPoints.begin()));
   MutationPointAddress address = MP->getAddress();
   ASSERT_TRUE(isa<BinaryOperator>(MP->getOriginalValue()));
 
@@ -313,10 +318,11 @@ TEST(MutationPoint, SimpleTest_NegateConditionOperator_applyMutation) {
   Function *Testee = Testees[1]->getTesteeFunction();
   ASSERT_FALSE(Testee->empty());
 
-  std::vector<MutationPoint *> MutationPoints = Finder.findMutationPoints(Ctx, *Testee);
+  std::vector<IMutationPoint *> MutationPoints =
+    Finder.findMutationPoints(Ctx, *Testee);
   ASSERT_EQ(1U, MutationPoints.size());
 
-  MutationPoint *MP = (*(MutationPoints.begin()));
+  IMutationPoint *MP = (*(MutationPoints.begin()));
   ASSERT_TRUE(isa<CmpInst>(MP->getOriginalValue()));
 
   MutationPointAddress address = MP->getAddress();
@@ -363,12 +369,12 @@ TEST(MutationPoint, SimpleTest_AndOrMutationOperator_applyMutation) {
     // testee #0 is always test itself.
     Function *test1_testee1_function = test1_testees[1]->getTesteeFunction();
 
-    std::vector<MutationPoint *> test1_testee1_mutationPoints =
+    std::vector<IMutationPoint *> test1_testee1_mutationPoints =
       Finder.findMutationPoints(ctx, *test1_testee1_function);
 
     ASSERT_EQ(1U, test1_testee1_mutationPoints.size());
 
-    MutationPoint *test1_testee1_mutationPoint1 = (*(test1_testee1_mutationPoints.begin()));
+    IMutationPoint *test1_testee1_mutationPoint1 = (*(test1_testee1_mutationPoints.begin()));
 
     MutationPointAddress test1_testee1_mutationPoint1_address =
       test1_testee1_mutationPoint1->getAddress();

--- a/unittests/SQLiteReporterTest.cpp
+++ b/unittests/SQLiteReporterTest.cpp
@@ -55,12 +55,12 @@ TEST(SQLiteReporter, integrationTest) {
 
   ASSERT_FALSE(testeeFunction->empty());
 
-  std::vector<MutationPoint *> mutationPoints =
-  Finder.findMutationPoints(context, *testeeFunction);
+  std::vector<IMutationPoint *> mutationPoints =
+    Finder.findMutationPoints(context, *testeeFunction);
 
   ASSERT_EQ(1U, mutationPoints.size());
 
-  MutationPoint *mutationPoint = (*(mutationPoints.begin()));
+  IMutationPoint *mutationPoint = (*(mutationPoints.begin()));
 
   const long long RunningTime_1 = 1;
   const long long RunningTime_2 = 2;
@@ -343,12 +343,12 @@ TEST(SQLiteReporter, do_emitDebugInfo) {
 
   ASSERT_FALSE(testeeFunction->empty());
 
-  std::vector<MutationPoint *> mutationPoints =
-  Finder.findMutationPoints(context, *testeeFunction);
+  std::vector<IMutationPoint *> mutationPoints =
+    Finder.findMutationPoints(context, *testeeFunction);
 
   ASSERT_EQ(1U, mutationPoints.size());
 
-  MutationPoint *mutationPoint = (*(mutationPoints.begin()));
+  IMutationPoint *mutationPoint = (*(mutationPoints.begin()));
 
   const long long RunningTime_1 = 1;
   const long long RunningTime_2 = 2;
@@ -513,12 +513,12 @@ TEST(SQLiteReporter, do_not_emitDebugInfo) {
 
   ASSERT_FALSE(testeeFunction->empty());
 
-  std::vector<MutationPoint *> mutationPoints =
-  Finder.findMutationPoints(context, *testeeFunction);
+  std::vector<IMutationPoint *> mutationPoints =
+    Finder.findMutationPoints(context, *testeeFunction);
 
   ASSERT_EQ(1U, mutationPoints.size());
 
-  MutationPoint *mutationPoint = (*(mutationPoints.begin()));
+  IMutationPoint *mutationPoint = (*(mutationPoints.begin()));
 
   const long long RunningTime_1 = 1;
   const long long RunningTime_2 = 2;

--- a/unittests/SimpleTest/SimpleTestFinderTest.cpp
+++ b/unittests/SimpleTest/SimpleTestFinderTest.cpp
@@ -95,10 +95,11 @@ TEST(SimpleTestFinder, FindMutationPoints_AddMutationOperator) {
   Function *Testee = Testees[1]->getTesteeFunction();
   ASSERT_FALSE(Testee->empty());
 
-  std::vector<MutationPoint *> MutationPoints = Finder.findMutationPoints(Ctx, *Testee);
+  std::vector<IMutationPoint *> MutationPoints =
+    Finder.findMutationPoints(Ctx, *Testee);
   ASSERT_EQ(1U, MutationPoints.size());
 
-  MutationPoint *MP = (*(MutationPoints.begin()));
+  IMutationPoint *MP = (*(MutationPoints.begin()));
 
   /// TODO: Don't know how to compare unique pointer addMutationOperator with
   /// MutationOperator *.
@@ -134,10 +135,12 @@ TEST(SimpleTestFinder, FindMutationPoints_MathSubMutationOperator) {
   Function *Testee = Testees[1]->getTesteeFunction();
   ASSERT_FALSE(Testee->empty());
 
-  std::vector<MutationPoint *> MutationPoints = Finder.findMutationPoints(Ctx, *Testee);
+  std::vector<IMutationPoint *> MutationPoints =
+    Finder.findMutationPoints(Ctx, *Testee);
+
   ASSERT_EQ(1U, MutationPoints.size());
 
-  MutationPoint *MP = (*(MutationPoints.begin()));
+  IMutationPoint *MP = (*(MutationPoints.begin()));
 
   ASSERT_TRUE(isa<BinaryOperator>(MP->getOriginalValue()));
 
@@ -173,10 +176,12 @@ TEST(SimpleTestFinder, FindMutationPoints_NegateConditionMutationOperator) {
   Function *Testee = Testees[1]->getTesteeFunction();
   ASSERT_FALSE(Testee->empty());
 
-  std::vector<MutationPoint *> MutationPoints = Finder.findMutationPoints(Ctx, *Testee);
+  std::vector<IMutationPoint *> MutationPoints =
+    Finder.findMutationPoints(Ctx, *Testee);
+
   ASSERT_EQ(1U, MutationPoints.size());
 
-  MutationPoint *MP = (*(MutationPoints.begin()));
+  IMutationPoint *MP = (*(MutationPoints.begin()));
 
   /// TODO: Don't know how to compare unique pointer addMutationOperator with
   /// MutationOperator *.
@@ -218,10 +223,12 @@ TEST(SimpleTestFinder, FindMutationPoints_RemoteVoidFunctionMutationOperator) {
   ASSERT_FALSE(Testee2->empty());
   ASSERT_FALSE(Testee3->empty());
 
-  std::vector<MutationPoint *> MutationPoints = Finder.findMutationPoints(Ctx, *Testee2);
+  std::vector<IMutationPoint *> MutationPoints =
+    Finder.findMutationPoints(Ctx, *Testee2);
+
   ASSERT_EQ(1U, MutationPoints.size());
 
-  MutationPoint *MP = (*(MutationPoints.begin()));
+  IMutationPoint *MP = (*(MutationPoints.begin()));
 
   /// TODO: Don't know how to compare unique pointer addMutationOperator with
   /// MutationOperator *.
@@ -259,12 +266,12 @@ TEST(SimpleTestFinder, findMutationPoints_AndOrReplacementMutationOperator) {
 
   Function *testee_test_and_operator = testees[1]->getTesteeFunction(); // testee_and_operator()
 
-  std::vector<MutationPoint *> MutationPoints =
+  std::vector<IMutationPoint *> MutationPoints =
     Finder.findMutationPoints(ctx, *testee_test_and_operator);
 
   ASSERT_EQ(1U, MutationPoints.size());
 
-  MutationPoint *mutationPoint = (*(MutationPoints.begin()));
+  IMutationPoint *mutationPoint = (*(MutationPoints.begin()));
 
   MutationPointAddress mutationPointAddress = mutationPoint->getAddress();
   ASSERT_EQ(mutationPointAddress.getFnIndex(), 0);
@@ -280,19 +287,19 @@ TEST(SimpleTestFinder, findMutationPoints_AndOrReplacementMutationOperator) {
 
   Function *testee5_function = test5_testees[1]->getTesteeFunction(); // testee_and_operator()
 
-  std::vector<MutationPoint *> testee5_mutationPoints =
+  std::vector<IMutationPoint *> testee5_mutationPoints =
     Finder.findMutationPoints(ctx, *testee5_function);
 
   ASSERT_EQ(2U, testee5_mutationPoints.size());
 
-  MutationPoint *testee5_mutationPoint1 = testee5_mutationPoints[0];
+  IMutationPoint *testee5_mutationPoint1 = testee5_mutationPoints[0];
 
   MutationPointAddress testee5_mutationPoint1_address = testee5_mutationPoint1->getAddress();
   ASSERT_EQ(testee5_mutationPoint1_address.getFnIndex(), 5);
   ASSERT_EQ(testee5_mutationPoint1_address.getBBIndex(), 0);
   ASSERT_EQ(testee5_mutationPoint1_address.getIIndex(), 10);
 
-  MutationPoint *testee5_mutationPoint2 = testee5_mutationPoints[1];
+  IMutationPoint *testee5_mutationPoint2 = testee5_mutationPoints[1];
 
   MutationPointAddress testee5_mutationPoint2_address = testee5_mutationPoint2->getAddress();
   ASSERT_EQ(testee5_mutationPoint2_address.getFnIndex(), 5);

--- a/unittests/TestRunnersTests.cpp
+++ b/unittests/TestRunnersTests.cpp
@@ -81,7 +81,8 @@ TEST(SimpleTestRunner, runTest) {
   /// afterwards we apply single mutation and run test again
   /// expecting it to fail
 
-  std::vector<std::unique_ptr<Testee>> Testees = testFinder.findTestees(Test.get(), Ctx, 4);
+  std::vector<std::unique_ptr<Testee>> Testees =
+    testFinder.findTestees(Test.get(), Ctx, 4);
 
   ASSERT_NE(0U, Testees.size());
   Function *Testee = Testees[1]->getTesteeFunction();
@@ -89,9 +90,10 @@ TEST(SimpleTestRunner, runTest) {
   AddMutationOperator MutOp;
   std::vector<MutationOperator *> MutOps({&MutOp});
 
-  std::vector<MutationPoint *> MutationPoints = testFinder.findMutationPoints(Ctx, *Testee);
+  std::vector<IMutationPoint *> MutationPoints =
+    testFinder.findMutationPoints(Ctx, *Testee);
 
-  MutationPoint *MP = (*(MutationPoints.begin()));
+  IMutationPoint *MP = (*(MutationPoints.begin()));
   auto ownedMutatedTesteeModule = MP->cloneModuleAndApplyMutation();
 
   {
@@ -175,10 +177,11 @@ TEST(SimpleTestRunner, runTestUsingLibC) {
   AddMutationOperator MutOp;
   std::vector<MutationOperator *> MutOps({&MutOp});
 
-  std::vector<MutationPoint *> MutationPoints = Finder.findMutationPoints(Ctx, *Testee);
+  std::vector<IMutationPoint *> MutationPoints =
+    Finder.findMutationPoints(Ctx, *Testee);
   ASSERT_EQ(1U, MutationPoints.size());
 
-  MutationPoint *MP = (*(MutationPoints.begin()));
+  IMutationPoint *MP = (*(MutationPoints.begin()));
 
   auto ownedMutatedTesteeModule = MP->cloneModuleAndApplyMutation();
 


### PR DESCRIPTION
1) `IMutationPoint` interface is introduced (just picked up the easiest name for the fastest changes everywhere). 
2) `MutationPoint` now conforms to `IMutationPoint`.
3) `NegateConditionMutationPoint` class is introduced to contain information specific for `NegateCondition` mutation.
4) Observe that within `NegateConditionMutationPoint` and `NegateConditionMutationOperator` there are no casts at all. They interact about their specifics only with each other, no specific interaction happens with outside.
