### PR TITLE
CentOS: fix unique_ptr errors.

### DIFF
--- a/include/MutationOperators/MutationOperatorsFactory.h
+++ b/include/MutationOperators/MutationOperatorsFactory.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <memory>
 
 namespace mull {
 

--- a/include/MutationPoint.h
+++ b/include/MutationPoint.h
@@ -2,6 +2,7 @@
 
 #include <functional>
 #include <string>
+#include <memory>
 
 namespace llvm {
 

--- a/include/TestFinder.h
+++ b/include/TestFinder.h
@@ -2,6 +2,8 @@
 
 #include "Test.h"
 
+#include <memory>
+
 namespace mull {
 
 class Context;


### PR DESCRIPTION
```
../include/MutationsFinder.h:17:38: error: no member named 'unique_ptr' in namespace 'std'
```