### PR TITLE
Docs/Ubuntu: LLVM 3.9 distribution has llvm-dev package now.

### DIFF
--- a/Docs/GettingStartedUbuntu.md
+++ b/Docs/GettingStartedUbuntu.md
@@ -30,7 +30,7 @@ $ apt-get update
 $ apt-get -y install git make vim ninja-build wget \
                      libz-dev sqlite3 libsqlite3-dev ncurses-dev \
                      cmake \
-                     llvm-3.9 clang-3.9
+                     llvm-3.9 clang-3.9 llvm-3.9-dev
 ```
 
 ### Cloning mull


### PR DESCRIPTION
[skip ci]