### PR TITLE
Adapt progress_reporter to a non-terminal environment

### DIFF
--- a/include/Parallelization/Progress.h
+++ b/include/Parallelization/Progress.h
@@ -33,12 +33,15 @@ public:
   void operator()();
 private:
   void printProgress(progress_counter::CounterType current,
-                     progress_counter::CounterType total);
+                     progress_counter::CounterType total,
+                     bool force);
   void backspace();
 
   std::vector<progress_counter> &counters;
   llvm::raw_ostream &stream;
   progress_counter::CounterType total;
+  progress_counter::CounterType previousValue;
   std::string backspaces;
+  bool hasTerminal;
 };
 }


### PR DESCRIPTION
Simply prints dots when running from an IDE (Xcode/CLion).