### PR TITLE
Add functional include

### DIFF
--- a/unittests/MutatorsFactoryTests.cpp
+++ b/unittests/MutatorsFactoryTests.cpp
@@ -2,6 +2,7 @@
 
 #include "gtest/gtest.h"
 
+#include <functional>
 #include <vector>
 
 using namespace mull;


### PR DESCRIPTION
Fixes compilation with clang 6.0.1 on my machine since std::functional is defined in functional header.