### PR TITLE
Use i8 instead of void for trampoline pointers

### DIFF
--- a/lib/Instrumentation/Callbacks.cpp
+++ b/lib/Instrumentation/Callbacks.cpp
@@ -31,7 +31,7 @@ extern "C" void mull_leaveFunction(void **trampoline, uint32_t functionIndex) {
 Value *Callbacks::injectInstrumentationInfoPointer(Module *module,
                                                    const char *variableName) {
   auto &context = module->getContext();
-  auto trampolineType = Type::getVoidTy(context)->getPointerTo()->getPointerTo();
+  auto trampolineType = Type::getInt8Ty(context)->getPointerTo();
   return module->getOrInsertGlobal(variableName, trampolineType);
 }
 
@@ -51,7 +51,7 @@ void Callbacks::injectCallbacks(llvm::Function *function,
                                 Value *offset) {
   auto &context = function->getParent()->getContext();
   auto intType = Type::getInt32Ty(context);
-  auto trampolineType = Type::getVoidTy(context)->getPointerTo()->getPointerTo();
+  auto trampolineType = Type::getInt8Ty(context)->getPointerTo()->getPointerTo();
   auto voidType = Type::getVoidTy(context);
   std::vector<Type *> parameterTypes({trampolineType, intType});
 


### PR DESCRIPTION
Creating void pointers is forbidden by [LLVM assertions ("Invalid type for pointer element!")](https://llvm.org/doxygen/Type_8cpp_source.html#l00644).
Clang uses pointers to 8-bit integers to represent void pointers, so let's do the same.

Why minus one `->getPointerTo()`? For some reason `injectInstrumentationInfoPointer` was generating a triple pointer, which tripped a different assertion ("Calling a function with a bad signature!") — I have no idea how that happens o_0