### PR TITLE
Rename LLVM_ROOT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ before_install:
 
 # Build steps
 script:
-- if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then make ninja.init travis.test LLVM_ROOT=/opt/llvm-$LLVM_VERSION INSTALL_DIR=/tmp/mull; fi
-- if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then make ninja.init travis.test LLVM_ROOT=/opt/llvm-$LLVM_VERSION INSTALL_DIR=/tmp/mull; fi
+- if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then make ninja.init travis.test PRECOMPILED_LLVM_DIR=/opt/llvm-$LLVM_VERSION INSTALL_DIR=/tmp/mull; fi
+- if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then make ninja.init travis.test PRECOMPILED_LLVM_DIR=/opt/llvm-$LLVM_VERSION INSTALL_DIR=/tmp/mull; fi
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,16 @@ cmake_minimum_required(VERSION 3.5.1)
 project(Mull)
 enable_language(C CXX)
 
-if (NOT LLVM_ROOT)
-  message(FATAL_ERROR "This CMakeLists.txt file expects cmake to be called with
-  LLVM_ROOT provided:\n \
-  -DLLVM_ROOT=path-to-llvm-installation")
+if (NOT PRECOMPILED_LLVM_DIR AND NOT SOURCE_LLVM_DIR)
+  message(FATAL_ERROR " 
+ The cmake is supposed to be called with either of the following options:
+ PRECOMPILED_LLVM_DIR: path to a precompiled version of LLVM
+ SOURCE_LLVM_DIR: path to a source code of LLVM
+ 
+ Examples:
+ cmake -G \"${CMAKE_GENERATOR}\" -DPRECOMPILED_LLVM_DIR=/opt/llvm-3.9.0 ${CMAKE_SOURCE_DIR}
+ cmake -G \"${CMAKE_GENERATOR}\" -DSOURCE_LLVM_DIR=${CMAKE_SOURCE_DIR}/llvm_source/3.9.0 ${CMAKE_SOURCE_DIR}
+")
 endif()
 
 # This enables assertions for Release builds.
@@ -25,21 +31,29 @@ if (PkgConfig_FOUND)
   endif()
 endif()
 
-set (search_paths
-  ${LLVM_ROOT}
-  ${LLVM_ROOT}/lib/cmake
-  ${LLVM_ROOT}/lib/cmake/llvm
-  ${LLVM_ROOT}/lib/cmake/clang
-  ${LLVM_ROOT}/share/clang/cmake/
-  ${LLVM_ROOT}/share/llvm/cmake/
-)
+if (PRECOMPILED_LLVM_DIR)
+  set (search_paths
+    ${PRECOMPILED_LLVM_DIR}
+    ${PRECOMPILED_LLVM_DIR}/lib/cmake
+    ${PRECOMPILED_LLVM_DIR}/lib/cmake/llvm
+    ${PRECOMPILED_LLVM_DIR}/lib/cmake/clang
+    ${PRECOMPILED_LLVM_DIR}/share/clang/cmake/
+    ${PRECOMPILED_LLVM_DIR}/share/llvm/cmake/
+  )
 
-find_package(LLVM REQUIRED CONFIG PATHS ${search_paths} NO_DEFAULT_PATH)
-find_package(Clang REQUIRED CONFIG PATHS ${search_paths} NO_DEFAULT_PATH)
+  find_package(LLVM REQUIRED CONFIG PATHS ${search_paths} NO_DEFAULT_PATH)
+  find_package(Clang REQUIRED CONFIG PATHS ${search_paths} NO_DEFAULT_PATH)
+endif()
+
+if(SOURCE_LLVM_DIR)
+  # TBD
+endif()
 
 set (llvm_patch_version "${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}")
 set (llvm_minor_version "${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.x")
 set (llvm_major_version "${LLVM_VERSION_MAJOR}.x.x")
+
+set (full_llvm_version ${llvm_patch_version})
 
 if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/LLVMCompatibility/${llvm_patch_version})
   set (LLVM_COMPATIBILITY_DIR ${llvm_patch_version})
@@ -50,7 +64,7 @@ elseif(EXISTS ${CMAKE_CURRENT_LIST_DIR}/LLVMCompatibility/${llvm_minor_version})
 elseif(EXISTS ${CMAKE_CURRENT_LIST_DIR}/LLVMCompatibility/${llvm_major_version})
   set (LLVM_COMPATIBILITY_DIR ${llvm_major_version})
 else()
-  message(FATAL_ERROR "LLVM-${LLVM_PACKAGE_VERSION} is not supported")
+  message(FATAL_ERROR "LLVM-${full_llvm_version} is not supported")
 endif()
 
 set(MULL_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})

--- a/Makefile
+++ b/Makefile
@@ -12,20 +12,6 @@ CMAKE_COMMAND_LINE_DEBUG_FLAGS=# --debug-output # --debug-output --trace --trace
 
 OS?=$(shell uname -s)
 
-ifeq ($(LLVM_ROOT),)
-	ifeq ($(OS), Darwin)
-		LLVM_ROOT=/opt/llvm-3.9
-	else
-		ifneq ($(wildcard /etc/debian_version),)
-			LLVM_ROOT=/usr/lib/llvm-3.9
-		endif
-	endif
-endif
-
-ifeq ($(LLVM_ROOT),)
-$(error Could not find/identify LLVM_ROOT)
-endif
-
 # Self-Documented Makefile
 # http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 .PHONY: help
@@ -55,7 +41,7 @@ ninja.init: $(BUILD_DIR_NINJA) ## Prepare Ninja project on macOS
 	cd $(BUILD_DIR_NINJA) && cmake -G Ninja \
     -DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR) \
     $(CMAKE_COMMAND_LINE_DEBUG_FLAGS) \
-    -DLLVM_ROOT=$(LLVM_ROOT) \
+    -DPRECOMPILED_LLVM_DIR=$(PRECOMPILED_LLVM_DIR) \
     ../
 
 ninja.build.mull-driver: ## Build mull-driver on macOS
@@ -73,7 +59,7 @@ ninja.build.example: ninja.install.mull-driver ## Build example on macOS
     export PATH=$(INSTALL_DIR)/bin:$(PATH) && \
     make example \
       MULL=mull-driver \
-      MULL_CC=$(LLVM_ROOT)/bin/clang
+      MULL_CC=$(PRECOMPILED_LLVM_DIR)/bin/clang
 
 ninja.run.unit-tests: ninja.build.unit-tests ## Run unit-tests on macOS
 	cd $(MULL_UNIT_TESTS_DIR) && $(MULL_UNIT_TESTS)
@@ -83,7 +69,7 @@ ninja.run.example: ninja.build.example ## Run example on macOS
     export PATH=$(INSTALL_DIR)/bin:$(PATH) && \
     make run \
       MULL=mull-driver \
-      MULL_CC=$(LLVM_ROOT)/bin/clang
+      MULL_CC=$(PRECOMPILED_LLVM_DIR)/bin/clang
 
 
 ninja.clean:
@@ -143,7 +129,7 @@ travis.install.ubuntu:
 xcode.init: $(BUILD_DIR_XCODE) ## Build Xcode project with CMake.
 	cd $(BUILD_DIR_XCODE) && cmake ../ -G Xcode \
     $(CMAKE_COMMAND_LINE_DEBUG_FLAGS) \
-    -DLLVM_ROOT=$(LLVM_ROOT) \
+    -DPRECOMPILED_LLVM_DIR=$(PRECOMPILED_LLVM_DIR) \
 
 xcode.kill-and-rebuild: xcode.kill-and-reopen ## Build Xcode project with CMake, kill Xcode, reopen the project in Xcode
 

--- a/lab/CMakeLists.txt
+++ b/lab/CMakeLists.txt
@@ -1,5 +1,5 @@
-set (CURRENT_CC ${LLVM_ROOT}/bin/clang)
-set (CURRENT_CXX ${LLVM_ROOT}/bin/clang++)
+set (CURRENT_CC ${PRECOMPILED_LLVM_DIR}/bin/clang)
+set (CURRENT_CXX ${PRECOMPILED_LLVM_DIR}/bin/clang++)
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/Makefile.common.in
   ${CMAKE_CURRENT_SOURCE_DIR}/Makefile.common


### PR DESCRIPTION
*_ROOT variable names are reserved by CMake and should not be used.
This patch renames the LLVM_ROOT to PRECOMPILED_LLVM_DIR, which serves
the same purpose.