### PR TITLE
Exclude google-test and unit-tests from ALL

### DIFF
--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -6,7 +6,7 @@ file(GLOB_RECURSE google_test_headers ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
 
 set(google_test_sources src/gtest-all.cc src/gtest_main.cc)
 
-add_library(google-test STATIC ${google_test_sources} ${google_test_headers})
+add_library(google-test STATIC EXCLUDE_FROM_ALL ${google_test_sources} ${google_test_headers})
 
 set_target_properties(google-test
   PROPERTIES COMPILE_FLAGS ${MULL_CXX_FLAGS}

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -37,7 +37,7 @@ set(mull_unittests_sources
   ConfigParserTestFixture.h
 )
 
-add_executable(MullUnitTests ${mull_unittests_sources})
+add_executable(MullUnitTests EXCLUDE_FROM_ALL ${mull_unittests_sources})
 target_link_libraries(MullUnitTests
   mull
   google-test


### PR DESCRIPTION
By default, when one runs `make install` cmake builds each and every
target, including `google-test` and `MullUnitTests`.
This patch excludes unneeded parts.