### PR TITLE
[Junk Detection] Introduce custom CompilationDatabase

### DIFF
--- a/include/JunkDetection/CXX/CompilationDatabase.h
+++ b/include/JunkDetection/CXX/CompilationDatabase.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace mull {
+
+class CompilationDatabase {
+public:
+  class Path {
+  public:
+    explicit Path(std::string p) : path(std::move(p)) {}
+    std::string getPath() const { return path; }
+
+  private:
+    std::string path;
+  };
+  class Flags {
+  public:
+    explicit Flags(std::string f) : flags(std::move(f)) {}
+    std::string getFlags() const { return flags; }
+
+  private:
+    std::string flags;
+  };
+
+public:
+  CompilationDatabase(Path path, Flags flags);
+
+  const std::vector<std::string> &
+  compilationFlagsForFile(const std::string &filepath) const;
+
+private:
+  const std::vector<std::string> flags;
+  const std::map<std::string, std::vector<std::string>> database;
+};
+
+} // namespace mull

--- a/lab/junk_detection/compdb/CMakeLists.txt
+++ b/lab/junk_detection/compdb/CMakeLists.txt
@@ -29,3 +29,14 @@ configure_file(
 
 add_fixture(${CMAKE_CURRENT_LIST_DIR}/include)
 
+set (databases
+  ${CMAKE_CURRENT_LIST_DIR}/db_with_arguments.json
+  ${CMAKE_CURRENT_LIST_DIR}/db_with_commands.json
+  ${CMAKE_CURRENT_LIST_DIR}/db_with_output.json
+  ${CMAKE_CURRENT_LIST_DIR}/db_with_fullpath_compiler.json
+)
+
+foreach(database ${databases})
+  add_fixture(${database})
+endforeach()
+

--- a/lab/junk_detection/compdb/db_with_arguments.json
+++ b/lab/junk_detection/compdb/db_with_arguments.json
@@ -1,0 +1,7 @@
+[
+{
+  "directory": "/foo/bar",
+  "arguments": "clang++ -I foo -I bar -c foobar.cpp",
+  "file": "foobar.cpp"
+}
+]

--- a/lab/junk_detection/compdb/db_with_commands.json
+++ b/lab/junk_detection/compdb/db_with_commands.json
@@ -1,0 +1,8 @@
+[
+{
+  "directory": "/foo/bar",
+  "command": "clang++ -I foo -I bar -c foobar.cpp",
+  "file": "foobar.cpp"
+}
+]
+

--- a/lab/junk_detection/compdb/db_with_fullpath_compiler.json
+++ b/lab/junk_detection/compdb/db_with_fullpath_compiler.json
@@ -1,0 +1,8 @@
+[
+{
+  "directory": "/foo/bar",
+  "arguments": "/opt/bin/clang++ -I foo -I bar -c foobar.cpp",
+  "file": "foobar.cpp",
+  "output" : "foobar.exe"
+}
+]

--- a/lab/junk_detection/compdb/db_with_output.json
+++ b/lab/junk_detection/compdb/db_with_output.json
@@ -1,0 +1,9 @@
+[
+{
+  "directory": "/foo/bar",
+  "arguments": "clang++ -I foo -I bar -c foobar.cpp",
+  "file": "foobar.cpp",
+  "output" : "foobar.exe"
+}
+]
+

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -77,7 +77,7 @@ set(mull_sources
   Config/ConfigurationOptions.cpp
   Config/Configuration.cpp
   TestFrameworks/TestFramework.cpp
-  TestFrameworks/TestFrameworkFactory.cpp Program/Program.cpp ObjectLoader.cpp JunkDetection/CXX/Visitors/InstructionRangeVisitor.cpp JunkDetection/CXX/Visitors/ConditionalsBoundaryVisitor.cpp JunkDetection/CXX/Visitors/MathAddVisitor.cpp JunkDetection/CXX/Visitors/MathSubVisitor.cpp JunkDetection/CXX/Visitors/RemoveVoidFunctionVisitor.cpp JunkDetection/CXX/Visitors/NegateConditionVisitor.cpp JunkDetection/CXX/ASTStorage.cpp)
+  TestFrameworks/TestFrameworkFactory.cpp Program/Program.cpp ObjectLoader.cpp JunkDetection/CXX/Visitors/InstructionRangeVisitor.cpp JunkDetection/CXX/Visitors/ConditionalsBoundaryVisitor.cpp JunkDetection/CXX/Visitors/MathAddVisitor.cpp JunkDetection/CXX/Visitors/MathSubVisitor.cpp JunkDetection/CXX/Visitors/RemoveVoidFunctionVisitor.cpp JunkDetection/CXX/Visitors/NegateConditionVisitor.cpp JunkDetection/CXX/ASTStorage.cpp JunkDetection/CXX/CompilationDatabase.cpp)
 
 set (MULL_INCLUDE_DIR ${MULL_SOURCE_DIR}/include)
 

--- a/lib/JunkDetection/CXX/CompilationDatabase.cpp
+++ b/lib/JunkDetection/CXX/CompilationDatabase.cpp
@@ -1,0 +1,150 @@
+#include "JunkDetection/CXX/CompilationDatabase.h"
+#include "CompilationDatabaseParser.h"
+#include "Logger.h"
+
+#include <clang/Basic/Version.h>
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/SmallString.h>
+#include <llvm/Support/Path.h>
+
+#include <sstream>
+
+using namespace mull;
+
+/// Skips the next word even if it is several spaces away:
+///
+/// Examples:
+///     ' aaa bbb' ->  ' aaa bbb'
+///      ^                   ^
+///
+///     '   aaa bbb' ->  '   aaa bbb'
+///      ^                       ^
+static void skipNextWord(std::istringstream &stream) {
+  int c = stream.get();
+  while (c == ' ') {
+    stream.ignore(std::numeric_limits<std::streamsize>::max(), ' ');
+    c = stream.get();
+  }
+  if (stream.good()) {
+    stream.unget();
+  }
+}
+
+static std::vector<std::string> flagsFromString(const std::string &s) {
+  std::vector<std::string> flags;
+
+  std::istringstream stream(s);
+  while (!stream.eof()) {
+    std::string value;
+    stream >> value;
+    if (value.empty()) {
+      continue;
+    }
+    if (value == "-c") {
+      skipNextWord(stream);
+      continue;
+    }
+    flags.push_back(value);
+  }
+
+  return flags;
+}
+
+const std::string &commandOrArguments(const CompileCommand &command) {
+  if (command.arguments.empty()) {
+    return command.command;
+  }
+  return command.arguments;
+}
+
+void addHeaderSearchPathsFromCompiler(std::vector<std::string> &flags,
+                                      const std::string &compiler) {
+  if (compiler.empty()) {
+    return;
+  }
+
+  auto binDirectory = llvm::sys::path::parent_path(compiler);
+  if (binDirectory.empty()) {
+    return;
+  }
+
+  auto installDirectory = llvm::sys::path::parent_path(binDirectory);
+  llvm::SmallString<128> cppIncludeDir;
+  llvm::sys::path::append(cppIncludeDir, installDirectory, "include", "c++",
+                          "v1");
+
+  llvm::SmallString<128> cIncludeDir;
+  llvm::sys::path::append(cIncludeDir, installDirectory, "lib", "clang",
+                          CLANG_VERSION_STRING);
+  llvm::sys::path::append(cIncludeDir, "include");
+
+  flags.emplace_back("-I");
+  flags.emplace_back(cppIncludeDir.c_str());
+  flags.emplace_back("-I");
+  flags.emplace_back(cIncludeDir.c_str());
+}
+
+static std::vector<std::string>
+flagsFromCommand(const CompileCommand &command) {
+  const std::string &input = commandOrArguments(command);
+
+  std::istringstream stream(input);
+  std::string compiler;
+  stream >> compiler;
+
+  std::string rest;
+  std::getline(stream, rest);
+
+  std::vector<std::string> flags = flagsFromString(rest);
+  addHeaderSearchPathsFromCompiler(flags, compiler);
+  return flags;
+}
+
+static std::map<std::string, std::vector<std::string>>
+loadDatabaseFromFile(const std::string &path) {
+  std::map<std::string, std::vector<std::string>> database;
+  if (path.empty()) {
+    return database;
+  }
+
+  std::vector<CompileCommand> commands;
+
+  auto bufferOrError = llvm::MemoryBuffer::getFile(path);
+  if (!bufferOrError) {
+    Logger::error() << "Can not read compilation database: " << path << '\n';
+  } else {
+    auto buffer = bufferOrError->get();
+    llvm::yaml::Input json(buffer->getBuffer());
+
+    json >> commands;
+
+    if (json.error()) {
+      Logger::error() << "Can not read compilation database: " << path << '\n';
+    }
+  }
+
+  for (auto &command : commands) {
+    database[command.file] = flagsFromCommand(command);
+  }
+
+  return database;
+}
+
+CompilationDatabase::CompilationDatabase(CompilationDatabase::Path path,
+                                         CompilationDatabase::Flags flags)
+    : flags(flagsFromString(flags.getFlags())),
+      database(loadDatabaseFromFile(path.getPath())) {}
+
+const std::vector<std::string> &CompilationDatabase::compilationFlagsForFile(
+    const std::string &filepath) const {
+  if (database.empty()) {
+    return flags;
+  }
+
+  auto it = database.find(filepath);
+  if (it == database.end()) {
+    return flags;
+  }
+
+  return it->second;
+}

--- a/lib/JunkDetection/CXX/CompilationDatabaseParser.h
+++ b/lib/JunkDetection/CXX/CompilationDatabaseParser.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <llvm/Support/YAMLParser.h>
+#include <llvm/Support/YAMLTraits.h>
+
+#include <string>
+#include <vector>
+
+namespace mull {
+
+struct CompileCommand {
+  std::string directory;
+  std::string file;
+  std::string output;
+  std::string arguments;
+  std::string command;
+};
+
+} // namespace mull
+
+namespace llvm {
+namespace yaml {
+class Input;
+
+template <> struct SequenceTraits<std::vector<mull::CompileCommand>> {
+  static size_t size(IO &io, std::vector<mull::CompileCommand> &list) {
+    return list.size();
+  }
+
+  static mull::CompileCommand &
+  element(IO &io, std::vector<mull::CompileCommand> &list, size_t index) {
+    mull::CompileCommand t;
+    list.push_back(t);
+    return list.back();
+  }
+};
+
+template <> struct MappingTraits<mull::CompileCommand> {
+  static void mapping(IO &io, mull::CompileCommand &command) {
+    io.mapRequired("directory", command.directory);
+    io.mapRequired("file", command.file);
+    io.mapOptional("output", command.output);
+    io.mapOptional("arguments", command.arguments);
+    io.mapOptional("command", command.command);
+  }
+};
+} // namespace yaml
+} // namespace llvm

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -37,7 +37,7 @@ set(mull_unittests_sources
 
   ConfigParserTestFixture.h
   ${FACTORY_HEADER}
-)
+  JunkDetection/CompilationDatabaseTests.cpp)
 
 get_filename_component(factory_include_dir ${FACTORY_HEADER} DIRECTORY)
 

--- a/unittests/JunkDetection/CompilationDatabaseTests.cpp
+++ b/unittests/JunkDetection/CompilationDatabaseTests.cpp
@@ -1,0 +1,115 @@
+#include "FixturePaths.h"
+#include "JunkDetection/CXX/CompilationDatabase.h"
+
+#include <clang/Basic/Version.h>
+
+#include <gtest/gtest.h>
+
+using namespace mull;
+
+TEST(CompilationDatabaseFromCompilationFlags, returnsAllFlags) {
+  const CompilationDatabase database(
+      CompilationDatabase::Path(""),
+      CompilationDatabase::Flags("-I     /usr/foo/include   "));
+
+  const std::string filepath("foobar");
+  const auto flags = database.compilationFlagsForFile(filepath);
+  ASSERT_EQ(flags.size(), size_t(2));
+}
+
+TEST(CompilationDatabaseFromCompilationFlags, returnsAllFlagsForAnyFile) {
+  const CompilationDatabase database(
+      CompilationDatabase::Path(""),
+      CompilationDatabase::Flags("-I /usr/foo/include   "));
+
+  const std::string foo("foo");
+  const std::string bar("bar");
+
+  const auto fooFlags = database.compilationFlagsForFile(foo);
+  const auto barFlags = database.compilationFlagsForFile(bar);
+
+  ASSERT_EQ(fooFlags.size(), barFlags.size());
+
+  for (size_t index(0); index < fooFlags.size(); index++) {
+    auto &fooFlag = fooFlags.at(index);
+    auto &barFlag = barFlags.at(index);
+
+    ASSERT_EQ(fooFlag, barFlag);
+  }
+}
+
+TEST(CompilationDatabaseFromCompilationFlags, cleansUpFlags) {
+  const std::vector<std::string> testFlags(
+      {"-c", "-c foo.cpp", "-c     foo.cpp"});
+
+  const std::string file("foobar.cpp");
+  for (auto &flags : testFlags) {
+    const CompilationDatabase database(CompilationDatabase::Path(""),
+                                       CompilationDatabase::Flags(flags));
+
+    auto compilationFlags = database.compilationFlagsForFile(file);
+    ASSERT_EQ(compilationFlags.size(), size_t(0));
+  }
+}
+
+TEST(CompilationDatabaseFromCompilationFlags, cleansUpMixedFlags) {
+  const std::vector<std::string> testFlags(
+      {"-I foo -I bar -c foo.cpp", "-c foo.cpp -I foo -I bar",
+       "-I foo -c foo.cpp -I bar", "-I foo -I bar -c"});
+
+  const std::string file("foobar.cpp");
+  for (auto &flags : testFlags) {
+    const CompilationDatabase database(CompilationDatabase::Path(""),
+                                       CompilationDatabase::Flags(flags));
+
+    auto compilationFlags = database.compilationFlagsForFile(file);
+    ASSERT_EQ(compilationFlags.size(), size_t(4));
+
+    ASSERT_EQ(compilationFlags.at(0), std::string("-I"));
+    ASSERT_EQ(compilationFlags.at(1), std::string("foo"));
+    ASSERT_EQ(compilationFlags.at(2), std::string("-I"));
+    ASSERT_EQ(compilationFlags.at(3), std::string("bar"));
+  }
+}
+
+TEST(CompilationDatabaseFromFile, loadsFromValidFiles) {
+  const std::vector<std::string> databasePaths(
+      {fixtures::junk_detection_compdb_db_with_arguments_json_path(),
+       fixtures::junk_detection_compdb_db_with_commands_json_path(),
+       fixtures::junk_detection_compdb_db_with_output_json_path()});
+
+  const std::string file("foobar.cpp");
+  for (auto &path : databasePaths) {
+    const CompilationDatabase database(CompilationDatabase::Path(path),
+                                       CompilationDatabase::Flags(""));
+
+    auto compilationFlags = database.compilationFlagsForFile(file);
+    ASSERT_EQ(compilationFlags.size(), size_t(4));
+
+    ASSERT_EQ(compilationFlags.at(0), std::string("-I"));
+    ASSERT_EQ(compilationFlags.at(1), std::string("foo"));
+    ASSERT_EQ(compilationFlags.at(2), std::string("-I"));
+    ASSERT_EQ(compilationFlags.at(3), std::string("bar"));
+  }
+}
+
+TEST(CompilationDatabaseFromFile, includesInternalHeaderSearchPaths) {
+  auto path =
+      fixtures::junk_detection_compdb_db_with_fullpath_compiler_json_path();
+  const CompilationDatabase database(CompilationDatabase::Path(path),
+                                     CompilationDatabase::Flags(""));
+
+  const std::string file("foobar.cpp");
+  auto compilationFlags = database.compilationFlagsForFile(file);
+  ASSERT_EQ(compilationFlags.size(), size_t(8));
+
+  ASSERT_EQ(compilationFlags.at(0), std::string("-I"));
+  ASSERT_EQ(compilationFlags.at(1), std::string("foo"));
+  ASSERT_EQ(compilationFlags.at(2), std::string("-I"));
+  ASSERT_EQ(compilationFlags.at(3), std::string("bar"));
+  ASSERT_EQ(compilationFlags.at(4), std::string("-I"));
+  ASSERT_EQ(compilationFlags.at(5), std::string("/opt/include/c++/v1"));
+  ASSERT_EQ(compilationFlags.at(6), std::string("-I"));
+  ASSERT_EQ(compilationFlags.at(7),
+            std::string("/opt/lib/clang/" CLANG_VERSION_STRING "/include"));
+}


### PR DESCRIPTION
There are at least two reasons we do not use the CompilationDatabase from
Clang:

1. It expects a directory with a hardcoded filename
   (compile_commands.json), which is a weird UX.
2. It silently eats the very first argument in the command/arguments
   string, which is required on macOS in order to build the right header
   search paths.