### PR TITLE
[JunkDetection] Rebrand compilation flags

### DIFF
--- a/include/JunkDetection/CXX/CompilationDatabase.h
+++ b/include/JunkDetection/CXX/CompilationDatabase.h
@@ -33,7 +33,7 @@ public:
   compilationFlagsForFile(const std::string &filepath) const;
 
 private:
-  const std::vector<std::string> flags;
+  const std::vector<std::string> extraFlags;
   const std::map<std::string, std::vector<std::string>> database;
 };
 

--- a/tools/driver-cxx/driver-cxx.cpp
+++ b/tools/driver-cxx/driver-cxx.cpp
@@ -88,7 +88,7 @@ llvm::cl::opt<std::string> CompilationDatabasePath(
 
 llvm::cl::opt<std::string> CompilationFlags(
     "compilation-flags", llvm::cl::Optional,
-    llvm::cl::desc("Compilation flags for junk detection"),
+    llvm::cl::desc("Extra compilation flags for junk detection"),
     llvm::cl::cat(MullCXXCategory), llvm::cl::init(""));
 
 llvm::cl::opt<std::string> CacheDir(

--- a/unittests/JunkDetection/CompilationDatabaseTests.cpp
+++ b/unittests/JunkDetection/CompilationDatabaseTests.cpp
@@ -93,11 +93,13 @@ TEST(CompilationDatabaseFromFile, loadsFromValidFiles) {
   }
 }
 
-TEST(CompilationDatabaseFromFile, includesInternalHeaderSearchPaths) {
+TEST(CompilationDatabaseFromFile, includesCompilationFlagsPassedSeparately) {
   auto path =
       fixtures::junk_detection_compdb_db_with_fullpath_compiler_json_path();
-  const CompilationDatabase database(CompilationDatabase::Path(path),
-                                     CompilationDatabase::Flags(""));
+  const CompilationDatabase database(
+      CompilationDatabase::Path(path),
+      CompilationDatabase::Flags(
+          "-isystem /usr/local/include -isystem /usr/include"));
 
   const std::string file("foobar.cpp");
   auto compilationFlags = database.compilationFlagsForFile(file);
@@ -108,8 +110,7 @@ TEST(CompilationDatabaseFromFile, includesInternalHeaderSearchPaths) {
   ASSERT_EQ(compilationFlags.at(2), std::string("-I"));
   ASSERT_EQ(compilationFlags.at(3), std::string("bar"));
   ASSERT_EQ(compilationFlags.at(4), std::string("-isystem"));
-  ASSERT_EQ(compilationFlags.at(5), std::string("/opt/include/c++/v1"));
+  ASSERT_EQ(compilationFlags.at(5), std::string("/usr/local/include"));
   ASSERT_EQ(compilationFlags.at(6), std::string("-isystem"));
-  ASSERT_EQ(compilationFlags.at(7),
-            std::string("/opt/lib/clang/" CLANG_VERSION_STRING "/include"));
+  ASSERT_EQ(compilationFlags.at(7), std::string("/usr/include"));
 }


### PR DESCRIPTION
Junk Detection does not try to infer implicit include paths hardcoded into clang.