### PR TITLE
[mull-cxx] Introduce IDEReporter

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -11,8 +11,6 @@ configure_file (
   @ONLY
 )
 
-message("${PROJECT_DESCRIPTION}")
-
 add_library(MullVersion ${CMAKE_BINARY_DIR}/lib/Version.cpp)
 target_include_directories(MullVersion PRIVATE
   ${MULL_INCLUDE_DIRS}

--- a/include/Reporters/IDEReporter.h
+++ b/include/Reporters/IDEReporter.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "Reporters/Reporter.h"
+
+namespace mull {
+
+class IDEReporter : public Reporter {
+public:
+  void reportResults(const Result &result, const RawConfig &config,
+                     const Metrics &metrics) override;
+};
+
+} // namespace mull

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -88,7 +88,7 @@ set(mull_sources
   JunkDetection/CXX/Visitors/NegateConditionVisitor.cpp
   JunkDetection/CXX/ASTStorage.cpp
   JunkDetection/CXX/CompilationDatabase.cpp
-)
+  Reporters/IDEReporter.cpp)
 
 set (MULL_INCLUDE_DIR ${MULL_SOURCE_DIR}/include)
 

--- a/lib/Mutators/MutatorsFactory.cpp
+++ b/lib/Mutators/MutatorsFactory.cpp
@@ -128,9 +128,7 @@ MutatorsFactory::mutators(const vector<string> &groups) {
 
   set<string> expandedGroups;
 
-  if (groups.size() == 0) {
-    Logger::info() << "No mutators specified. Switching to default mutators.\n";
-
+  if (groups.empty()) {
     expandGroups({ DefaultMutatorsGroup }, groupsMapping, expandedGroups);
   } else {
     expandGroups(groups, groupsMapping, expandedGroups);
@@ -138,7 +136,7 @@ MutatorsFactory::mutators(const vector<string> &groups) {
 
   vector<unique_ptr<Mutator>> mutators;
 
-  for (string group: expandedGroups) {
+  for (const string &group: expandedGroups) {
     if (mutatorsMapping.count(group) == 0) {
       Logger::error() << "Unknown mutator: '" << group << "'\n";
       continue;
@@ -147,7 +145,7 @@ MutatorsFactory::mutators(const vector<string> &groups) {
     mutatorsMapping.erase(group);
   }
 
-  if (mutators.size() == 0) {
+  if (mutators.empty()) {
     Logger::error()
       << "No valid mutators found in a config file.\n";
   }
@@ -177,8 +175,7 @@ std::vector<std::pair<std::string, std::string>>
 MutatorsFactory::commandLineOptions() {
   std::vector<std::pair<std::string, std::string>> options;
   for (auto &group : groupsMapping) {
-    options.push_back(std::make_pair(group.first,
-                                     descriptionForGroup(group.second)));
+    options.emplace_back(group.first, descriptionForGroup(group.second));
   }
 
   std::set<std::string> mutatorsSet;
@@ -188,8 +185,8 @@ MutatorsFactory::commandLineOptions() {
   auto allMutators = mutators({ AllMutatorsGroup });
 
   for (auto &mutator : allMutators) {
-    options.push_back(std::make_pair(mutator->getUniqueIdentifier(),
-                                     mutator->getDescription()));
+    options.emplace_back(mutator->getUniqueIdentifier(),
+                         mutator->getDescription());
   }
 
   return options;

--- a/lib/Mutators/NegateConditionMutator.cpp
+++ b/lib/Mutators/NegateConditionMutator.cpp
@@ -269,8 +269,6 @@ static std::string getDiagnostics(CmpInst::Predicate originalPredicate,
   diagnostics << describePredicate(originalPredicate);
   diagnostics << " with ";
   diagnostics << describePredicate(negatedPredicate);
-  diagnostics << " (" << originalPredicate << "->" << negatedPredicate << ")";
-  diagnostics << "\n";
 
   return diagnostics.str();
 }

--- a/lib/Reporters/IDEReporter.cpp
+++ b/lib/Reporters/IDEReporter.cpp
@@ -1,0 +1,131 @@
+#include "Reporters/IDEReporter.h"
+
+#include "Logger.h"
+#include "MutationResult.h"
+#include "Result.h"
+
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace mull;
+
+struct LineOffset {
+  FILE *file;
+  std::vector<uint> offsets;
+  LineOffset(FILE *file, std::vector<uint> offsets)
+      : file(file), offsets(std::move(offsets)) {}
+};
+
+class SourceManager {
+public:
+  std::string getLine(const SourceLocation &location) {
+    LineOffset &lineOffset = getLineOffset(location);
+    assert(location.line < lineOffset.offsets.size());
+
+    uint lineBegin = lineOffset.offsets[location.line - 1];
+    uint lineEnd = lineOffset.offsets[location.line];
+    uint lineLength = lineEnd - lineBegin;
+    fseek(lineOffset.file, lineBegin, SEEK_SET);
+    char *buffer = new char[lineLength + 1];
+    fread(buffer, sizeof(char), lineLength, lineOffset.file);
+    buffer[lineLength] = '\0';
+    auto line = std::string(buffer);
+    free(buffer);
+    return line;
+  }
+  ~SourceManager() {
+    for (auto &pair : lineOffsets) {
+      fclose(pair.second.file);
+    }
+  }
+
+private:
+  std::map<std::string, LineOffset> lineOffsets;
+
+  LineOffset &getLineOffset(const SourceLocation &location) {
+    if (lineOffsets.count(location.filePath)) {
+      return lineOffsets.at(location.filePath);
+    }
+
+    FILE *file = fopen(location.filePath.c_str(), "rb");
+    if (!file) {
+      perror("IDEReporter");
+    }
+    std::vector<uint> offsets;
+    uint offset = 0;
+    char c = '\n';
+    for (; c != EOF; c = fgetc(file), offset++) {
+      if (c == '\n') {
+        offsets.push_back(offset);
+      }
+    }
+
+    LineOffset lineOffset(file, offsets);
+    auto inserted =
+        lineOffsets.insert(std::make_pair(location.filePath, lineOffset));
+    return inserted.first->second;
+  }
+};
+
+static bool mutantSurvived(const ExecutionStatus &status) {
+  return status == ExecutionStatus::Passed;
+}
+
+static void printSurvivedMutant(SourceManager &sourceManager,
+                                const MutationPoint &mutant) {
+  auto &sourceLocation = mutant.getSourceLocation();
+  Logger::info() << sourceLocation.filePath << ":" << sourceLocation.line << ":"
+                 << sourceLocation.column
+                 << ": warning: " << mutant.getDiagnostics() << "\n";
+  auto line = sourceManager.getLine(sourceLocation);
+  assert(sourceLocation.column < line.size());
+  std::string caret(sourceLocation.column, ' ');
+  for (size_t index = 0; index < sourceLocation.column; index++) {
+    if (line[index] == '\t') {
+      caret[index] = '\t';
+    }
+  }
+  caret[sourceLocation.column - 1] = '^';
+
+  Logger::info() << line;
+  Logger::info() << caret << "\n";
+}
+
+void IDEReporter::reportResults(const Result &result, const RawConfig &config,
+                                const Metrics &metrics) {
+  if (result.getMutationPoints().empty()) {
+    Logger::info() << "No mutants found. Mutation score: infinitely high\n";
+    return;
+  }
+
+  std::set<MutationPoint *> killedMutants;
+  for (auto &mutationResult : result.getMutationResults()) {
+    auto mutant = mutationResult->getMutationPoint();
+    auto &executionResult = mutationResult->getExecutionResult();
+
+    if (!mutantSurvived(executionResult.status)) {
+      killedMutants.insert(mutant);
+    }
+  }
+
+  auto survivedMutantsCount =
+      result.getMutationPoints().size() - killedMutants.size();
+
+  Logger::info() << "\nSurvived mutants (" << survivedMutantsCount << "/"
+                 << result.getMutationPoints().size() << "):\n\n";
+
+  SourceManager sourceManager;
+  for (auto mutant : result.getMutationPoints()) {
+    if (killedMutants.find(mutant) == killedMutants.end()) {
+      printSurvivedMutant(sourceManager, *mutant);
+    }
+  }
+
+  auto rawScore =
+      double(killedMutants.size()) / double(result.getMutationPoints().size());
+  auto score = uint(rawScore * 100);
+  Logger::info() << "Mutation score: " << score << "%\n";
+}

--- a/tools/driver-cxx/driver-cxx.cpp
+++ b/tools/driver-cxx/driver-cxx.cpp
@@ -14,23 +14,24 @@
 
 #include "Config/Configuration.h"
 #include "Driver.h"
-#include "JunkDetection/JunkDetector.h"
+#include "DynamicLibraries.h"
 #include "JunkDetection/CXX/CXXJunkDetector.h"
+#include "JunkDetection/JunkDetector.h"
 #include "Metrics/Metrics.h"
 #include "ModuleLoader.h"
 #include "MutationsFinder.h"
 #include "Mutators/MutatorsFactory.h"
 #include "Parallelization/Parallelization.h"
 #include "Program/Program.h"
+#include "Reporters/IDEReporter.h"
 #include "Result.h"
 #include "TestFrameworks/TestFrameworkFactory.h"
-#include "DynamicLibraries.h"
 #include "Version.h"
 
 /// Temp includes to make it running
 
-#include "Config/RawConfig.h"
 #include "Config/ConfigurationOptions.h"
+#include "Config/RawConfig.h"
 #include "Metrics/Metrics.h"
 #include "Reporters/SQLiteReporter.h"
 
@@ -287,9 +288,11 @@ int main(int argc, char **argv) {
   metrics.endRun();
 
   mull::RawConfig rawConfig;
-  mull::SQLiteReporter reporter;
-  reporter.reportResults(*result, rawConfig, metrics);
+//  mull::SQLiteReporter reporter;
+//  reporter.reportResults(*result, rawConfig, metrics);
 
+  mull::IDEReporter ideReporter;
+  ideReporter.reportResults(*result, rawConfig, metrics);
   llvm::llvm_shutdown();
 
   totalExecutionTime.finish();


### PR DESCRIPTION
Closes #439.

Example output:
```
Survived mutants (4/10):

/Users/alexdenisov/Projects/Mull/mull/Examples/HelloWorld/../../googletest/include/gtest/gtest.h:1397:10: warning: Remove Void Call: removed _ZN7testing8internal18CmpHelperEQFailureIiiEENS_15AssertionResultEPKcS4_RKT_RKT0_
  return CmpHelperEQFailure(lhs_expression, rhs_expression, lhs, rhs);
         ^
/Users/alexdenisov/Projects/Mull/mull/Examples/HelloWorld/../../googletest/include/gtest/internal/gtest-port.h:1154:19: warning: Remove Void Call: removed _ZN7testing8internal10scoped_ptrINSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEEE5resetEPS8_
  ~scoped_ptr() { reset(); }
                  ^
/Users/alexdenisov/Projects/Mull/mull/Examples/HelloWorld/../../googletest/include/gtest/internal/gtest-port.h:1167:11: warning: Negate Condition: replaced != with ==
    if (p != ptr_) {
          ^
/Users/alexdenisov/Projects/Mull/mull/Examples/HelloWorld/../../googletest/include/gtest/internal/gtest-port.h:1169:9: warning: Negate Condition: replaced == with !=
        delete ptr_;
        ^
Mutation score: 60%
```