### PR TITLE
CPack: do not error on unknown OS; mull-cxx: support shared libLLVM

### DIFF
--- a/cmake/cpack.cmake
+++ b/cmake/cpack.cmake
@@ -41,6 +41,9 @@ else()
       endif()
     endforeach()
 
+  else()
+    set (CPACK_SYSTEM_NAME "unknown")
+
   endif()
 endif()
 

--- a/tools/driver-cxx/CMakeLists.txt
+++ b/tools/driver-cxx/CMakeLists.txt
@@ -3,8 +3,18 @@ set (SOURCES
   ${CMAKE_CURRENT_LIST_DIR}/DynamicLibraries.cpp
 )
 
+if ("LLVM" IN_LIST LLVM_AVAILABLE_LIBS)
+  set (MULL_CXX_LLVM_LIBRARIES
+    LLVM
+  )
+else()
+  set (MULL_CXX_LLVM_LIBRARIES
+    LLVMObject
+  )
+endif()
+
 add_mull_executable(
   NAME mull-cxx
   SOURCES ${SOURCES}
-  LINK_WITH ebc mull LLVMObject
+  LINK_WITH ebc mull ${MULL_CXX_LLVM_LIBRARIES}
 )


### PR DESCRIPTION
Fixes the following error:

```
CMake Error at cmake/cpack.cmake:47 (if):
  if given arguments:

    "STREQUAL" "macOS"

  Unknown arguments specified
```