### PR TITLE
Add target to validate mutations

### DIFF
--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -27,3 +27,28 @@ macro(add_mull_executable)
   )
 endmacro()
 
+macro(add_mull_internal_executable)
+  set (prefix local)
+  set (optionArguments )
+  set (singleValueArguments NAME)
+  set (multipleValueArguments SOURCES LINK_WITH)
+
+  cmake_parse_arguments(${prefix}
+    "${optionArguments}"
+    "${singleValueArguments}"
+    "${multipleValueArguments}"
+    ${ARGN}
+  )
+
+  add_executable(${local_NAME} ${local_SOURCES})
+  target_link_libraries(${local_NAME} ${local_LINK_WITH})
+
+  set_target_properties(${local_NAME} PROPERTIES
+    LINK_FLAGS ${MULL_LINK_FLAGS}
+    COMPILE_FLAGS ${MULL_CXX_FLAGS}
+  )
+  target_include_directories(${local_NAME} PUBLIC
+    ${MULL_INCLUDE_DIRS}
+  )
+endmacro()
+

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,2 +1,3 @@
+add_subdirectory(internal)
 add_subdirectory(driver)
 add_subdirectory(driver-cxx)

--- a/tools/driver-cxx/driver-cxx.cpp
+++ b/tools/driver-cxx/driver-cxx.cpp
@@ -275,7 +275,6 @@ int main(int argc, char **argv) {
   mull::CXXJunkDetector junkDetector(junkDetectionConfig);
 
   mull::Filter filter;
-  mull::MutatorsFactory factory;
   mull::MutationsFinder mutationsFinder(mutatorsOptions.mutators(),
                                         configuration);
 

--- a/tools/internal/CMakeLists.txt
+++ b/tools/internal/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(mutator-validator)

--- a/tools/internal/mutator-validator/CMakeLists.txt
+++ b/tools/internal/mutator-validator/CMakeLists.txt
@@ -1,0 +1,10 @@
+set (SOURCES
+  ${CMAKE_CURRENT_LIST_DIR}/mutator-validator.cpp
+)
+
+add_mull_internal_executable(
+  SOURCES ${SOURCES}
+  NAME mull-mutator-validator
+  LINK_WITH mull
+)
+

--- a/tools/internal/mutator-validator/mutator-validator.cpp
+++ b/tools/internal/mutator-validator/mutator-validator.cpp
@@ -1,0 +1,69 @@
+#include <cassert>
+#include <utility>
+#include <vector>
+
+#include <mull/Config/Configuration.h>
+#include <mull/Filter.h>
+#include <mull/ModuleLoader.h>
+#include <mull/MutationsFinder.h>
+#include <mull/Mutators/MutatorsFactory.h>
+#include <mull/Parallelization/TaskExecutor.h>
+#include <mull/Program/Program.h>
+#include <mull/Toolchain/Toolchain.h>
+
+int main(int argc, char **argv) {
+  assert(argc == 3 && "Expect mutator name and path to a bitcode file");
+
+  std::vector<std::string> mutatorGroups({argv[1]});
+  const char *bitcodePath = argv[2];
+
+  mull::ModuleLoader loader;
+  llvm::LLVMContext context;
+  std::vector<std::unique_ptr<mull::MullModule>> modules;
+  modules.push_back(std::move(loader.loadModuleAtPath(bitcodePath, context)));
+  mull::Program program({}, {}, std::move(modules));
+
+  mull::MutatorsFactory factory;
+  auto mutators = factory.mutators(mutatorGroups);
+
+  mull::Configuration configuration;
+  mull::MutationsFinder finder(std::move(mutators), configuration);
+
+  std::vector<mull::MergedTestee> testees;
+  for (auto &module : program.modules()) {
+    for (auto &function : module->getModule()->functions()) {
+      testees.emplace_back(&function, nullptr, 1);
+    }
+  }
+
+  mull::Filter filter;
+
+  auto mutants = finder.getMutationPoints(program, testees, filter);
+
+  printf("Found %lu mutants\n", mutants.size());
+
+  mull::SingleTaskExecutor prepareMutants("Preparing mutants", [&] {
+    for (auto &module : program.modules()) {
+      module->prepareMutations();
+    }
+  });
+  prepareMutants.execute();
+
+  mull::SingleTaskExecutor applyMutants("Applying mutants", [&] {
+    for (auto &mutant : mutants) {
+      mutant->applyMutation();
+    }
+  });
+  applyMutants.execute();
+
+  mull::Toolchain toolchain(configuration);
+  mull::SingleTaskExecutor compileMutants("Compiling mutants", [&] {
+    for (auto &module : program.modules()) {
+      toolchain.compiler().compileModule(module->getModule(),
+                                         toolchain.targetMachine());
+    }
+  });
+  compileMutants.execute();
+
+  return 0;
+}


### PR DESCRIPTION
Closes #451.

Adds a new target to test mutators:

```
mutator-validator <mutator> <path to bitcode file>
```