### PR TITLE
Reporters: extract SourceManager to a separate class

### DIFF
--- a/include/mull/Reporters/SourceManager.h
+++ b/include/mull/Reporters/SourceManager.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "mull/SourceLocation.h"
+
+#include <map>
+#include <utility>
+#include <vector>
+
+namespace mull {
+
+struct LineOffset {
+  FILE *file;
+  std::vector<uint32_t> offsets;
+  LineOffset(FILE *file, std::vector<uint32_t> offsets)
+      : file(file), offsets(std::move(offsets)) {}
+};
+
+class SourceManager {
+public:
+  std::string getLine(const SourceLocation &location);
+
+  ~SourceManager();
+
+private:
+  std::map<std::string, LineOffset> lineOffsets;
+
+  LineOffset &getLineOffset(const SourceLocation &location);
+};
+
+} // namespace mull

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -54,6 +54,7 @@ set(mull_sources
 
   JunkDetection/CXX/CXXJunkDetector.cpp
 
+  Reporters/SourceManager.cpp
   Reporters/SQLiteReporter.cpp
   Reporters/TimeReporter.cpp
   SourceLocation.cpp

--- a/lib/Reporters/SourceManager.cpp
+++ b/lib/Reporters/SourceManager.cpp
@@ -1,0 +1,51 @@
+#include "mull/Reporters/SourceManager.h"
+
+#include <cassert>
+
+using namespace mull;
+
+SourceManager::~SourceManager() {
+  for (auto &pair : lineOffsets) {
+    fclose(pair.second.file);
+  }
+}
+
+std::string SourceManager::getLine(const SourceLocation &location) {
+  LineOffset &lineOffset = getLineOffset(location);
+  assert(location.line < lineOffset.offsets.size());
+
+  uint32_t lineBegin = lineOffset.offsets[location.line - 1];
+  uint32_t lineEnd = lineOffset.offsets[location.line];
+  uint32_t lineLength = lineEnd - lineBegin;
+  fseek(lineOffset.file, lineBegin, SEEK_SET);
+  char *buffer = new char[lineLength + 1];
+  fread(buffer, sizeof(char), lineLength, lineOffset.file);
+  buffer[lineLength] = '\0';
+  auto line = std::string(buffer);
+  free(buffer);
+  return line;
+}
+
+LineOffset &SourceManager::getLineOffset(const SourceLocation &location) {
+  if (lineOffsets.count(location.filePath)) {
+    return lineOffsets.at(location.filePath);
+  }
+
+  FILE *file = fopen(location.filePath.c_str(), "rb");
+  if (!file) {
+    perror("SourceManager");
+  }
+  std::vector<uint32_t> offsets;
+  uint32_t offset = 0;
+  char c = '\n';
+  for (; c != EOF; c = fgetc(file), offset++) {
+    if (c == '\n') {
+      offsets.push_back(offset);
+    }
+  }
+
+  LineOffset lineOffset(file, offsets);
+  auto inserted =
+      lineOffsets.insert(std::make_pair(location.filePath, lineOffset));
+  return inserted.first->second;
+}


### PR DESCRIPTION
As requested in #517 [here](https://github.com/mull-project/mull/pull/517#discussion_r289600262), I am sending this changeset with a separate merge request.

No changes are involved, the code is simply moved to the separate header/source files.