### PR TITLE
WIP: Possible Bug Report: the LLVM Modules and Instructions content gets corrupted before mull finishes execution

### DIFF
--- a/include/mull/JunkDetection/CXX/CXXJunkDetector.h
+++ b/include/mull/JunkDetection/CXX/CXXJunkDetector.h
@@ -10,13 +10,13 @@ struct JunkDetectionConfig;
 
 class CXXJunkDetector : public JunkDetector {
 public:
-  explicit CXXJunkDetector(JunkDetectionConfig &config);
+  explicit CXXJunkDetector(ASTStorage &astStorage);
   ~CXXJunkDetector() override = default;
 
   bool isJunk(MutationPoint *point) override;
 
 private:
-  ASTStorage astStorage;
+  ASTStorage &astStorage;
 };
 
 } // namespace mull

--- a/lib/JunkDetection/CXX/ASTStorage.cpp
+++ b/lib/JunkDetection/CXX/ASTStorage.cpp
@@ -96,7 +96,13 @@ ThreadSafeASTUnit *ASTStorage::findAST(const MutationPoint *point) {
   assert(point);
   assert(!point->getSourceLocation().isNull() && "Missing debug information?");
 
+  errs() << "mutation point: " << point << "\n";
+
   auto instruction = dyn_cast<Instruction>(point->getOriginalValue());
+  assert(
+    instruction &&
+    "Expected instruction to still be available at this point of execution");
+
   if (instruction == nullptr) {
     return nullptr;
   }

--- a/lib/JunkDetection/CXX/CXXJunkDetector.cpp
+++ b/lib/JunkDetection/CXX/CXXJunkDetector.cpp
@@ -34,9 +34,8 @@ static bool isJunkMutation(ASTStorage &storage, MutationPoint *point) {
   return !visitor.foundMutant();
 }
 
-CXXJunkDetector::CXXJunkDetector(JunkDetectionConfig &config)
-    : astStorage(config.cxxCompilationDatabasePath,
-                 config.cxxCompilationFlags) {}
+CXXJunkDetector::CXXJunkDetector(ASTStorage &astStorage)
+    : astStorage(astStorage) {}
 
 bool CXXJunkDetector::isJunk(MutationPoint *point) {
   if (point->getSourceLocation().isNull()) {

--- a/tools/driver-cxx/driver-cxx.cpp
+++ b/tools/driver-cxx/driver-cxx.cpp
@@ -272,7 +272,10 @@ int main(int argc, char **argv) {
         CompilationDatabasePath.getValue();
     configuration.junkDetectionEnabled = true;
   }
-  mull::CXXJunkDetector junkDetector(junkDetectionConfig);
+
+  mull::ASTStorage astStorage(junkDetectionConfig.cxxCompilationDatabasePath,
+                              junkDetectionConfig.cxxCompilationFlags);
+  mull::CXXJunkDetector junkDetector(astStorage);
 
   mull::Filter filter;
   mull::MutationsFinder mutationsFinder(mutatorsOptions.mutators(),
@@ -292,6 +295,12 @@ int main(int argc, char **argv) {
 
   mull::IDEReporter ideReporter;
   ideReporter.reportResults(*result, rawConfig, metrics);
+
+  for (mull::MutationPoint *mutationPoint: result->getMutationPoints()) {
+    mull::ThreadSafeASTUnit *astUnit = astStorage.findAST(mutationPoint);
+    assert(astUnit);
+  }
+
   llvm::llvm_shutdown();
 
   totalExecutionTime.finish();


### PR DESCRIPTION
In order to proceed with finishing the work on Mutation Testing Elements support,
we need to make sure that MutationTestingElementsReporter can have access to
original LLVM Module/Instructions content that is used for generating mutation
points.

This small changeset on top of the latest master branch shows that by the
time we want to call the MutationTestingElements to generate the JSON report,
the LLVM Module/Instruction content gets corrupted.

The example demonstrates that the critical asserts of this changeset are hit
instead of going further. It is important that at the moment the Junk Detection
is run, the same mutation points works inside findAST() method, but then
it hits the assert when the findAST() is called later in the end of the driver-cxx.

This is a minimal example that reproduces the issue found during this work:

WIP: Reporting JSON to Mutation Testing Elements #517,
https://github.com/mull-project/mull/pull/517

[skip ci]