### PR TITLE
Include build date into the version info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - Fix incorrect handling of the NSW/NUW flags #540
  - Bring back abandoned sandbox approach #541, #542
  - Add LLVM 9 support #544
+ - Include build date into the version info #546
 
 ## [0.3.0] - 02 Jun 2019
 

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -5,6 +5,13 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
+execute_process(
+  COMMAND date "+%d %b %Y"
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE BUILD_DATE
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
 configure_file (
   ${CMAKE_SOURCE_DIR}/lib/Version.cpp
   ${CMAKE_BINARY_DIR}/lib/Version.cpp

--- a/include/mull/Version.h
+++ b/include/mull/Version.h
@@ -10,6 +10,7 @@ const char *mullVersionString();
 const char *mullCommitString();
 const char *mullDescriptionString();
 const char *mullHomepageString();
+const char *mullBuildDateString();
 
 const char *llvmVersionString();
 

--- a/lib/Version.cpp
+++ b/lib/Version.cpp
@@ -6,6 +6,7 @@ namespace mull {
 
 const char *mullVersionString() { return "@PROJECT_VERSION@"; }
 const char *mullCommitString() { return "@GIT_COMMIT@"; }
+const char *mullBuildDateString() { return "@BUILD_DATE@"; }
 const char *mullDescriptionString() { return "@PROJECT_DESCRIPTION@"; }
 const char *mullHomepageString() { return "@PROJECT_HOMEPAGE_URL@"; }
 
@@ -18,6 +19,7 @@ void printVersionInformationStream(llvm::raw_ostream &out) {
   out << mullHomepageString() << "\n";
   out << "Version: " << mullVersionString() << "\n";
   out << "Commit: " << mullCommitString() << "\n";
+  out << "Date: " << mullBuildDateString() << "\n";
   out << "LLVM: " << llvmVersionString() << "\n";
 }
 


### PR DESCRIPTION
Example:
```
> mull-cxx --version
Mull: LLVM-based mutation testing
https://github.com/mull-project/mull
Version: 0.3.0
Commit: e190672
Date: 08 Aug 2019
LLVM: 8.0.0
```