### PR TITLE
Junk Detection for ReplaceAssignment mutator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - Introduce `-exclude-path` option to filter mutations #553
  - Enable reporters configuration via `-reporters` option #555
  - Junk detection for the Scalar Value mutator #557
+ - Junk detection for the Replace Assignment mutator #559
 
 ## [0.4.0] - 11 Aug 2019
 

--- a/include/mull/JunkDetection/CXX/Visitors/ReplaceAssignmentVisitor.h
+++ b/include/mull/JunkDetection/CXX/Visitors/ReplaceAssignmentVisitor.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "InstructionRangeVisitor.h"
+#include "VisitorParameters.h"
+
+#include <clang/AST/RecursiveASTVisitor.h>
+
+namespace mull {
+
+class ReplaceAssignmentVisitor : public clang::RecursiveASTVisitor<ReplaceAssignmentVisitor> {
+public:
+  ReplaceAssignmentVisitor(const VisitorParameters &parameters);
+
+  bool VisitBinAssign(clang::BinaryOperator *binaryOperator);
+  clang::Expr *foundMutant();
+
+private:
+  InstructionRangeVisitor visitor;
+};
+
+} // namespace mull

--- a/include/mull/Mutators/Mutator.h
+++ b/include/mull/Mutators/Mutator.h
@@ -29,6 +29,7 @@ enum class MutatorKind {
   ReplaceCallMutator,
   AndOrReplacementMutator,
   ScalarValueMutator,
+  ReplaceAssignmentMutator,
 };
 
 class Mutator {

--- a/include/mull/Mutators/ReplaceAssignmentMutator.h
+++ b/include/mull/Mutators/ReplaceAssignmentMutator.h
@@ -18,6 +18,9 @@ public:
   std::string getUniqueIdentifier() override { return ID; }
   std::string getUniqueIdentifier() const override { return ID; }
   std::string getDescription() const override { return description; }
+  MutatorKind mutatorKind() override {
+    return MutatorKind::ReplaceAssignmentMutator;
+  }
 
   void applyMutation(llvm::Function *function,
                      const MutationPointAddress &address) override;

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -89,6 +89,7 @@ set(mull_sources
   JunkDetection/CXX/Visitors/NegateConditionVisitor.cpp
   JunkDetection/CXX/Visitors/RemoveVoidFunctionVisitor.cpp
   JunkDetection/CXX/Visitors/ReplaceCallVisitor.cpp
+  JunkDetection/CXX/Visitors/ReplaceAssignmentVisitor.cpp
   JunkDetection/CXX/ASTStorage.cpp
   JunkDetection/CXX/CompilationDatabase.cpp
 

--- a/lib/JunkDetection/CXX/CXXJunkDetector.cpp
+++ b/lib/JunkDetection/CXX/CXXJunkDetector.cpp
@@ -12,6 +12,7 @@
 #include "mull/JunkDetection/CXX/Visitors/MathSubVisitor.h"
 #include "mull/JunkDetection/CXX/Visitors/NegateConditionVisitor.h"
 #include "mull/JunkDetection/CXX/Visitors/RemoveVoidFunctionVisitor.h"
+#include "mull/JunkDetection/CXX/Visitors/ReplaceAssignmentVisitor.h"
 #include "mull/JunkDetection/CXX/Visitors/ReplaceCallVisitor.h"
 #include "mull/JunkDetection/CXX/Visitors/ScalarValueVisitor.h"
 
@@ -69,6 +70,8 @@ bool CXXJunkDetector::isJunk(MutationPoint *point) {
     return isJunkMutation<AndOrReplacementVisitor>(astStorage, point);
   case MutatorKind::ScalarValueMutator:
     return isJunkMutation<ScalarValueVisitor>(astStorage, point);
+  case MutatorKind::ReplaceAssignmentMutator:
+    return isJunkMutation<ReplaceAssignmentVisitor>(astStorage, point);
   default:
     return false;
   }

--- a/lib/JunkDetection/CXX/Visitors/ReplaceAssignmentVisitor.cpp
+++ b/lib/JunkDetection/CXX/Visitors/ReplaceAssignmentVisitor.cpp
@@ -1,0 +1,15 @@
+#include "mull/JunkDetection/CXX/Visitors/ReplaceAssignmentVisitor.h"
+
+using namespace mull;
+
+ReplaceAssignmentVisitor::ReplaceAssignmentVisitor(const VisitorParameters &parameters)
+    : visitor(parameters) {}
+
+bool ReplaceAssignmentVisitor::VisitBinAssign(clang::BinaryOperator *binaryOperator) {
+  visitor.visitRangeWithASTExpr(binaryOperator);
+  return true;
+}
+
+clang::Expr *ReplaceAssignmentVisitor::foundMutant() {
+  return visitor.getMatchingASTNode();
+}

--- a/tests/fixtures/mutators/replace_assignment/CMakeLists.txt
+++ b/tests/fixtures/mutators/replace_assignment/CMakeLists.txt
@@ -4,3 +4,14 @@ compile_fixture(
   FLAGS -g -c -emit-llvm
 )
 
+compile_fixture(
+  INPUT ${CMAKE_CURRENT_LIST_DIR}/junk.cpp
+  OUTPUT_EXTENSION bc
+  FLAGS -g -c -emit-llvm
+)
+
+compile_fixture(
+  INPUT ${CMAKE_CURRENT_LIST_DIR}/junk.cpp
+  OUTPUT_EXTENSION ll
+  FLAGS -g -c -S -emit-llvm
+)

--- a/tests/fixtures/mutators/replace_assignment/junk.cpp
+++ b/tests/fixtures/mutators/replace_assignment/junk.cpp
@@ -1,0 +1,44 @@
+struct point {
+  int x;
+  int y;
+};
+
+extern int externIntegerCall();
+extern double externDoubleCall();
+extern float externFloatCall();
+
+extern char *externCharPtrCall();
+
+extern int externInteger;
+extern double externDouble;
+extern float externFloat;
+
+void test1() {
+  auto t1 = externIntegerCall();
+  auto t2 = externDoubleCall();
+  auto t3 = externFloatCall();
+  auto t4 = externCharPtrCall();
+}
+
+void test2() {
+  int t1;
+  t1 = externInteger;
+  double t2;
+  t2 = externDoubleCall();
+  float t3;
+  t3 = externFloat;
+  char *t4;
+  t4 = externCharPtrCall();
+}
+
+void test3() {
+  point p;
+  p.x = externInteger;
+  p.y = externIntegerCall();
+}
+
+void test4() {
+  auto t1(externInteger);
+  auto t2(externFloatCall());
+  auto t3(externDouble);
+}


### PR DESCRIPTION
It is important to understand that the Replace Assignment covers only
the following case:

```
int x = 0;  // <-- ignored
x = 31;     // <-- mutated
```

The line `int x = 0` is equivalent to the `int x(0)` which is in fact
a declaration, and not an assignment.

Fixes #482.