### PR TITLE
Speed up junk detection

### DIFF
--- a/include/mull/JunkDetection/CXX/ASTStorage.h
+++ b/include/mull/JunkDetection/CXX/ASTStorage.h
@@ -7,6 +7,7 @@
 #include <map>
 #include <mutex>
 #include <string>
+#include <vector>
 
 namespace mull {
 
@@ -22,12 +23,17 @@ public:
   clang::SourceLocation getLocation(MutationPoint *point);
   bool isInSystemHeader(clang::SourceLocation &location);
 
+  clang::Decl *getDecl(clang::SourceLocation &location);
+
 private:
+  void recordDeclarations();
+
   const clang::FileEntry *findFileEntry(const MutationPoint *point);
   const clang::FileEntry *findFileEntry(const std::string &filePath);
 
   std::unique_ptr<clang::ASTUnit> ast;
   std::mutex mutex;
+  std::vector<clang::Decl *> decls;
 };
 
 class ASTStorage {

--- a/lib/JunkDetection/CXX/ASTStorage.cpp
+++ b/lib/JunkDetection/CXX/ASTStorage.cpp
@@ -3,17 +3,53 @@
 #include "mull/Logger.h"
 #include "mull/MutationPoint.h"
 
+#include <clang/AST/RecursiveASTVisitor.h>
 #include <clang/Frontend/CompilerInstance.h>
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/Path.h>
-
 #include <sstream>
 
 using namespace mull;
 using namespace llvm;
 
+class DeclVisitor : public clang::RecursiveASTVisitor<DeclVisitor> {
+
+public:
+  DeclVisitor(clang::SourceManager &sourceManager,
+              std::vector<clang::Decl *> &decls)
+      : sourceManager(sourceManager), declarations(decls) {}
+
+  bool VisitFunctionTemplateDecl(clang::FunctionTemplateDecl *decl) {
+    addDecl(decl);
+    return true;
+  }
+
+  bool VisitFunctionDecl(clang::FunctionDecl *decl) {
+    addDecl(decl);
+    return true;
+  }
+
+private:
+  void addDecl(clang::Decl *decl) {
+    if (!decl->hasBody()) {
+      return;
+    }
+    if (sourceManager.isInSystemHeader(decl->getSourceRange().getBegin())) {
+      return;
+    }
+    declarations.push_back(decl);
+  }
+
+  clang::SourceManager &sourceManager;
+  std::vector<clang::Decl *> &declarations;
+};
+
 ThreadSafeASTUnit::ThreadSafeASTUnit(clang::ASTUnit *ast)
-    : ast(std::unique_ptr<clang::ASTUnit>(ast)) {}
+    : ast(std::unique_ptr<clang::ASTUnit>(ast)) {
+  if (this->ast) {
+    recordDeclarations();
+  }
+}
 
 clang::SourceManager &ThreadSafeASTUnit::getSourceManager() {
   return ast->getSourceManager();
@@ -74,6 +110,72 @@ clang::SourceLocation ThreadSafeASTUnit::getLocation(MutationPoint *point) {
       ast->getLocation(file, mutantLocation.line, mutantLocation.column);
   assert(location.isValid());
   return location;
+}
+
+struct SortLocationComparator {
+  explicit SortLocationComparator(clang::SourceManager &sourceManager)
+      : sourceManager(sourceManager), cmp(sourceManager) {}
+
+  bool operator()(const clang::Decl *lhs, const clang::Decl *rhs) const {
+    return cmp(lhs->getSourceRange().getBegin(),
+               rhs->getSourceRange().getBegin());
+  }
+
+  clang::SourceManager &sourceManager;
+  clang::BeforeThanCompare<clang::SourceLocation> cmp;
+};
+
+struct UniqueLocationComparator {
+  explicit UniqueLocationComparator(clang::SourceManager &sourceManager)
+      : sourceManager(sourceManager), cmp(sourceManager) {}
+
+  bool operator()(const clang::Decl *lhs, const clang::Decl *rhs) const {
+    return !cmp(lhs->getSourceRange().getEnd(),
+                rhs->getSourceRange().getBegin());
+  }
+
+  clang::SourceManager &sourceManager;
+  clang::BeforeThanCompare<clang::SourceLocation> cmp;
+};
+
+void ThreadSafeASTUnit::recordDeclarations() {
+  assert(ast);
+  clang::SourceManager &sourceManager = ast->getSourceManager();
+  DeclVisitor visitor(sourceManager, decls);
+  visitor.TraverseDecl(ast->getASTContext().getTranslationUnitDecl());
+
+  SortLocationComparator sortComparator(sourceManager);
+  std::sort(decls.begin(), decls.end(), sortComparator);
+
+  UniqueLocationComparator uniqueComparator(sourceManager);
+  auto last = std::unique(decls.begin(), decls.end(), uniqueComparator);
+  decls.erase(last, decls.end());
+}
+
+clang::Decl *ThreadSafeASTUnit::getDecl(clang::SourceLocation &location) {
+  if (decls.empty()) {
+    return nullptr;
+  }
+  std::lock_guard<std::mutex> lock(mutex);
+  clang::BeforeThanCompare<clang::SourceLocation> comparator(
+      ast->getSourceManager());
+
+  auto lower = std::lower_bound(
+      decls.begin(), decls.end(), location,
+      [&](const clang::Decl *decl, const clang::SourceLocation &loc) {
+        return comparator(decl->getSourceRange().getEnd(), loc);
+      });
+
+  if (lower == decls.end()) {
+    return nullptr;
+  }
+
+  if (comparator((*lower)->getSourceRange().getBegin(), location) &&
+      comparator(location, (*lower)->getSourceRange().getEnd())) {
+    return *lower;
+  }
+
+  return nullptr;
 }
 
 ASTStorage::ASTStorage(const std::string &cxxCompilationDatabasePath,

--- a/lib/JunkDetection/CXX/CXXJunkDetector.cpp
+++ b/lib/JunkDetection/CXX/CXXJunkDetector.cpp
@@ -24,11 +24,16 @@ static bool isJunkMutation(ASTStorage &storage, MutationPoint *point) {
     return true;
   }
 
+  clang::Decl *decl = ast->getDecl(location);
+  if (!decl) {
+    return true;
+  }
+
   VisitorParameters parameters = {.sourceManager = ast->getSourceManager(),
                                   .sourceLocation = location,
                                   .astContext = ast->getASTContext()};
   Visitor visitor(parameters);
-  visitor.TraverseDecl(ast->getASTContext().getTranslationUnitDecl());
+  visitor.TraverseDecl(decl);
 
   if (clang::Expr *mutantExpression = visitor.foundMutant()) {
     storage.setMutantASTNode(point, mutantExpression);

--- a/lib/Mutators/CXX/RelationalMutators.cpp
+++ b/lib/Mutators/CXX/RelationalMutators.cpp
@@ -92,7 +92,7 @@ EqualToNotEqual::EqualToNotEqual()
     : TrivialCXXMutator(std::move(getEqualToNotEqual()),
                         MutatorKind::CXX_Relation_EqualToNotEqual,
                         EqualToNotEqual::ID,
-                        "Replaces == with !=", "!=", "Replaced != with !=") {}
+                        "Replaces == with !=", "!=", "Replaced == with !=") {}
 
 const std::string NotEqualToEqual::ID = "cxx_relational_ne_to_eq";
 


### PR DESCRIPTION
Before this patch visitors traversed whole translation unit for each mutant,
within this patch, Mull traverses the only function that can potentially
contain the mutant.

---
On an example app I've got the following numbers (debug build):
Before:
 - junk detection: 72s
 - total: 108s
After:
 - junk detection: 4s
 - total: 40s


@stanislaw could you give it a try on your project and check is there is no regression?
I would also appreciate if you can share the numbers.