### PR TITLE
Apply only mutations that are not junk

### DIFF
--- a/include/mull/Bitcode.h
+++ b/include/mull/Bitcode.h
@@ -41,7 +41,6 @@ private:
   std::string uniqueIdentifier;
 
   std::map<llvm::Function *, std::vector<MutationPoint *>> mutationPoints;
-  std::mutex mutex;
 
   explicit Bitcode(std::unique_ptr<llvm::Module> module);
 };

--- a/lib/Bitcode.cpp
+++ b/lib/Bitcode.cpp
@@ -59,7 +59,6 @@ std::string Bitcode::getUniqueIdentifier() { return uniqueIdentifier; }
 std::string Bitcode::getUniqueIdentifier() const { return uniqueIdentifier; }
 
 void Bitcode::addMutation(MutationPoint *point) {
-  std::lock_guard<std::mutex> guard(mutex);
   auto function = point->getOriginalFunction();
   mutationPoints[function].push_back(point);
 }

--- a/lib/Driver.cpp
+++ b/lib/Driver.cpp
@@ -206,6 +206,13 @@ std::vector<std::unique_ptr<MutationResult>>
 Driver::normalRunMutations(const std::vector<MutationPoint *> &mutationPoints) {
   std::vector<std::string> mutatedFunctions;
 
+  SingleTaskExecutor prepareMutations("Prepare mutations", [&]() {
+    for (auto point : mutationPoints) {
+      point->getBitcode()->addMutation(point);
+    }
+  });
+  prepareMutations.execute();
+
   auto workers = config.parallelization.workers;
   TaskExecutor<CloneMutatedFunctionsTask> cloneFunctions(
       "Cloning functions for mutation", program.bitcode(), mutatedFunctions,

--- a/lib/Parallelization/Tasks/SearchMutationPointsTask.cpp
+++ b/lib/Parallelization/Tasks/SearchMutationPointsTask.cpp
@@ -45,7 +45,6 @@ operator()(iterator begin, iterator end,
     for (auto &mutator : mutators) {
       auto mutants = mutator->getMutations(bitcode, function);
       for (auto mutant : mutants) {
-        bitcode->addMutation(mutant);
         for (auto &reachableTest : testee.getReachableTests()) {
           mutant->addReachableTest(reachableTest.first, reachableTest.second);
         }

--- a/tests/TestRunnersTests.cpp
+++ b/tests/TestRunnersTests.cpp
@@ -67,7 +67,9 @@ TEST(NativeTestRunner, runTest) {
 
   std::vector<MutationPoint *> mutationPoints =
       mutationsFinder.getMutationPoints(program, mergedTestees, filter);
-
+  for (auto point : mutationPoints) {
+    point->getBitcode()->addMutation(point);
+  }
   MutationPoint *mutationPoint = mutationPoints.front();
 
   SimpleTestFinder testFinder;


### PR DESCRIPTION
This is how it works before the patch:

 - find all the mutations
 - put them into a bitcode file
 - apply each mutation added to the bitcode file

The problem is that whenever the mutation is considered as junk and
removed from the execution pipeline it is still applied as if it would
run.

The patch moves adding of mutants to the bitcode only after all the junk
is filtered out.

---

Numbers for 38k mutants only 19 of which are not filtered out:

Before: ~20 minutes

```
Cloning functions for mutation (threads: 4): 4/4. Finished in 1167456ms.
Removing original functions (threads: 4): 4/4. Finished in 32479ms.
```

After: ~100ms

```
Cloning functions for mutation (threads: 4): 4/4. Finished in 79ms.
Removing original functions (threads: 4): 4/4. Finished in 36ms.
```