### PR TITLE
Report warming when a symbol cannot be resolved by JIT engine

### DIFF
--- a/include/mull/Toolchain/JITEngine.h
+++ b/include/mull/Toolchain/JITEngine.h
@@ -5,18 +5,18 @@
 namespace mull {
 
 class JITEngine {
+public:
+  JITEngine();
+  void addObjectFiles(std::vector<llvm::object::ObjectFile *> &files,
+                      llvm_compat::SymbolResolver &resolver,
+                      std::unique_ptr<llvm::RuntimeDyld::MemoryManager> memoryManager);
+  llvm_compat::JITSymbol &getSymbol(llvm::StringRef name);
+
+private:
   std::vector<llvm::object::ObjectFile *> objectFiles;
   llvm::StringMap<llvm_compat::JITSymbol> symbolTable;
   llvm_compat::JITSymbol symbolNotFound;
   std::unique_ptr<llvm::RuntimeDyld::MemoryManager> memoryManager;
-
-public:
-  JITEngine();
-  void addObjectFiles(
-      std::vector<llvm::object::ObjectFile *> &files,
-      llvm_compat::SymbolResolver &resolver,
-      std::unique_ptr<llvm::RuntimeDyld::MemoryManager> memoryManager);
-  llvm_compat::JITSymbol &getSymbol(llvm::StringRef name);
 };
 
 } // namespace mull

--- a/lib/Toolchain/JITEngine.cpp
+++ b/lib/Toolchain/JITEngine.cpp
@@ -1,35 +1,41 @@
 #include "mull/Toolchain/JITEngine.h"
 
+#include <mull/Logger.h>
+#include <unordered_set>
+
 using namespace mull;
 using namespace llvm;
 
 JITEngine::JITEngine() : symbolNotFound(nullptr) {}
 
-void JITEngine::addObjectFiles(
-    std::vector<object::ObjectFile *> &files,
-    llvm_compat::SymbolResolver &resolver,
-    std::unique_ptr<llvm::RuntimeDyld::MemoryManager> memManager) {
+void JITEngine::addObjectFiles(std::vector<object::ObjectFile *> &files,
+                               llvm_compat::SymbolResolver &resolver,
+                               std::unique_ptr<llvm::RuntimeDyld::MemoryManager> memManager) {
   std::vector<object::ObjectFile *>().swap(objectFiles);
   llvm::StringMap<llvm_compat::JITSymbolInfo>().swap(symbolTable);
   memoryManager = std::move(memManager);
+
+  std::unordered_set<std::string> unresolvedSymbols;
 
   for (auto object : files) {
     objectFiles.push_back(object);
 
     for (auto symbol : object->symbols()) {
+      Expected<StringRef> nameOrError = symbol.getName();
+      if (!nameOrError) {
+        consumeError(nameOrError.takeError());
+        continue;
+      }
+      std::string name = nameOrError.get();
       if (symbol.getFlags() & object::SymbolRef::SF_Undefined) {
+        if (!(symbol.getFlags() & object::SymbolRef::SF_Weak)) {
+          unresolvedSymbols.insert(name);
+        }
         continue;
       }
-
-      Expected<StringRef> name = symbol.getName();
-      if (!name) {
-        consumeError(name.takeError());
-        continue;
-      }
-
+      unresolvedSymbols.erase(name);
       auto flags = llvm_compat::JITSymbolFlagsFromObjectSymbol(symbol);
-      symbolTable.insert(
-          std::make_pair(name.get(), llvm_compat::JITSymbol(0, flags)));
+      symbolTable.insert(std::make_pair(name, llvm_compat::JITSymbol(0, flags)));
     }
   }
 
@@ -45,6 +51,29 @@ void JITEngine::addObjectFiles(
   }
 
   dynamicLoader.finalizeWithMemoryManagerLocking();
+
+  auto it = unresolvedSymbols.begin();
+  while (it != unresolvedSymbols.end()) {
+    std::string name = *it;
+    auto dlSymbol = dynamicLoader.getSymbol(name);
+    if (dlSymbol.getAddress() != 0) {
+      it = unresolvedSymbols.erase(it);
+      continue;
+    }
+    auto resolverSymbol = llvm_compat::JITSymbol(resolver.findSymbol(name));
+    if (llvm_compat::JITSymbolAddress(resolverSymbol) != 0) {
+      it = unresolvedSymbols.erase(it);
+      continue;
+    }
+    ++it;
+  }
+
+  if (!unresolvedSymbols.empty()) {
+    Logger::error() << "\nJIT engine could not resolve the following symbols:\n";
+    for (const std::string &name : unresolvedSymbols) {
+      Logger::error() << name << "\n";
+    }
+  }
 }
 
 llvm_compat::JITSymbol &JITEngine::getSymbol(llvm::StringRef name) {


### PR DESCRIPTION
Historically it was handled by the underlying JIT components, but I think since LLVM 8.0 we should handle this ourselves.
Since this part was removed from the dynamic loader we were simply getting NULLs instead of some functions, which led to a crash.