### PR TITLE
Fix designator order in ReporterParameters initialization

### DIFF
--- a/tools/driver-cxx/driver-cxx.cpp
+++ b/tools/driver-cxx/driver-cxx.cpp
@@ -182,8 +182,8 @@ int main(int argc, char **argv) {
   metrics.endRun();
 
   tool::ReporterParameters params{
-    .reporterDirectory = tool::ReportDirectory.getValue(),
     .reporterName = tool::ReportName.getValue(),
+    .reporterDirectory = tool::ReportDirectory.getValue(),
     .sourceInfoProvider = sourceInfoProvider,
   };
   std::vector<std::unique_ptr<mull::Reporter>> reporters = reportersOption.reporters(params);


### PR DESCRIPTION
Without this building master fails with:
```
[ 98%] Building CXX object tools/driver-cxx/CMakeFiles/mull-cxx.dir/driver-cxx.cpp.o
mull/tools/driver-cxx/driver-cxx.cpp: In function ‘int main(int, char**)’:
mull/tools/driver-cxx/driver-cxx.cpp:188:3: error: member ‘tool::ReporterParameters::sourceInfoProvider’ is uninitialized reference
  188 |   };
      |   ^
mull/tools/driver-cxx/driver-cxx.cpp:188:3: error: designator order for field ‘tool::ReporterParameters::reporterName’ does not match declaration order in ‘tool::ReporterParameters’
```