### PR TITLE
Move AndOr mutations to the experimental group

### DIFF
--- a/docs/generated/CLIOptions.rst
+++ b/docs/generated/CLIOptions.rst
@@ -49,7 +49,7 @@
     Groups:
       :all:	cxx_all, experimental
 
-      :cxx_all:	cxx_assignment, cxx_increment, cxx_decrement, cxx_arithmetic, cxx_logical, cxx_comparison, cxx_boundary
+      :cxx_all:	cxx_assignment, cxx_increment, cxx_decrement, cxx_arithmetic, cxx_comparison, cxx_boundary
 
       :cxx_arithmetic:	cxx_minus_to_noop, cxx_add_to_sub, cxx_sub_to_add, cxx_mul_to_div, cxx_div_to_mul, cxx_rem_to_div
 
@@ -75,7 +75,7 @@
 
       :cxx_logical:	cxx_logical_and_to_or, cxx_logical_or_to_and
 
-      :experimental:	negate_mutator, remove_void_function_mutator, scalar_value_mutator, replace_call_mutator
+      :experimental:	negate_mutator, remove_void_function_mutator, scalar_value_mutator, replace_call_mutator, cxx_logical
 
     Single mutators:
       :cxx_add_assign_to_sub_assign:	Replaces += with -=

--- a/lib/Mutators/MutatorsFactory.cpp
+++ b/lib/Mutators/MutatorsFactory.cpp
@@ -125,8 +125,7 @@ MutatorsFactory::MutatorsFactory() {
   };
 
   groupsMapping[CXX_All] = {
-    CXX_Assignment, CXX_Increment,  CXX_Decrement, CXX_Arithmetic,
-    CXX_Logical,    CXX_Comparison, CXX_Boundary,
+    CXX_Assignment, CXX_Increment, CXX_Decrement, CXX_Arithmetic, CXX_Comparison, CXX_Boundary,
   };
 
   groupsMapping[CXX_Default] = {
@@ -136,12 +135,11 @@ MutatorsFactory::MutatorsFactory() {
     CXX_Boundary,
   };
 
-  groupsMapping[Experimental] = {
-    NegateConditionMutator::ID,
-    RemoveVoidFunctionMutator::ID,
-    ScalarValueMutator::ID,
-    ReplaceCallMutator::ID,
-  };
+  groupsMapping[Experimental] = { NegateConditionMutator::ID,
+                                  RemoveVoidFunctionMutator::ID,
+                                  ScalarValueMutator::ID,
+                                  ReplaceCallMutator::ID,
+                                  CXX_Logical };
   groupsMapping[AllMutatorsGroup] = { CXX_All, Experimental };
 }
 

--- a/tests/MutatorsFactoryTests.cpp
+++ b/tests/MutatorsFactoryTests.cpp
@@ -66,7 +66,7 @@ TEST(MutatorsFactory, CompositeMutators) {
 
   {
     mutators = factory.mutators({ "experimental" });
-    ASSERT_EQ(mutators.size(), 4UL);
+    ASSERT_EQ(mutators.size(), 6UL);
 
     searchResult = find_if(mutators.begin(), mutators.end(), predicate("replace_call_mutator"));
     ASSERT_NE(searchResult, mutators.end());


### PR DESCRIPTION
AndOr is not reliable at the moment.
Steps to reproduce: run them against `fmt` example.