### PR TITLE
IDEReporter: revert to iterating over result's mutation points

### DIFF
--- a/lib/Reporters/IDEReporter.cpp
+++ b/lib/Reporters/IDEReporter.cpp
@@ -76,17 +76,18 @@ void IDEReporter::reportResults(const Result &result, const Metrics &metrics) {
     }
   }
 
-  Logger::info() << "\nSurvived mutants (" << survivedMutantsCount << "/"
-                 << result.getMutationPoints().size() << "):\n\n";
-
-  for (auto &mutant : result.getMutationPoints()) {
-    if (killedMutants.find(mutant) == killedMutants.end()) {
-      printMutant(sourceManager, *mutant, true);
-    }
-  }
-
   if (survivedMutantsCount > 0) {
+    Logger::info() << "\nSurvived mutants (" << survivedMutantsCount << "/"
+                   << result.getMutationPoints().size() << "):\n\n";
+
+    for (auto &mutant : result.getMutationPoints()) {
+      if (killedMutants.find(mutant) == killedMutants.end()) {
+        printMutant(sourceManager, *mutant, true);
+      }
+    }
     Logger::info() << "\n";
+  } else {
+    Logger::info() << "\nAll mutations have been killed\n\n";
   }
 
   auto rawScore = double(killedMutants.size()) / double(result.getMutationPoints().size());

--- a/lib/Reporters/IDEReporter.cpp
+++ b/lib/Reporters/IDEReporter.cpp
@@ -7,7 +7,6 @@
 
 #include <map>
 #include <set>
-#include <string>
 #include <utility>
 
 using namespace mull;
@@ -70,8 +69,14 @@ void IDEReporter::reportSurvivedMutants(const Result &result, const Metrics &met
                  << result.getMutationPoints().size() << "):\n\n";
 
   SourceManager sourceManager;
-  for (auto &mutant : survivedMutants) {
-    printMutant(sourceManager, *mutant, true);
+
+  /// It is important that below we iterate over result.getMutationPoints()
+  /// because we want the output to be stable across multiple executions of Mull.
+  /// Optimizing this here was a bad idea: https://github.com/mull-project/mull/pull/640
+  for (auto &mutant : result.getMutationPoints()) {
+    if (survivedMutants.find(mutant) != survivedMutants.end()) {
+      printMutant(sourceManager, *mutant, true);
+    }
   }
   if (!survivedMutants.empty()) {
     Logger::info() << "\n";
@@ -110,15 +115,22 @@ void IDEReporter::reportAllMutants(const Result &result, const Metrics &metrics)
   Logger::info() << "\nKilled mutants (" << killedMutantsCount << "/"
                  << result.getMutationPoints().size() << "):\n\n";
 
-  for (auto &mutant : killedMutants) {
-    printMutant(sourceManager, *mutant, false);
+  /// It is important that below we iterate over result.getMutationPoints()
+  /// because we want the output to be stable across multiple executions of Mull.
+  /// Optimizing this here was a bad idea: https://github.com/mull-project/mull/pull/640.
+  for (auto &mutant : result.getMutationPoints()) {
+    if (killedMutants.find(mutant) != killedMutants.end()) {
+      printMutant(sourceManager, *mutant, false);
+    }
   }
 
   Logger::info() << "\nSurvived mutants (" << survivedMutantsCount << "/"
                  << result.getMutationPoints().size() << "):\n\n";
 
-  for (auto &mutant : survivedMutants) {
-    printMutant(sourceManager, *mutant, true);
+  for (auto &mutant : result.getMutationPoints()) {
+    if (survivedMutants.find(mutant) != survivedMutants.end()) {
+      printMutant(sourceManager, *mutant, true);
+    }
   }
   if (!survivedMutants.empty()) {
     Logger::info() << "\n";

--- a/lib/Reporters/IDEReporter.cpp
+++ b/lib/Reporters/IDEReporter.cpp
@@ -42,68 +42,18 @@ static void printMutant(SourceManager &sourceManager, const MutationPoint &mutan
 IDEReporter::IDEReporter(bool showKilled) : showKilled(showKilled) {}
 
 void IDEReporter::reportResults(const Result &result, const Metrics &metrics) {
-  if (showKilled) {
-    reportAllMutants(result, metrics);
-  } else {
-    reportSurvivedMutants(result, metrics);
-  }
-}
-
-void IDEReporter::reportSurvivedMutants(const Result &result, const Metrics &metrics) {
-  if (result.getMutationPoints().empty()) {
-    Logger::info() << "No mutants found. Mutation score: infinitely high\n";
-    return;
-  }
-
-  std::set<MutationPoint *> survivedMutants;
-  for (auto &mutationResult : result.getMutationResults()) {
-    auto mutant = mutationResult->getMutationPoint();
-    auto &executionResult = mutationResult->getExecutionResult();
-
-    if (mutantSurvived(executionResult.status)) {
-      survivedMutants.insert(mutant);
-    }
-  }
-
-  Logger::info() << "\nSurvived mutants (" << survivedMutants.size() << "/"
-                 << result.getMutationPoints().size() << "):\n\n";
-
-  SourceManager sourceManager;
-
-  /// It is important that below we iterate over result.getMutationPoints()
-  /// because we want the output to be stable across multiple executions of Mull.
-  /// Optimizing this here was a bad idea: https://github.com/mull-project/mull/pull/640
-  for (auto &mutant : result.getMutationPoints()) {
-    if (survivedMutants.find(mutant) != survivedMutants.end()) {
-      printMutant(sourceManager, *mutant, true);
-    }
-  }
-  if (!survivedMutants.empty()) {
-    Logger::info() << "\n";
-  }
-
-  size_t killedMutantsCount = result.getMutationPoints().size() - survivedMutants.size();
-  auto rawScore = double(killedMutantsCount) / double(result.getMutationPoints().size());
-  auto score = uint(rawScore * 100);
-  Logger::info() << "Mutation score: " << score << "%\n";
-}
-
-void IDEReporter::reportAllMutants(const Result &result, const Metrics &metrics) {
   if (result.getMutationPoints().empty()) {
     Logger::info() << "No mutants found. Mutation score: infinitely high\n";
     return;
   }
 
   std::set<MutationPoint *> killedMutants;
-  std::set<MutationPoint *> survivedMutants;
   for (auto &mutationResult : result.getMutationResults()) {
     auto mutant = mutationResult->getMutationPoint();
     auto &executionResult = mutationResult->getExecutionResult();
 
     if (!mutantSurvived(executionResult.status)) {
       killedMutants.insert(mutant);
-    } else {
-      survivedMutants.insert(mutant);
     }
   }
 
@@ -112,15 +62,17 @@ void IDEReporter::reportAllMutants(const Result &result, const Metrics &metrics)
 
   SourceManager sourceManager;
 
-  Logger::info() << "\nKilled mutants (" << killedMutantsCount << "/"
-                 << result.getMutationPoints().size() << "):\n\n";
-
   /// It is important that below we iterate over result.getMutationPoints()
   /// because we want the output to be stable across multiple executions of Mull.
   /// Optimizing this here was a bad idea: https://github.com/mull-project/mull/pull/640.
-  for (auto &mutant : result.getMutationPoints()) {
-    if (killedMutants.find(mutant) != killedMutants.end()) {
-      printMutant(sourceManager, *mutant, false);
+  if (showKilled && killedMutantsCount > 0) {
+    Logger::info() << "\nKilled mutants (" << killedMutantsCount << "/"
+                   << result.getMutationPoints().size() << "):\n\n";
+
+    for (auto &mutant : result.getMutationPoints()) {
+      if (killedMutants.find(mutant) != killedMutants.end()) {
+        printMutant(sourceManager, *mutant, false);
+      }
     }
   }
 
@@ -128,11 +80,12 @@ void IDEReporter::reportAllMutants(const Result &result, const Metrics &metrics)
                  << result.getMutationPoints().size() << "):\n\n";
 
   for (auto &mutant : result.getMutationPoints()) {
-    if (survivedMutants.find(mutant) != survivedMutants.end()) {
+    if (killedMutants.find(mutant) == killedMutants.end()) {
       printMutant(sourceManager, *mutant, true);
     }
   }
-  if (!survivedMutants.empty()) {
+
+  if (survivedMutantsCount > 0) {
     Logger::info() << "\n";
   }
 

--- a/tests-lit/tests/mutations/math/cxx_add_to_sub/02_basic/sample.cpp
+++ b/tests-lit/tests/mutations/math/cxx_add_to_sub/02_basic/sample.cpp
@@ -4,7 +4,7 @@
 ; RUN: %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE %s.exe | %FILECHECK_EXEC %s
 ; CHECK: Running mutants (threads: 1): 1/1
 ; CHECK-EMPTY:
-; CHECK: Survived mutants (0/1):
+; CHECK:All mutations have been killed
 ; CHECK-EMPTY:
 ; CHECK: Mutation score: 100%
 ; CHECK-EMPTY:

--- a/tests-lit/tests/options/-ide-reporter-show-killed/01_one_killed/sample.cpp
+++ b/tests-lit/tests/options/-ide-reporter-show-killed/01_one_killed/sample.cpp
@@ -1,0 +1,40 @@
+/**
+; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
+; RUN: cd %CURRENT_DIR
+
+/// IDEReporter is enabled by default. So we test both invocations of mull-cxx:
+/// 1) when -reporters=IDE is not provided
+/// 2) when -reporters=IDE is provided
+
+; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
+; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
+; WITHOUT-OPTION:{{^Running mutants \(threads: 1\): 1\/1.*$}}
+; WITHOUT-OPTION-EMPTY:
+; WITHOUT-OPTION-NEXT:All mutations have been killed
+; WITHOUT-OPTION-EMPTY:
+; WITHOUT-OPTION-NEXT:Mutation score: 100%
+; WITHOUT-OPTION-EMPTY:
+
+; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
+; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
+; WITH-OPTION:{{^Running mutants \(threads: 1\): 1\/1.*$}}
+; WITH-OPTION:Killed mutants (1/1):
+; WITH-OPTION-EMPTY:
+; WITH-OPTION-NEXT:{{^.*}}sample.cpp:34:18: warning: Killed: Replaced + with -
+; WITH-OPTION-NEXT:  int result = a + b;
+; WITH-OPTION-NEXT:                 ^
+; WITH-OPTION-EMPTY:
+; WITH-OPTION-NEXT:All mutations have been killed
+; WITH-OPTION-EMPTY:
+; WITH-OPTION-NEXT:Mutation score: 100%
+; WITH-OPTION-EMPTY:
+*/
+
+int sum(int a, int b) {
+  int result = a + b;
+  return result;
+}
+
+int main() {
+  return sum(-2, 2);
+}

--- a/tests-lit/tests/options/-ide-reporter-show-killed/02_one_survived/sample.cpp
+++ b/tests-lit/tests/options/-ide-reporter-show-killed/02_one_survived/sample.cpp
@@ -8,40 +8,36 @@
 
 ; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
 ; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
-; WITHOUT-OPTION:{{^Running mutants \(threads: 2\): 2\/2.*$}}
-; WITHOUT-OPTION:Survived mutants (1/2):
+; WITHOUT-OPTION:{{^Running mutants \(threads: 1\): 1\/1.*$}}
 ; WITHOUT-OPTION-EMPTY:
-; WITHOUT-OPTION-NEXT:{{^.*}}sample.cpp:41:19: warning: Survived: Replaced + with -{{$}}
-; WITHOUT-OPTION-NEXT:  result = result + 0;
-; WITHOUT-OPTION-NEXT:                  ^
+; WITHOUT-OPTION:Survived mutants (1/1):
 ; WITHOUT-OPTION-EMPTY:
-; WITHOUT-OPTION-NEXT:Mutation score: 50%
+; WITHOUT-OPTION-NEXT:{{^.*}}sample.cpp:37:18: warning: Survived: Replaced + with -
+; WITHOUT-OPTION-NEXT:  int result = a + b;
+; WITHOUT-OPTION-NEXT:                 ^
+; WITHOUT-OPTION-EMPTY:
+; WITHOUT-OPTION-NEXT:Mutation score: 0%
 ; WITHOUT-OPTION-EMPTY:
 
 ; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
 ; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
-; WITH-OPTION:{{^Running mutants \(threads: 2\): 2\/2.*$}}
-; WITH-OPTION:Killed mutants (1/2):
+; WITH-OPTION:{{^Running mutants \(threads: 1\): 1\/1.*$}}
 ; WITH-OPTION-EMPTY:
-; WITH-OPTION-NEXT:{{^.*}}sample.cpp:40:18: warning: Killed: Replaced + with -
+; WITH-OPTION:Survived mutants (1/1):
+; WITH-OPTION-EMPTY:
+; WITH-OPTION-NEXT:{{^.*}}sample.cpp:37:18: warning: Survived: Replaced + with -
 ; WITH-OPTION-NEXT:  int result = a + b;
 ; WITH-OPTION-NEXT:                 ^
 ; WITH-OPTION-EMPTY:
-; WITH-OPTION-NEXT:Survived mutants (1/2):
+; WITH-OPTION-NEXT:Mutation score: 0%
 ; WITH-OPTION-EMPTY:
-; WITH-OPTION-NEXT:{{^.*}}sample.cpp:41:19: warning: Survived: Replaced + with -
-; WITH-OPTION-NEXT:  result = result + 0;
-; WITH-OPTION-NEXT:                  ^
-; WITH-OPTION-EMPTY:
-; WITH-OPTION-NEXT:Mutation score: 50%
 */
 
 int sum(int a, int b) {
   int result = a + b;
-  result = result + 0;
   return result;
 }
 
 int main() {
-  return sum(-2, 2);
+  return sum(2, 0) != 2;
 }

--- a/tests-lit/tests/options/-ide-reporter-show-killed/03_one_surviving_one_killed/sample.cpp
+++ b/tests-lit/tests/options/-ide-reporter-show-killed/03_one_surviving_one_killed/sample.cpp
@@ -1,0 +1,48 @@
+/**
+; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
+; RUN: cd %CURRENT_DIR
+
+/// IDEReporter is enabled by default. So we test both invocations of mull-cxx:
+/// 1) when -reporters=IDE is not provided
+/// 2) when -reporters=IDE is provided
+
+; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
+; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
+; WITHOUT-OPTION:{{^Running mutants \(threads: 2\): 2\/2.*$}}
+; WITHOUT-OPTION:Survived mutants (1/2):
+; WITHOUT-OPTION-EMPTY:
+; WITHOUT-OPTION-NEXT:{{^.*}}sample.cpp:42:19: warning: Survived: Replaced + with -{{$}}
+; WITHOUT-OPTION-NEXT:  result = result + 0;
+; WITHOUT-OPTION-NEXT:                  ^
+; WITHOUT-OPTION-EMPTY:
+; WITHOUT-OPTION-NEXT:Mutation score: 50%
+; WITHOUT-OPTION-EMPTY:
+
+; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
+; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
+; WITH-OPTION:{{^Running mutants \(threads: 2\): 2\/2.*$}}
+; WITH-OPTION:Killed mutants (1/2):
+; WITH-OPTION-EMPTY:
+; WITH-OPTION-NEXT:{{^.*}}sample.cpp:41:18: warning: Killed: Replaced + with -
+; WITH-OPTION-NEXT:  int result = a + b;
+; WITH-OPTION-NEXT:                 ^
+; WITH-OPTION-EMPTY:
+; WITH-OPTION-NEXT:Survived mutants (1/2):
+; WITH-OPTION-EMPTY:
+; WITH-OPTION-NEXT:{{^.*}}sample.cpp:42:19: warning: Survived: Replaced + with -
+; WITH-OPTION-NEXT:  result = result + 0;
+; WITH-OPTION-NEXT:                  ^
+; WITH-OPTION-EMPTY:
+; WITH-OPTION-NEXT:Mutation score: 50%
+; WITH-OPTION-EMPTY:
+*/
+
+int sum(int a, int b) {
+  int result = a + b;
+  result = result + 0;
+  return result;
+}
+
+int main() {
+  return sum(-2, 2);
+}


### PR DESCRIPTION
It is important that we iterate over result.getMutationPoints() because we want
the output to be stable across multiple executions of Mull.

Optimizing this here was a bad idea: https://github.com/mull-project/mull/pull/640.