### PR TITLE
Strict mode: warning messages are treated as fatal errors 

### DIFF
--- a/docs/generated/CLIOptions.rst
+++ b/docs/generated/CLIOptions.rst
@@ -22,6 +22,8 @@
 
 --debug		Enables Debug Mode: more logs are printed
 
+--strict		Enables Strict Mode: all warning messages are treated as fatal errors
+
 --compdb-path filename		Path to a compilation database (compile_commands.json) for junk detection
 
 --compilation-flags string		Extra compilation flags for junk detection

--- a/include/mull/Diagnostics/Diagnostics.h
+++ b/include/mull/Diagnostics/Diagnostics.h
@@ -13,6 +13,7 @@ public:
   ~Diagnostics();
 
   void enableDebugMode();
+  void enableStrictMode();
 
   void info(const std::string& message);
   void warning(const std::string& message);
@@ -27,6 +28,7 @@ private:
   std::mutex mutex;
   bool seenProgress;
   bool debugModeEnabled;
+  bool strictModeEnabled;
 };
 
 }

--- a/tests-lit/tests/options/-debug/01-debug-option/sample.cpp
+++ b/tests-lit/tests/options/-debug/01-debug-option/sample.cpp
@@ -15,6 +15,6 @@ int main() {
 ; WITHOUT-DEBUG-NOT:{{^.*\[debug\].*$}}
 ; WITHOUT-DEBUG:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced + with - [cxx_add_to_sub]{{$}}
 
-; WITH-DEBUG:[debug] Diagnostics: debug mode enabled
+; WITH-DEBUG:[debug] Diagnostics: Debug Mode enabled. Debug-level messages will be printed.
 ; WITH-DEBUG:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced + with - [cxx_add_to_sub]{{$}}
 **/

--- a/tests-lit/tests/options/-strict/01-strict-mode/sample.cpp
+++ b/tests-lit/tests/options/-strict/01-strict-mode/sample.cpp
@@ -1,0 +1,18 @@
+int main() {
+  return 0;
+}
+
+/**
+; RUN: cd / && %CLANG_EXEC %s -o %s.exe
+; RUN: cd %CURRENT_DIR
+; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION
+; RUN: (unset TERM; %MULL_EXEC -strict -test-framework CustomTest %s.exe 2>&1; test $? = 1) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION
+
+; WITHOUT-OPTION:[warning] No bitcode: x86_64
+; WITHOUT-OPTION:[info] No mutants found. Mutation score: infinitely high
+
+; WITH-OPTION:[info] Diagnostics: Strict Mode enabled. Warning messages will be treated as fatal errors.
+; WITH-OPTION:[warning] No bitcode: x86_64
+; WITH-OPTION:[warning] Strict Mode enabled: warning messages are treated as fatal errors. Exiting now.
+; WITH-OPTION-EMPTY:
+**/

--- a/tools/driver-cxx/CLIOptions.cpp
+++ b/tools/driver-cxx/CLIOptions.cpp
@@ -143,6 +143,13 @@ opt<bool> tool::DebugEnabled(
   init(false),
   cat(MullCXXCategory));
 
+opt<bool> tool::StrictModeEnabled(
+  "strict",
+  desc("Enables Strict Mode: all warning messages are treated as fatal errors"),
+  Optional,
+  init(false),
+  cat(MullCXXCategory));
+
 opt<bool> tool::DumpCLIInterface(
     "dump-cli",
     desc("Prints CLI options in the Sphinx/RST friendly format"),
@@ -309,6 +316,7 @@ void tool::dumpCLIInterface(Diagnostics &diagnostics) {
       reporters,
       &IDEReporterShowKilled,
       &DebugEnabled,
+      &StrictModeEnabled,
 
       &CompilationDatabasePath,
       &CompilationFlags,

--- a/tools/driver-cxx/CLIOptions.h
+++ b/tools/driver-cxx/CLIOptions.h
@@ -40,6 +40,7 @@ extern list<ReporterKind> ReportersOption;
 extern opt<bool> IDEReporterShowKilled;
 
 extern opt<bool> DebugEnabled;
+extern opt<bool> StrictModeEnabled;
 
 extern opt<SandboxKind> SandboxOption;
 

--- a/tools/driver-cxx/driver-cxx.cpp
+++ b/tools/driver-cxx/driver-cxx.cpp
@@ -64,7 +64,12 @@ int main(int argc, char **argv) {
 
   if (tool::DebugEnabled) {
     diagnostics.enableDebugMode();
-    diagnostics.debug("Diagnostics: debug mode enabled");
+    diagnostics.debug("Diagnostics: Debug Mode enabled. Debug-level messages will be printed.");
+  }
+
+  if (tool::StrictModeEnabled) {
+    diagnostics.enableStrictMode();
+    diagnostics.info("Diagnostics: Strict Mode enabled. Warning messages will be treated as fatal errors.");
   }
 
   validateInputFile();


### PR DESCRIPTION
Also error messages are always treated as fatal errors.

Closes #594