### PR TITLE
Add options to control stderr/stdout capturing

### DIFF
--- a/docs/generated/CLIOptions.rst
+++ b/docs/generated/CLIOptions.rst
@@ -24,6 +24,12 @@
 
 --strict		Enables Strict Mode: all warning messages are treated as fatal errors
 
+--no-test-output		Does not capture output from test runs
+
+--no-mutant-output		Does not capture output from mutant runs
+
+--no-output		Combines -no-test-output and -no-mutant-output
+
 --compdb-path filename		Path to a compilation database (compile_commands.json) for junk detection
 
 --compilation-flags string		Extra compilation flags for junk detection

--- a/include/mull/Config/Configuration.h
+++ b/include/mull/Config/Configuration.h
@@ -13,6 +13,8 @@ struct Configuration {
   bool dryRunEnabled;
   bool failFastEnabled;
   bool cacheEnabled;
+  bool captureTestOutput;
+  bool captureMutantOutput;
 
   int timeout;
   int maxDistance;

--- a/include/mull/Sandbox/ProcessSandbox.h
+++ b/include/mull/Sandbox/ProcessSandbox.h
@@ -15,25 +15,25 @@ public:
 
   virtual ~ProcessSandbox() = default;
   virtual ExecutionResult run(Diagnostics &diagnostics, std::function<ExecutionStatus()> function,
-                              long long timeoutMilliseconds) const = 0;
+                              long long timeoutMilliseconds, bool shouldCaptureOutput) const = 0;
 };
 
 class ForkTimerSandbox : public ProcessSandbox {
 public:
   ExecutionResult run(Diagnostics &diagnostics, std::function<ExecutionStatus()> function,
-                      long long timeoutMilliseconds) const override;
+                      long long timeoutMilliseconds, bool shouldCaptureOutput) const override;
 };
 
 class ForkWatchdogSandbox : public ProcessSandbox {
 public:
   ExecutionResult run(Diagnostics &diagnostics, std::function<ExecutionStatus()> function,
-                      long long timeoutMilliseconds) const override;
+                      long long timeoutMilliseconds, bool shouldCaptureOutput) const override;
 };
 
 class NullProcessSandbox : public ProcessSandbox {
 public:
   ExecutionResult run(Diagnostics &diagnostics, std::function<ExecutionStatus()> function,
-                      long long timeoutMilliseconds) const override;
+                      long long timeoutMilliseconds, bool shouldCaptureOutput) const override;
 };
 
 } // namespace mull

--- a/lib/Config/Configuration.cpp
+++ b/lib/Config/Configuration.cpp
@@ -16,8 +16,8 @@ ParallelizationConfig singleThreadParallelization() {
 int MullDefaultTimeoutMilliseconds = 3000;
 
 Configuration::Configuration()
-    : dryRunEnabled(false), failFastEnabled(false), cacheEnabled(false),
-      timeout(MullDefaultTimeoutMilliseconds), maxDistance(128),
+    : dryRunEnabled(false), failFastEnabled(false), cacheEnabled(false), captureTestOutput(true),
+      captureMutantOutput(true), timeout(MullDefaultTimeoutMilliseconds), maxDistance(128),
       diagnostics(IDEDiagnosticsKind::None), parallelization(singleThreadParallelization()) {}
 
 } // namespace mull

--- a/lib/Parallelization/Tasks/MutantExecutionTask.cpp
+++ b/lib/Parallelization/Tasks/MutantExecutionTask.cpp
@@ -57,7 +57,8 @@ void MutantExecutionTask::operator()(iterator begin, iterator end, Out &storage,
               assert(status != ExecutionStatus::Invalid && "Expect to see valid TestResult");
               return status;
             },
-            sandboxTimeout);
+            sandboxTimeout,
+            config.captureMutantOutput);
 
         assert(result.status != ExecutionStatus::Invalid && "Expect to see valid TestResult");
 

--- a/lib/Parallelization/Tasks/OriginalTestExecutionTask.cpp
+++ b/lib/Parallelization/Tasks/OriginalTestExecutionTask.cpp
@@ -27,7 +27,10 @@ void OriginalTestExecutionTask::operator()(iterator begin, iterator end, Out &st
     instrumentation.setupInstrumentationInfo(test);
 
     ExecutionResult testExecutionResult = sandbox.run(
-        diagnostics, [&]() { return runner.runTest(jit, program, test); }, config.timeout);
+        diagnostics,
+        [&]() { return runner.runTest(jit, program, test); },
+        config.timeout,
+        config.captureTestOutput);
 
     test.setExecutionResult(testExecutionResult);
 

--- a/lib/Reporters/SQLiteReporter.cpp
+++ b/lib/Reporters/SQLiteReporter.cpp
@@ -247,7 +247,7 @@ void mull::SQLiteReporter::reportResults(const Result &result, const Metrics &me
 
   sqlite3_close(database);
 
-  outs() << "Results can be found at '" << databasePath << "'\n";
+  diagnostics.info(std::string("Results can be found at '") + databasePath + "'");
 }
 
 #pragma mark - Database Schema

--- a/tests/CustomTestFramework/CustomTestRunnerTests.cpp
+++ b/tests/CustomTestFramework/CustomTestRunnerTests.cpp
@@ -79,7 +79,7 @@ TEST_P(CustomTestRunnerTest, all) {
   Trampolines trampolines(trampolineNames);
   runner.loadMutatedProgram(objects, trampolines, jit);
   ExecutionResult result = sandbox.run(
-      diagnostics, [&]() { return runner.runTest(jit, program, test); }, TestTimeout);
+      diagnostics, [&]() { return runner.runTest(jit, program, test); }, TestTimeout, true);
   ASSERT_EQ(result.status, parameter.status);
 }
 

--- a/tools/driver-cxx/CLIOptions.cpp
+++ b/tools/driver-cxx/CLIOptions.cpp
@@ -150,6 +150,27 @@ opt<bool> tool::StrictModeEnabled(
   init(false),
   cat(MullCXXCategory));
 
+opt<bool> tool::NoTestOutput(
+    "no-test-output",
+    desc("Does not capture output from test runs"),
+    Optional,
+    init(false),
+    cat(MullCXXCategory));
+
+opt<bool> tool::NoMutantOutput(
+    "no-mutant-output",
+    desc("Does not capture output from mutant runs"),
+    Optional,
+    init(false),
+    cat(MullCXXCategory));
+
+opt<bool> tool::NoOutput(
+    "no-output",
+    desc("Combines -no-test-output and -no-mutant-output"),
+    Optional,
+    init(false),
+    cat(MullCXXCategory));
+
 opt<bool> tool::DumpCLIInterface(
     "dump-cli",
     desc("Prints CLI options in the Sphinx/RST friendly format"),
@@ -317,6 +338,10 @@ void tool::dumpCLIInterface(Diagnostics &diagnostics) {
       &IDEReporterShowKilled,
       &DebugEnabled,
       &StrictModeEnabled,
+
+      &NoTestOutput,
+      &NoMutantOutput,
+      &NoOutput,
 
       &CompilationDatabasePath,
       &CompilationFlags,

--- a/tools/driver-cxx/CLIOptions.h
+++ b/tools/driver-cxx/CLIOptions.h
@@ -42,6 +42,10 @@ extern opt<bool> IDEReporterShowKilled;
 extern opt<bool> DebugEnabled;
 extern opt<bool> StrictModeEnabled;
 
+extern opt<bool> NoOutput;
+extern opt<bool> NoTestOutput;
+extern opt<bool> NoMutantOutput;
+
 extern opt<SandboxKind> SandboxOption;
 
 extern list<std::string> LDSearchPaths;

--- a/tools/driver-cxx/driver-cxx.cpp
+++ b/tools/driver-cxx/driver-cxx.cpp
@@ -101,6 +101,13 @@ int main(int argc, char **argv) {
     configuration.cacheDirectory = tool::CacheDir.getValue();
   }
 
+  if (tool::NoTestOutput.getValue() || tool::NoOutput.getValue()) {
+    configuration.captureTestOutput = false;
+  }
+  if (tool::NoMutantOutput.getValue() || tool::NoOutput.getValue()) {
+    configuration.captureMutantOutput = false;
+  }
+
   std::vector<std::unique_ptr<ebc::EmbeddedFile>> embeddedFiles;
   mull::SingleTaskExecutor extractBitcodeBuffers(
       diagnostics, "Extracting bitcode from executable", [&] {


### PR DESCRIPTION
This information is not always required for further analysis, but it
greatly affects the size of an SQLite report: output strings may take
gigabytes