### PR TITLE
Enable LIT tests on CI for Linux

### DIFF
--- a/infrastructure/ubuntu-playbook.yaml
+++ b/infrastructure/ubuntu-playbook.yaml
@@ -25,6 +25,7 @@
       - uuid-dev
       - binutils
       - liblzma-dev
+      - python3-pip
 
   vars_files:
     - helpers/variables.yaml
@@ -58,6 +59,8 @@
     - name: Build Mull
       include: helpers/build-mull.yaml
 
+    - name: LIT Tests
+      include: helpers/lit-tests.yaml
+
     - name: Integration Tests
       include: helpers/integration-tests.yaml
-

--- a/tests-lit/CMakeLists.txt
+++ b/tests-lit/CMakeLists.txt
@@ -14,8 +14,9 @@ else()
 endif()
 
 set(TEST_CXX_FLAGS
-  "-isystem ${PATH_TO_LLVM}/include/c++/v1 -isystem ${PATH_TO_LLVM}/lib/clang/${LLVM_VERSION}/include"
+  "-stdlib=libc++ -isystem ${PATH_TO_LLVM}/include/c++/v1 -isystem ${PATH_TO_LLVM}/lib/clang/${LLVM_VERSION}/include"
 )
+
 if (SYSROOT)
   set(TEST_CXX_FLAGS "${TEST_CXX_FLAGS} ${SYSROOT}")
 endif()

--- a/tests-lit/lit.cfg
+++ b/tests-lit/lit.cfg
@@ -17,11 +17,18 @@ def get_os_filename_string():
     print("error: lit.cfg could not detect OS")
     return "Unknown"
 
-def get_mull_portable_flags():
-    if get_os_filename_string() == 'Linux':
-        return '-ld-search-path=/usr/lib/x86_64-linux-gnu -ld-search-path=/lib/x86_64-linux-gnu'
+def get_mull_portable_exec(llvm_path):
+    components = [ mull_exec ]
 
-    return ''
+    if get_os_filename_string() == 'Linux':
+        linux_env = 'LD_LIBRARY_PATH={}/lib'.format(llvm_path)
+        linux_flags = '-ld-search-path={}/lib -ld-search-path=/usr/lib/x86_64-linux-gnu -ld-search-path=/lib/x86_64-linux-gnu'.format(llvm_path)
+
+        components.insert(0, linux_env)
+        components.append(linux_flags)
+
+    return ' '.join(components)
+
 
 config.name = "Mull integration tests"
 config.test_format = lit.formats.ShTest("0")
@@ -42,7 +49,7 @@ assert test_cxx_flags
 
 test_cxx_flags = unescape_string(test_cxx_flags)
 
-portable_mull_exec = "{} {}".format(mull_exec, get_mull_portable_flags()).rstrip()
+portable_mull_exec = get_mull_portable_exec(llvm_path)
 
 config.substitutions.append(('%CURRENT_DIR', current_dir))
 config.substitutions.append(('%CLANG_EXEC', clang_exec))

--- a/tests-lit/lit.cfg
+++ b/tests-lit/lit.cfg
@@ -1,3 +1,4 @@
+import platform
 import re
 
 import lit.formats
@@ -7,6 +8,20 @@ import lit.formats
 # Example: "-isystem\ /opt/llvm-3.9.0/include/c++/v1 ..."
 def unescape_string(string):
     return re.sub(r'\\ ', ' ', string)
+
+def get_os_filename_string():
+    if platform.system() == 'Darwin':
+        return "macOS"
+    if platform.system() == 'Linux':
+        return "Linux"
+    print("error: lit.cfg could not detect OS")
+    return "Unknown"
+
+def get_mull_portable_flags():
+    if get_os_filename_string() == 'Linux':
+        return '-ld-search-path=/usr/lib/x86_64-linux-gnu -ld-search-path=/lib/x86_64-linux-gnu'
+
+    return ''
 
 config.name = "Mull integration tests"
 config.test_format = lit.formats.ShTest("0")
@@ -27,9 +42,11 @@ assert test_cxx_flags
 
 test_cxx_flags = unescape_string(test_cxx_flags)
 
+portable_mull_exec = "{} {}".format(mull_exec, get_mull_portable_flags()).rstrip()
+
 config.substitutions.append(('%CURRENT_DIR', current_dir))
 config.substitutions.append(('%CLANG_EXEC', clang_exec))
-config.substitutions.append(('%MULL_EXEC', mull_exec))
+config.substitutions.append(('%MULL_EXEC', portable_mull_exec))
 config.substitutions.append(('%FILECHECK_EXEC', filecheck_exec))
 config.substitutions.append(('%LLVM_PATH', llvm_path))
 config.substitutions.append(('%TEST_CXX_FLAGS', test_cxx_flags))

--- a/tests-lit/tests/junk_detection/05_compilation_database_escaped_path/sample.cpp
+++ b/tests-lit/tests/junk_detection/05_compilation_database_escaped_path/sample.cpp
@@ -9,12 +9,12 @@
 #define STRINGIFY(a) _STRINGIFY(a)
 
 int main() {
-  bool equal = std::string(STRINGIFY(ESCAPED_DEFINITION_STUB)) == std::string("/src/builds/amd64-linux-mull");
+  bool equal = std::string(STRINGIFY(ESCAPED_DEFINITION_STUB)) == std::string("/src/builds/amd64-mull");
   return ! equal;
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode %TEST_CXX_FLAGS -g -O0 -DESCAPED_DEFINITION_STUB=/src/builds/amd64-linux-mull %s -o %s.exe
+; RUN: cd / && %CLANG_EXEC -fembed-bitcode %TEST_CXX_FLAGS -g -O0 -DESCAPED_DEFINITION_STUB=/src/builds/amd64-mull %s -o %s.exe
 ; RUN: sed -e "s:%PWD:%S:g" -e "s:#TEST_CXX_FLAGS:%TEST_CXX_FLAGS:g" %S/compile_commands.json.template > %S/compile_commands.json
 ; RUN: cd %CURRENT_DIR
 ; RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1 | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines


### PR DESCRIPTION
- [x] pip3 is missing in Ubuntu Linux playbook
- [x] `[warning] Could not find dynamic library: libstdc++.so.6`
- [x] `error: no member named 'abort' in namespace 'std'`

And after the libc fix:

- [x] `[warning] Could not find dynamic library: libc++.so.1`

Closes #715