### PR TITLE
cmake: Cache PATH_TO_LLVM variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ include(${CMAKE_CURRENT_LIST_DIR}/cmake/properties.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/fixtures.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/functions.cmake)
 
+set(PATH_TO_LLVM "" CACHE PATH "Path to installed LLVM or LLVM source tree")
+
 if (PRECOMPILED_LLVM_DIR)
   message(WARNING "PRECOMPILED_LLVM_DIR is deprecated. Please, use PATH_TO_LLVM instead")
   set(PATH_TO_LLVM ${PRECOMPILED_LLVM_DIR})


### PR DESCRIPTION
Avoids the need to specify it again if we run `cmake .` from the build directory.