### PR TITLE
Add debug logging for object loading

### DIFF
--- a/lib/Driver.cpp
+++ b/lib/Driver.cpp
@@ -64,6 +64,9 @@ void Driver::loadDynamicLibraries() {
   singleTask.execute("Loading dynamic libraries", [&]() {
     for (const std::string &dylibPath : program.getDynamicLibraryPaths()) {
       std::string msg;
+      std::ostringstream ss;
+      ss << "Loading dynamic library " << dylibPath;
+      diagnostics.debug(ss.str());
       auto error = sys::DynamicLibrary::LoadLibraryPermanently(dylibPath.c_str(), &msg);
       if (error) {
         std::stringstream message;

--- a/lib/Toolchain/JITEngine.cpp
+++ b/lib/Toolchain/JITEngine.cpp
@@ -61,7 +61,7 @@ void JITEngine::addObjectFiles(std::vector<object::ObjectFile *> &files,
   diagnostics.debug("Resolving symbol references");
   auto it = unresolvedSymbols.begin();
   while (it != unresolvedSymbols.end()) {
-    std::string name = *it;
+    const std::string &name = *it;
     auto dlSymbol = dynamicLoader.getSymbol(name);
     if (dlSymbol.getAddress() != 0) {
       std::ostringstream ss;


### PR DESCRIPTION
This adds debug level messages for loading libraries and objects, and for resolving external references between objects and libraries.
Useful to better see what is going on inside mull-cxx during the prepare phase. This was written while debugging #743.