### PR TITLE
FilePathFilter: Allow combined include-path + exclude-path

### DIFF
--- a/lib/Filters/FilePathFilter.cpp
+++ b/lib/Filters/FilePathFilter.cpp
@@ -33,19 +33,20 @@ bool FilePathFilter::shouldSkip(const std::string &sourceFilePath) const {
   if (cache.count(sourceFilePath) == 0) {
     bool allow = true;
 
-    if (includeFilters.empty()) {
-      for (const auto &r : excludeFilters) {
-        if (std::regex_search(sourceFilePath, r)) {
-          allow = false;
-          break;
-        }
-      }
-    } else {
+    if (!includeFilters.empty()) {
       allow = false;
 
       for (const auto &r : includeFilters) {
         if (std::regex_search(sourceFilePath, r)) {
           allow = true;
+          break;
+        }
+      }
+    }
+    if (allow) {
+      for (const auto &r : excludeFilters) {
+        if (std::regex_search(sourceFilePath, r)) {
+          allow = false;
           break;
         }
       }


### PR DESCRIPTION
Include will be applied first, then excludes.

If only include-path or only exclude-path is given then the behavior is unchanged from before.

This is useful if test code lives in the same tree as the code under test, so you can do `mull-cxx --include-path=mymodule --exclude-path=tests`