### PR TITLE
reports: Fix a possible infinite loop in SourceManager

### DIFF
--- a/lib/Reporters/SourceManager.cpp
+++ b/lib/Reporters/SourceManager.cpp
@@ -43,7 +43,7 @@ LineOffset &SourceManager::getLineOffset(const SourceLocation &location) {
   }
   std::vector<uint32_t> offsets;
   uint32_t offset = 0;
-  char c = '\n';
+  int c = '\n';
   for (; c != EOF; c = fgetc(file), offset++) {
     if (c == '\n') {
       offsets.push_back(offset);


### PR DESCRIPTION
fgetc returns an int, however char was specified.
This fixes a case where the EOF is truncated to a char
which may not be detected depending on the sign of a char.

This issue is known to trigger on ppc64le.