### PR TITLE
cmake: Link against native codegen and asmparser libs.

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -162,8 +162,8 @@ else ()
     LLVMOrcJIT
     LLVMSupport
     LLVMOption
-    LLVMX86CodeGen
-    LLVMX86AsmParser
+    LLVM${LLVM_NATIVE_ARCH}CodeGen
+    LLVM${LLVM_NATIVE_ARCH}AsmParser
     )
 endif ()
 


### PR DESCRIPTION
This fixes a linking issue when building under ppc64le.