### PR TITLE
gcc: Fix build failures when building on GCC 10.

### DIFF
--- a/include/mull/ExecutionResult.h
+++ b/include/mull/ExecutionResult.h
@@ -16,6 +16,8 @@ enum ExecutionStatus {
 
 static std::string executionStatusAsString(ExecutionStatus status) {
   switch (status) {
+  default:
+    return "Unknown";
   case Invalid:
     return "Invalid";
   case Failed:

--- a/lib/Config/ConfigurationOptions.cpp
+++ b/lib/Config/ConfigurationOptions.cpp
@@ -13,6 +13,9 @@ namespace mull {
 
 std::string diagnosticsToString(IDEDiagnosticsKind diagnostics) {
   switch (diagnostics) {
+  default: {
+    return "unknown";
+  }
   case IDEDiagnosticsKind::None: {
     return "none";
   }

--- a/lib/Mutators/MutatorKind.cpp
+++ b/lib/Mutators/MutatorKind.cpp
@@ -3,6 +3,9 @@
 namespace mull {
 std::string MutationKindToString(MutatorKind mutatorKind) {
   switch (mutatorKind) {
+  default: {
+    return "Unknown";
+  }
   case MutatorKind::NegateMutator: {
     return "Negate";
   }

--- a/tools/mull-cxx/CLIOptions.cpp
+++ b/tools/mull-cxx/CLIOptions.cpp
@@ -256,6 +256,7 @@ std::unique_ptr<mull::ProcessSandbox> SandboxCLIOptions::sandbox() {
     return std::make_unique<mull::NullProcessSandbox>();
   case SandboxKind::Watchdog:
     return std::make_unique<mull::ForkWatchdogSandbox>();
+  default:
   case SandboxKind::Timer:
     return std::make_unique<mull::ForkTimerSandbox>();
   }


### PR DESCRIPTION
A couple of functions could previously return witout a return statment.
This updates the functions to always return the specified return type
by setting a defaulte case for most switch statements.

Signed-off-by: Evan Lojewski <github@meklort.com>