### PR TITLE
Add command line option -ld-preload

### DIFF
--- a/tools/mull-cxx/CLIOptions.cpp
+++ b/tools/mull-cxx/CLIOptions.cpp
@@ -93,6 +93,13 @@ opt<TestFrameworkOptionIndex> tool::TestFrameworks(
   value_desc("framework"),
   cat(MullCXXCategory));
 
+list<std::string> tool::LDPreloads(
+  "ld-preload",
+  desc("Load the given libraries before dynamic linking"),
+  ZeroOrMore,
+  value_desc("library"),
+  cat(MullCXXCategory));
+
 list<std::string> tool::LDSearchPaths(
   "ld-search-path",
   desc("Library search path"),
@@ -352,6 +359,7 @@ void tool::dumpCLIInterface(Diagnostics &diagnostics) {
 
       &CompilationDatabasePath,
       &CompilationFlags,
+      &(Option &)LDPreloads,
       &(Option &)LDSearchPaths,
       &(Option &)IncludePaths,
       &(Option &)ExcludePaths,

--- a/tools/mull-cxx/CLIOptions.h
+++ b/tools/mull-cxx/CLIOptions.h
@@ -49,6 +49,7 @@ extern opt<bool> NoMutantOutput;
 extern opt<SandboxKind> SandboxOption;
 extern opt<bool> EnableAST;
 
+extern list<std::string> LDPreloads;
 extern list<std::string> LDSearchPaths;
 extern list<std::string> ExcludePaths;
 extern list<std::string> IncludePaths;

--- a/tools/mull-cxx/DynamicLibraries.cpp
+++ b/tools/mull-cxx/DynamicLibraries.cpp
@@ -94,7 +94,7 @@ std::vector<std::string> mull::findDynamicLibraries(mull::Diagnostics &diagnosti
 
   auto symbolicOr = SymbolicFile::createSymbolicFile(buffer->getMemBufferRef());
   if (!symbolicOr) {
-    diagnostics.error(std::string("Cannot create symbolic file from: ") + executablePath);
+    diagnostics.error(std::string("Cannot create SymbolicFile from: ") + executablePath);
   }
 
   std::unique_ptr<SymbolicFile> symbolicFile(std::move(symbolicOr.get()));

--- a/tools/mull-cxx/DynamicLibraries.cpp
+++ b/tools/mull-cxx/DynamicLibraries.cpp
@@ -81,9 +81,23 @@ static std::string resolveLibraryPath(const std::string &library,
   return library;
 }
 
-std::vector<std::string> mull::findDynamicLibraries(mull::Diagnostics &diagnostics,
-                                                    const std::string &executablePath,
-                                                    std::vector<std::string> &librarySearchPaths) {
+void mull::resolveLibraries(mull::Diagnostics &diagnostics,
+                            std::vector<std::string> &resolvedLibraries,
+                            const std::vector<std::string> &libraries,
+                            const std::vector<std::string> &librarySearchPaths) {
+  resolvedLibraries.reserve(resolvedLibraries.size() + libraries.size());
+  for (auto &library : libraries) {
+    auto libraryPath = resolveLibraryPath(library, librarySearchPaths);
+    if (llvm::sys::fs::exists(libraryPath)) {
+      resolvedLibraries.push_back(std::move(libraryPath));
+    } else {
+      diagnostics.warning(std::string("Could not find dynamic library: ") + library);
+    }
+  }
+}
+
+std::vector<std::string> mull::getDynamicLibraryDependencies(mull::Diagnostics &diagnostics,
+                                         const std::string &executablePath) {
   std::vector<std::string> libraries;
 
   auto bufferOr = llvm::MemoryBuffer::getFile(executablePath);
@@ -115,16 +129,5 @@ std::vector<std::string> mull::findDynamicLibraries(mull::Diagnostics &diagnosti
       librariesFromElf(*elf64BEFile, libraries);
     }
   }
-
-  std::vector<std::string> resolvedLibraries;
-  for (auto &library : libraries) {
-    auto libraryPath = resolveLibraryPath(library, librarySearchPaths);
-    if (llvm::sys::fs::exists(libraryPath)) {
-      resolvedLibraries.push_back(libraryPath);
-    } else {
-      diagnostics.warning(std::string("Could not find dynamic library: ") + library);
-    }
-  }
-
-  return resolvedLibraries;
+  return libraries;
 }

--- a/tools/mull-cxx/DynamicLibraries.h
+++ b/tools/mull-cxx/DynamicLibraries.h
@@ -7,7 +7,10 @@ namespace mull {
 
 class Diagnostics;
 
-std::vector<std::string> findDynamicLibraries(mull::Diagnostics &diagnostics,
-                                              const std::string &executablePath,
-                                              std::vector<std::string> &librarySearchPaths);
+void resolveLibraries(mull::Diagnostics &diagnostics, std::vector<std::string> &resolvedLibraries,
+                      const std::vector<std::string> &libraries,
+                      const std::vector<std::string> &librarySearchPaths);
+
+std::vector<std::string> getDynamicLibraryDependencies(mull::Diagnostics &diagnostics,
+                                   const std::string &executablePath);
 } // namespace mull

--- a/tools/mull-cxx/mull-cxx.cpp
+++ b/tools/mull-cxx/mull-cxx.cpp
@@ -144,7 +144,13 @@ int main(int argc, char **argv) {
   std::vector<std::string> librarySearchPaths(std::begin(tool::LDSearchPaths),
                                               std::end(tool::LDSearchPaths));
 
+  std::vector<std::string> libraryPreloads(std::begin(tool::LDPreloads),
+                                           std::end(tool::LDPreloads));
+
   std::vector<std::string> resolvedLibraries;
+  // First load all -ld-preload libraries
+  mull::resolveLibraries(diagnostics, resolvedLibraries, libraryPreloads, librarySearchPaths);
+  // then load any dynamic libraries listed as DT_NEEDED
   mull::resolveLibraries(
       diagnostics,
       resolvedLibraries,

--- a/tools/mull-cxx/mull-cxx.cpp
+++ b/tools/mull-cxx/mull-cxx.cpp
@@ -30,6 +30,7 @@
 #include "mull/TestFrameworks/TestFrameworkFactory.h"
 #include "mull/Version.h"
 
+#include <iterator>
 #include <memory>
 #include <sstream>
 #include <unistd.h>
@@ -140,19 +141,21 @@ int main(int argc, char **argv) {
       diagnostics, "Loading bitcode files", embeddedFiles, bitcode, std::move(tasks));
   executor.execute();
 
-  std::vector<std::string> librarySearchPaths;
-  for (auto &searchPath : tool::LDSearchPaths) {
-    librarySearchPaths.push_back(searchPath);
-  }
+  std::vector<std::string> librarySearchPaths(std::begin(tool::LDSearchPaths),
+                                              std::end(tool::LDSearchPaths));
 
-  auto dynamicLibraries =
-      mull::findDynamicLibraries(diagnostics, tool::InputFile.getValue(), librarySearchPaths);
+  std::vector<std::string> resolvedLibraries;
+  mull::resolveLibraries(
+      diagnostics,
+      resolvedLibraries,
+      mull::getDynamicLibraryDependencies(diagnostics, tool::InputFile.getValue()),
+      librarySearchPaths);
 
   mull::BitcodeMetadataReader bitcodeCompilationDatabaseLoader;
   std::map<std::string, std::string> bitcodeCompilationFlags =
       bitcodeCompilationDatabaseLoader.getCompilationDatabase(bitcode);
 
-  mull::Program program(dynamicLibraries, {}, std::move(bitcode));
+  mull::Program program(resolvedLibraries, {}, std::move(bitcode));
 
   mull::Toolchain toolchain(diagnostics, configuration);
 


### PR DESCRIPTION
As suggested in https://github.com/mull-project/mull/pull/745#issuecomment-694489990
This adds a new CLI option `-ld-preload` for providing preloaded dynamic libraries. The primary use case is to override libraries for test binaries which fail when recompiled, in particular those using C++ `thread_local` variables.

Forked off from #745 to make reviewing easier.