### PR TITLE
CppUTest doesn't need to be added to the build system

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,7 +71,6 @@ add_executable(mull-tests EXCLUDE_FROM_ALL ${mull_unittests_sources})
 target_link_libraries(mull-tests
   mull
   google-test
-  CppUTest
   json11
   clangCodeGen
 )

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -1,7 +1,2 @@
 add_subdirectory(json11 EXCLUDE_FROM_ALL)
 add_subdirectory(LibEBC EXCLUDE_FROM_ALL)
-
-add_subdirectory(cpputest EXCLUDE_FROM_ALL)
-target_compile_definitions(CppUTest
-    PRIVATE CPPUTEST_MEM_LEAK_DETECTION_DISABLED
-)


### PR DESCRIPTION
Fixes #754