### PR TITLE
cmake: Use gtest_discover_tests for unit test enumeration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7.0)
+cmake_minimum_required(VERSION 3.10)
 
 if (NOT MULL_VERSION)
 set (MULL_VERSION 0.7.0)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_subdirectory(fixtures)
 generate_fixture_factory(FACTORY_HEADER)
 
+include(GoogleTest)
+
 set(mull_unittests_sources
   AST/ASTVisitor/ASTVisitor_Arithmetic_Tests.cpp
   AST/ASTVisitor/ASTVisitor_ArithmeticAssignment_Tests.cpp
@@ -68,7 +70,7 @@ set(mull_unittests_sources
 get_filename_component(factory_include_dir ${FACTORY_HEADER} DIRECTORY)
 
 add_executable(mull-tests ${mull_unittests_sources})
-add_test(NAME mull-tests COMMAND mull-tests)
+gtest_discover_tests(mull-tests)
 target_link_libraries(mull-tests
   mull
   google-test


### PR DESCRIPTION
Use builtin support for discovering individual test cases in Google test with CTest.

This was mentioned in https://github.com/mull-project/mull/pull/759#issuecomment-702377209

This change allows us to use `ctest -j N` to run `N` tests in parallel instead of all sequentially. The drawback is that running the tests sequentially one-by-one when not using `-j N` takes more time than running the full unit test binary once with all test cases enabled because of the extra overhead from starting a new process for each test case.

Currently 183 test cases are registered. Running `ctest -j9` on my machine takes 1.9 seconds, while running the test binary without ctest takes 4.3 seconds, so not really a big difference right now. `ctest` without `-j` takes 7.4 seconds with this PR, 4.9 seconds without it.