### PR TITLE
Cleanup: Remove semicolons from all integration test files

### DIFF
--- a/tests-lit/tests/invalid-input/01-no-bitcode/sample.cpp
+++ b/tests-lit/tests/invalid-input/01-no-bitcode/sample.cpp
@@ -1,9 +1,9 @@
 /**
-; RUN: cd / && %CLANG_EXEC %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK:[warning] No bitcode: x86_64
-; CHECK:[info] No mutants found. Mutation score: infinitely high
+RUN: cd / && %CLANG_EXEC %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK:[warning] No bitcode: x86_64
+CHECK:[info] No mutants found. Mutation score: infinitely high
 **/
 
 int main() {

--- a/tests-lit/tests/invalid-input/02-no-debug-information/sample.cpp
+++ b/tests-lit/tests/invalid-input/02-no-debug-information/sample.cpp
@@ -1,19 +1,19 @@
 /**
-; /// Without debug information we see the error message.
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-DEBUG
-; WITHOUT-DEBUG:[warning] Bitcode module does not have debug information.
-; WITHOUT-DEBUG:[info] No mutants found. Mutation score: infinitely high
+/// Without debug information we see the error message.
+RUN: cd / && %CLANG_EXEC -fembed-bitcode %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-DEBUG
+WITHOUT-DEBUG:[warning] Bitcode module does not have debug information.
+WITHOUT-DEBUG:[info] No mutants found. Mutation score: infinitely high
 
-; /// With debug information we do not see the error message.
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-DEBUG
-; WITH-DEBUG-NOT:[warning] Bitcode module does not have debug information.
-; WITH-DEBUG:[info] Running mutants (threads: 1)
-; WITHOUT-OPTION:{{^       \[################################\] 1/1\. Finished .*}}
-; WITH-DEBUG:[info] Mutation score: 100%
+/// With debug information we do not see the error message.
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-DEBUG
+WITH-DEBUG-NOT:[warning] Bitcode module does not have debug information.
+WITH-DEBUG:[info] Running mutants (threads: 1)
+WITHOUT-OPTION:{{^       \[################################\] 1/1\. Finished .*}}
+WITH-DEBUG:[info] Mutation score: 100%
 **/
 
 int sum(int a, int b) {

--- a/tests-lit/tests/junk_detection/00_error_compilation_flags_database_does_not_match_real_flags/sample.cpp
+++ b/tests-lit/tests/junk_detection/00_error_compilation_flags_database_does_not_match_real_flags/sample.cpp
@@ -11,26 +11,26 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 -DFLAG=1 %s -o %s.exe
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.no_flag.json.template > %S/compile_commands.no_flag.json
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.with_flag.json.template > %S/compile_commands.with_flag.json
-; RUN: cd %CURRENT_DIR
-; RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
-; RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.no_flag.json %s.exe 2>&1 | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-NO-FLAG
-; RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.with_flag.json %s.exe 2>&1 | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAG
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 -DFLAG=1 %s -o %s.exe
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.no_flag.json.template > %S/compile_commands.no_flag.json
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.with_flag.json.template > %S/compile_commands.with_flag.json
+RUN: cd %CURRENT_DIR
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.no_flag.json %s.exe 2>&1 | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-NO-FLAG
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.with_flag.json %s.exe 2>&1 | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAG
 
-; WITHOUT-JUNK-DETECTION:{{^.*}}sample.cpp:5:13: warning: Survived: Remove Void Call: removed llvm.dbg.declare [remove_void_function_mutator]{{$}}
+WITHOUT-JUNK-DETECTION:{{^.*}}sample.cpp:5:13: warning: Survived: Remove Void Call: removed llvm.dbg.declare [remove_void_function_mutator]{{$}}
 
-; WITH-JUNK-DETECTION-NO-FLAG:{{^.*}}sample.cpp:2:2: error: "FLAG is not defined"
-; WITH-JUNK-DETECTION-NO-FLAG:#error "FLAG is not defined"
-; WITH-JUNK-DETECTION-NO-FLAG: ^
-; WITH-JUNK-DETECTION-NO-FLAG:[warning] Cannot parse file: '{{.*}}sample.cpp':
-; WITH-JUNK-DETECTION-NO-FLAG:mull-cxx {{.*}}sample.cpp{{$}}
-; WITH-JUNK-DETECTION-NO-FLAG:Make sure that the flags provided to Mull are the same flags that are used for normal compilation.
-; TODO: It is interesting why there is no junk even if we have the error above.
-; WITH-JUNK-DETECTION-NO-FLAG:[info] Killed mutants (1/1):
+WITH-JUNK-DETECTION-NO-FLAG:{{^.*}}sample.cpp:2:2: error: "FLAG is not defined"
+WITH-JUNK-DETECTION-NO-FLAG:#error "FLAG is not defined"
+WITH-JUNK-DETECTION-NO-FLAG: ^
+WITH-JUNK-DETECTION-NO-FLAG:[warning] Cannot parse file: '{{.*}}sample.cpp':
+WITH-JUNK-DETECTION-NO-FLAG:mull-cxx {{.*}}sample.cpp{{$}}
+WITH-JUNK-DETECTION-NO-FLAG:Make sure that the flags provided to Mull are the same flags that are used for normal compilation.
+TODO: It is interesting why there is no junk even if we have the error above.
+WITH-JUNK-DETECTION-NO-FLAG:[info] Killed mutants (1/1):
 
-; WITH-JUNK-DETECTION-WITH-FLAG-NOT:#error "FLAG is not defined"
-; WITH-JUNK-DETECTION-WITH-FLAG-NOT:{{^.*[Ee]rror.*$}}
-; WITH-JUNK-DETECTION-WITH-FLAG:[info] Killed mutants (1/1):
+WITH-JUNK-DETECTION-WITH-FLAG-NOT:#error "FLAG is not defined"
+WITH-JUNK-DETECTION-WITH-FLAG-NOT:{{^.*[Ee]rror.*$}}
+WITH-JUNK-DETECTION-WITH-FLAG:[info] Killed mutants (1/1):
 **/

--- a/tests-lit/tests/junk_detection/01_junk_detection/sample.cpp
+++ b/tests-lit/tests/junk_detection/01_junk_detection/sample.cpp
@@ -7,21 +7,21 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
-; RUN: sed -e "s:%PWD:%s:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: cd %CURRENT_DIR
-; RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
-; RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
+RUN: sed -e "s:%PWD:%s:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: cd %CURRENT_DIR
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION
 
-; WITHOUT-JUNK-DETECTION-NOT:{{^.*}}[info] Running mutants (threads: 1){{$}}
-; WITHOUT-JUNK-DETECTION:{{^.*}}sample.cpp:1:13: warning: Survived: Remove Void Call: removed llvm.dbg.declare [remove_void_function_mutator]{{$}}
-; WITHOUT-JUNK-DETECTION-NOT:[info] Mutation score: 100%
+WITHOUT-JUNK-DETECTION-NOT:{{^.*}}[info] Running mutants (threads: 1){{$}}
+WITHOUT-JUNK-DETECTION:{{^.*}}sample.cpp:1:13: warning: Survived: Remove Void Call: removed llvm.dbg.declare [remove_void_function_mutator]{{$}}
+WITHOUT-JUNK-DETECTION-NOT:[info] Mutation score: 100%
 
-; WITH-JUNK-DETECTION:{{^.*}}[info] Running mutants (threads: 1){{$}}
-; WITH-JUNK-DETECTION:[info] Killed mutants (1/1):
-; WITH-JUNK-DETECTION:{{^.*}}/sample.cpp:2:12: warning: Killed: Replaced + with - [cxx_add_to_sub]{{$}}
-; WITH-JUNK-DETECTION:  return a + b;
-; WITH-JUNK-DETECTION:           ^
-; WITH-JUNK-DETECTION:[info] All mutations have been killed
-; WITH-JUNK-DETECTION:[info] Mutation score: 100%
+WITH-JUNK-DETECTION:{{^.*}}[info] Running mutants (threads: 1){{$}}
+WITH-JUNK-DETECTION:[info] Killed mutants (1/1):
+WITH-JUNK-DETECTION:{{^.*}}/sample.cpp:2:12: warning: Killed: Replaced + with - [cxx_add_to_sub]{{$}}
+WITH-JUNK-DETECTION:  return a + b;
+WITH-JUNK-DETECTION:           ^
+WITH-JUNK-DETECTION:[info] All mutations have been killed
+WITH-JUNK-DETECTION:[info] Mutation score: 100%
 **/

--- a/tests-lit/tests/junk_detection/02_junk_detection_using_extra_flags/sample.cpp
+++ b/tests-lit/tests/junk_detection/02_junk_detection_using_extra_flags/sample.cpp
@@ -11,24 +11,24 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 -DFLAG=1 %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
-; RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compilation-flags '-DWRONG_FLAG=1' %s.exe 2>&1 | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-NO-FLAG
-; RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compilation-flags '-DFLAG=1' %s.exe 2>&1 | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAG
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 -DFLAG=1 %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compilation-flags '-DWRONG_FLAG=1' %s.exe 2>&1 | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-NO-FLAG
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compilation-flags '-DFLAG=1' %s.exe 2>&1 | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAG
 
-; WITHOUT-JUNK-DETECTION:{{^.*}}sample.cpp:5:13: warning: Survived: Remove Void Call: removed llvm.dbg.declare [remove_void_function_mutator]{{$}}
+WITHOUT-JUNK-DETECTION:{{^.*}}sample.cpp:5:13: warning: Survived: Remove Void Call: removed llvm.dbg.declare [remove_void_function_mutator]{{$}}
 
-; WITH-JUNK-DETECTION-NO-FLAG:{{^.*}}sample.cpp:2:2: error: "FLAG is not defined"
-; WITH-JUNK-DETECTION-NO-FLAG:#error "FLAG is not defined"
-; WITH-JUNK-DETECTION-NO-FLAG: ^
-; WITH-JUNK-DETECTION-NO-FLAG:[warning] Cannot parse file: '{{.*}}sample.cpp':
-; WITH-JUNK-DETECTION-NO-FLAG:mull-cxx {{.*}}sample.cpp{{$}}
-; WITH-JUNK-DETECTION-NO-FLAG:Make sure that the flags provided to Mull are the same flags that are used for normal compilation.
-; TODO: It is interesting why there is no junk even if we have the error above.
-; WITH-JUNK-DETECTION-NO-FLAG:[info] Killed mutants (1/1):
+WITH-JUNK-DETECTION-NO-FLAG:{{^.*}}sample.cpp:2:2: error: "FLAG is not defined"
+WITH-JUNK-DETECTION-NO-FLAG:#error "FLAG is not defined"
+WITH-JUNK-DETECTION-NO-FLAG: ^
+WITH-JUNK-DETECTION-NO-FLAG:[warning] Cannot parse file: '{{.*}}sample.cpp':
+WITH-JUNK-DETECTION-NO-FLAG:mull-cxx {{.*}}sample.cpp{{$}}
+WITH-JUNK-DETECTION-NO-FLAG:Make sure that the flags provided to Mull are the same flags that are used for normal compilation.
+TODO: It is interesting why there is no junk even if we have the error above.
+WITH-JUNK-DETECTION-NO-FLAG:[info] Killed mutants (1/1):
 
-; WITH-JUNK-DETECTION-WITH-FLAG-NOT:#error "FLAG is not defined"
-; WITH-JUNK-DETECTION-WITH-FLAG-NOT:{{^.*[Ee]rror.*$}}
-; WITH-JUNK-DETECTION-WITH-FLAG:[info] Killed mutants (1/1):
+WITH-JUNK-DETECTION-WITH-FLAG-NOT:#error "FLAG is not defined"
+WITH-JUNK-DETECTION-WITH-FLAG-NOT:{{^.*[Ee]rror.*$}}
+WITH-JUNK-DETECTION-WITH-FLAG:[info] Killed mutants (1/1):
 **/

--- a/tests-lit/tests/junk_detection/03_junk_detection_merging_comp_db_and_extra_flags/sample.cpp
+++ b/tests-lit/tests/junk_detection/03_junk_detection_merging_comp_db_and_extra_flags/sample.cpp
@@ -15,14 +15,14 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 -DFLAG_VIA_COMP_DB=1 -DFLAG_VIA_EXTRA_FLAGS=1 %s -o %s.exe
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: cd %CURRENT_DIR
-; RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
-; RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json -compilation-flags '-DFLAG_VIA_EXTRA_FLAGS=1' %s.exe 2>&1 | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAGS
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 -DFLAG_VIA_COMP_DB=1 -DFLAG_VIA_EXTRA_FLAGS=1 %s -o %s.exe
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: cd %CURRENT_DIR
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json -compilation-flags '-DFLAG_VIA_EXTRA_FLAGS=1' %s.exe 2>&1 | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAGS
 
-; WITHOUT-JUNK-DETECTION:{{^.*}}sample.cpp:9:13: warning: Survived: Remove Void Call: removed llvm.dbg.declare [remove_void_function_mutator]{{$}}
+WITHOUT-JUNK-DETECTION:{{^.*}}sample.cpp:9:13: warning: Survived: Remove Void Call: removed llvm.dbg.declare [remove_void_function_mutator]{{$}}
 
-; WITH-JUNK-DETECTION-WITH-FLAGS-NOT:{{^.*[Ee]rror.*$}}
-; WITH-JUNK-DETECTION-WITH-FLAGS:[info] Killed mutants (1/1):
+WITH-JUNK-DETECTION-WITH-FLAGS-NOT:{{^.*[Ee]rror.*$}}
+WITH-JUNK-DETECTION-WITH-FLAGS:[info] Killed mutants (1/1):
 **/

--- a/tests-lit/tests/junk_detection/04_junk_detection_using_bitcode_compilation_flags_via_record_command_line_flag/sample.cpp
+++ b/tests-lit/tests/junk_detection/04_junk_detection_using_bitcode_compilation_flags_via_record_command_line_flag/sample.cpp
@@ -11,18 +11,17 @@ int main() {
 }
 
 /**
-; REQUIRES: LLVM_8_OR_HIGHER
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -DFLAG=1 %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-RECORD-COMMAND-LINE
-; WITHOUT-RECORD-COMMAND-LINE-NOT:Found compilation flags in the input bitcode
-; WITHOUT-RECORD-COMMAND-LINE:{{^.*}}sample.cpp:5:13: warning: Survived: Remove Void Call: removed llvm.dbg.declare [remove_void_function_mutator]{{$}}
+REQUIRES: LLVM_8_OR_HIGHER
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -DFLAG=1 %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-RECORD-COMMAND-LINE
+WITHOUT-RECORD-COMMAND-LINE-NOT:Found compilation flags in the input bitcode
+WITHOUT-RECORD-COMMAND-LINE:{{^.*}}sample.cpp:5:13: warning: Survived: Remove Void Call: removed llvm.dbg.declare [remove_void_function_mutator]{{$}}
 
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -DFLAG=1 -grecord-command-line %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-RECORD-COMMAND-LINE
-; WITH-RECORD-COMMAND-LINE:[info] Found compilation flags in the input bitcode
-; WITH-RECORD-COMMAND-LINE-NOT:{{^.*[Ee]rror.*$}}
-; WITH-RECORD-COMMAND-LINE:[info] Killed mutants (1/1):
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -DFLAG=1 -grecord-command-line %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-RECORD-COMMAND-LINE
+WITH-RECORD-COMMAND-LINE:[info] Found compilation flags in the input bitcode
+WITH-RECORD-COMMAND-LINE-NOT:{{^.*[Ee]rror.*$}}
+WITH-RECORD-COMMAND-LINE:[info] Killed mutants (1/1):
 **/
-

--- a/tests-lit/tests/junk_detection/05_compilation_database_escaped_path/sample.cpp
+++ b/tests-lit/tests/junk_detection/05_compilation_database_escaped_path/sample.cpp
@@ -14,11 +14,10 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode %TEST_CXX_FLAGS -g -O0 -DESCAPED_DEFINITION_STUB=/src/builds/amd64-mull %s -o %s.exe
-; RUN: sed -e "s:%PWD:%S:g" -e "s:#TEST_CXX_FLAGS:%TEST_CXX_FLAGS:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: cd %CURRENT_DIR
-; RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1 | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: cd / && %CLANG_EXEC -fembed-bitcode %TEST_CXX_FLAGS -g -O0 -DESCAPED_DEFINITION_STUB=/src/builds/amd64-mull %s -o %s.exe
+RUN: sed -e "s:%PWD:%S:g" -e "s:#TEST_CXX_FLAGS:%TEST_CXX_FLAGS:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: cd %CURRENT_DIR
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1 | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
 
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
-; CHCK:[info] Killed mutants (1/1):
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 **/

--- a/tests-lit/tests/mutations/logical/cxx_remove_negation/main.cpp
+++ b/tests-lit/tests/mutations/logical/cxx_remove_negation/main.cpp
@@ -12,16 +12,16 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: %MULL_EXEC -test-framework CustomTest -workers=1 -mutators=cxx_remove_negation --ide-reporter-show-killed -reporters=IDE %s.exe | %FILECHECK_EXEC %s
-; CHECK:[info] Running mutants (threads: 1)
-; CHECK:{{^       \[################################\] 2/2\. Finished .*}}
-; CHECK:[info] Killed mutants (1/2):
-; CHECK:{{^.*}}main.cpp:2:10: warning: Killed: Replaced !a with a [cxx_remove_negation]{{$}}
-; CHECK:[info] Survived mutants (1/2):
-; CHECK:{{^.*}}main.cpp:6:10: warning: Survived: Replaced !a with a [cxx_remove_negation]{{$}}
-; CHECK:[info] Mutation score: 50%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: %MULL_EXEC -test-framework CustomTest -workers=1 -mutators=cxx_remove_negation --ide-reporter-show-killed -reporters=IDE %s.exe | %FILECHECK_EXEC %s
+CHECK:[info] Running mutants (threads: 1)
+CHECK:{{^       \[################################\] 2/2\. Finished .*}}
+CHECK:[info] Killed mutants (1/2):
+CHECK:{{^.*}}main.cpp:2:10: warning: Killed: Replaced !a with a [cxx_remove_negation]{{$}}
+CHECK:[info] Survived mutants (1/2):
+CHECK:{{^.*}}main.cpp:6:10: warning: Survived: Replaced !a with a [cxx_remove_negation]{{$}}
+CHECK:[info] Mutation score: 50%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/mutations/math/cxx_add_to_sub/01_no_mutations/sample.cpp
+++ b/tests-lit/tests/mutations/math/cxx_add_to_sub/01_no_mutations/sample.cpp
@@ -1,8 +1,8 @@
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -compdb-path %S/compile_commands.json -compilation-flags="" -reporters=Elements -report-dir=%S -report-name=01_no_mutations %s.exe | %FILECHECK_EXEC %s
-; CHECK:[info] No mutants found. Mutation score: infinitely high
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -compdb-path %S/compile_commands.json -compilation-flags="" -reporters=Elements -report-dir=%S -report-name=01_no_mutations %s.exe | %FILECHECK_EXEC %s
+CHECK:[info] No mutants found. Mutation score: infinitely high
 **/
 
 int main() {

--- a/tests-lit/tests/mutations/math/cxx_add_to_sub/02_basic/sample.cpp
+++ b/tests-lit/tests/mutations/math/cxx_add_to_sub/02_basic/sample.cpp
@@ -1,13 +1,13 @@
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE %s.exe | %FILECHECK_EXEC %s
-; CHECK:[info] Running mutants (threads: 1)
-; CHECK:{{^       \[################################\] 1/1\. Finished .*}}
-; CHECK:[info] All mutations have been killed
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE %s.exe | %FILECHECK_EXEC %s
+CHECK:[info] Running mutants (threads: 1)
+CHECK:{{^       \[################################\] 1/1\. Finished .*}}
+CHECK:[info] All mutations have been killed
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/
 
 int sum(int a, int b) {

--- a/tests-lit/tests/options/-debug/01-debug-option/sample.cpp
+++ b/tests-lit/tests/options/-debug/01-debug-option/sample.cpp
@@ -7,14 +7,14 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-DEBUG
-; RUN: %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed %s.exe -debug | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-DEBUG
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-DEBUG
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed %s.exe -debug | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-DEBUG
 
-; WITHOUT-DEBUG-NOT:{{^.*\[debug\].*$}}
-; WITHOUT-DEBUG:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced + with - [cxx_add_to_sub]{{$}}
+WITHOUT-DEBUG-NOT:{{^.*\[debug\].*$}}
+WITHOUT-DEBUG:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced + with - [cxx_add_to_sub]{{$}}
 
-; WITH-DEBUG:[debug] Diagnostics: Debug Mode enabled. Debug-level messages will be printed.
-; WITH-DEBUG:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced + with - [cxx_add_to_sub]{{$}}
+WITH-DEBUG:[debug] Diagnostics: Debug Mode enabled. Debug-level messages will be printed.
+WITH-DEBUG:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced + with - [cxx_add_to_sub]{{$}}
 **/

--- a/tests-lit/tests/options/-ide-reporter-show-killed/01_one_killed/sample.cpp
+++ b/tests-lit/tests/options/-ide-reporter-show-killed/01_one_killed/sample.cpp
@@ -1,28 +1,28 @@
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
-; RUN: cd %CURRENT_DIR
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
+RUN: cd %CURRENT_DIR
 
 /// IDEReporter is enabled by default. So we test both invocations of mull-cxx:
 /// 1) when -reporters=IDE is not provided
 /// 2) when -reporters=IDE is provided
 
-; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
-; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
-; WITHOUT-OPTION:[info] Running mutants (threads: 1)
-; WITHOUT-OPTION:{{^       \[################################\] 1/1\. Finished .*}}
-; WITHOUT-OPTION-NEXT:[info] All mutations have been killed
-; WITHOUT-OPTION-NEXT:[info] Mutation score: 100%
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
+WITHOUT-OPTION:[info] Running mutants (threads: 1)
+WITHOUT-OPTION:{{^       \[################################\] 1/1\. Finished .*}}
+WITHOUT-OPTION-NEXT:[info] All mutations have been killed
+WITHOUT-OPTION-NEXT:[info] Mutation score: 100%
 
-; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
-; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
-; WITH-OPTION:[info] Running mutants (threads: 1)
-; WITH-OPTION:{{^       \[################################\] 1/1\. Finished .*}}
-; WITH-OPTION:[info] Killed mutants (1/1):
-; WITH-OPTION-NEXT:{{^.*}}sample.cpp:29:18: warning: Killed: Replaced + with -
-; WITH-OPTION-NEXT:  int result = a + b;
-; WITH-OPTION-NEXT:                 ^
-; WITH-OPTION-NEXT:[info] All mutations have been killed
-; WITH-OPTION-NEXT:[info] Mutation score: 100%
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
+WITH-OPTION:[info] Running mutants (threads: 1)
+WITH-OPTION:{{^       \[################################\] 1/1\. Finished .*}}
+WITH-OPTION:[info] Killed mutants (1/1):
+WITH-OPTION-NEXT:{{^.*}}sample.cpp:29:18: warning: Killed: Replaced + with -
+WITH-OPTION-NEXT:  int result = a + b;
+WITH-OPTION-NEXT:                 ^
+WITH-OPTION-NEXT:[info] All mutations have been killed
+WITH-OPTION-NEXT:[info] Mutation score: 100%
 */
 
 int sum(int a, int b) {

--- a/tests-lit/tests/options/-ide-reporter-show-killed/02_one_survived/sample.cpp
+++ b/tests-lit/tests/options/-ide-reporter-show-killed/02_one_survived/sample.cpp
@@ -1,30 +1,30 @@
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
-; RUN: cd %CURRENT_DIR
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
+RUN: cd %CURRENT_DIR
 
 /// IDEReporter is enabled by default. So we test both invocations of mull-cxx:
 /// 1) when -reporters=IDE is not provided
 /// 2) when -reporters=IDE is provided
 
-; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
-; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
-; WITHOUT-OPTION:[info] Running mutants (threads: 1)
-; WITHOUT-OPTION:{{^       \[################################\] 1/1\. Finished .*}}
-; WITHOUT-OPTION:[info] Survived mutants (1/1):
-; WITHOUT-OPTION-NEXT:{{^.*}}sample.cpp:31:18: warning: Survived: Replaced + with -
-; WITHOUT-OPTION-NEXT:  int result = a + b;
-; WITHOUT-OPTION-NEXT:                 ^
-; WITHOUT-OPTION-NEXT:[info] Mutation score: 0%
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
+WITHOUT-OPTION:[info] Running mutants (threads: 1)
+WITHOUT-OPTION:{{^       \[################################\] 1/1\. Finished .*}}
+WITHOUT-OPTION:[info] Survived mutants (1/1):
+WITHOUT-OPTION-NEXT:{{^.*}}sample.cpp:31:18: warning: Survived: Replaced + with -
+WITHOUT-OPTION-NEXT:  int result = a + b;
+WITHOUT-OPTION-NEXT:                 ^
+WITHOUT-OPTION-NEXT:[info] Mutation score: 0%
 
-; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
-; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
-; WITH-OPTION:[info] Running mutants (threads: 1)
-; WITH-OPTION:{{^       \[################################\] 1/1\. Finished .*}}
-; WITH-OPTION:[info] Survived mutants (1/1):
-; WITH-OPTION-NEXT:{{^.*}}sample.cpp:31:18: warning: Survived: Replaced + with -
-; WITH-OPTION-NEXT:  int result = a + b;
-; WITH-OPTION-NEXT:                 ^
-; WITH-OPTION-NEXT:[info] Mutation score: 0%
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
+WITH-OPTION:[info] Running mutants (threads: 1)
+WITH-OPTION:{{^       \[################################\] 1/1\. Finished .*}}
+WITH-OPTION:[info] Survived mutants (1/1):
+WITH-OPTION-NEXT:{{^.*}}sample.cpp:31:18: warning: Survived: Replaced + with -
+WITH-OPTION-NEXT:  int result = a + b;
+WITH-OPTION-NEXT:                 ^
+WITH-OPTION-NEXT:[info] Mutation score: 0%
 */
 
 int sum(int a, int b) {

--- a/tests-lit/tests/options/-ide-reporter-show-killed/03_one_surviving_one_killed/sample.cpp
+++ b/tests-lit/tests/options/-ide-reporter-show-killed/03_one_surviving_one_killed/sample.cpp
@@ -1,34 +1,34 @@
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
-; RUN: cd %CURRENT_DIR
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
+RUN: cd %CURRENT_DIR
 
 /// IDEReporter is enabled by default. So we test both invocations of mull-cxx:
 /// 1) when -reporters=IDE is not provided
 /// 2) when -reporters=IDE is provided
 
-; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
-; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
-; WITHOUT-OPTION:[info] Running mutants (threads: 2)
-; WITHOUT-OPTION:{{^       \[################################\] 2/2\. Finished .*}}
-; WITHOUT-OPTION:[info] Survived mutants (1/2):
-; WITHOUT-OPTION-NEXT:{{^.*}}sample.cpp:36:19: warning: Survived: Replaced + with - [cxx_add_to_sub]
-; WITHOUT-OPTION-NEXT:  result = result + 0;
-; WITHOUT-OPTION-NEXT:                  ^
-; WITHOUT-OPTION-NEXT:[info] Mutation score: 50%
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
+WITHOUT-OPTION:[info] Running mutants (threads: 2)
+WITHOUT-OPTION:{{^       \[################################\] 2/2\. Finished .*}}
+WITHOUT-OPTION:[info] Survived mutants (1/2):
+WITHOUT-OPTION-NEXT:{{^.*}}sample.cpp:36:19: warning: Survived: Replaced + with - [cxx_add_to_sub]
+WITHOUT-OPTION-NEXT:  result = result + 0;
+WITHOUT-OPTION-NEXT:                  ^
+WITHOUT-OPTION-NEXT:[info] Mutation score: 50%
 
-; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
-; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
-; WITH-OPTION:[info] Running mutants (threads: 2)
-; WITH-OPTION:{{^       \[################################\] 2/2\. Finished .*}}
-; WITH-OPTION:[info] Killed mutants (1/2):
-; WITH-OPTION-NEXT:{{^.*}}sample.cpp:35:18: warning: Killed: Replaced + with - [cxx_add_to_sub]
-; WITH-OPTION-NEXT:  int result = a + b;
-; WITH-OPTION-NEXT:                 ^
-; WITH-OPTION-NEXT:[info] Survived mutants (1/2):
-; WITH-OPTION-NEXT:{{^.*}}sample.cpp:36:19: warning: Survived: Replaced + with - [cxx_add_to_sub]
-; WITH-OPTION-NEXT:  result = result + 0;
-; WITH-OPTION-NEXT:                  ^
-; WITH-OPTION-NEXT:[info] Mutation score: 50%
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
+WITH-OPTION:[info] Running mutants (threads: 2)
+WITH-OPTION:{{^       \[################################\] 2/2\. Finished .*}}
+WITH-OPTION:[info] Killed mutants (1/2):
+WITH-OPTION-NEXT:{{^.*}}sample.cpp:35:18: warning: Killed: Replaced + with - [cxx_add_to_sub]
+WITH-OPTION-NEXT:  int result = a + b;
+WITH-OPTION-NEXT:                 ^
+WITH-OPTION-NEXT:[info] Survived mutants (1/2):
+WITH-OPTION-NEXT:{{^.*}}sample.cpp:36:19: warning: Survived: Replaced + with - [cxx_add_to_sub]
+WITH-OPTION-NEXT:  result = result + 0;
+WITH-OPTION-NEXT:                  ^
+WITH-OPTION-NEXT:[info] Mutation score: 50%
 */
 
 int sum(int a, int b) {

--- a/tests-lit/tests/options/-strict/01-strict-mode/sample.cpp
+++ b/tests-lit/tests/options/-strict/01-strict-mode/sample.cpp
@@ -3,16 +3,16 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION
-; RUN: (unset TERM; %MULL_EXEC -strict -test-framework CustomTest %s.exe 2>&1; test $? = 1) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION
+RUN: cd / && %CLANG_EXEC %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION
+RUN: (unset TERM; %MULL_EXEC -strict -test-framework CustomTest %s.exe 2>&1; test $? = 1) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION
 
-; WITHOUT-OPTION:[warning] No bitcode: x86_64
-; WITHOUT-OPTION:[info] No mutants found. Mutation score: infinitely high
+WITHOUT-OPTION:[warning] No bitcode: x86_64
+WITHOUT-OPTION:[info] No mutants found. Mutation score: infinitely high
 
-; WITH-OPTION:[info] Diagnostics: Strict Mode enabled. Warning messages will be treated as fatal errors.
-; WITH-OPTION:[warning] No bitcode: x86_64
-; WITH-OPTION:[warning] Strict Mode enabled: warning messages are treated as fatal errors. Exiting now.
-; WITH-OPTION-EMPTY:
+WITH-OPTION:[info] Diagnostics: Strict Mode enabled. Warning messages will be treated as fatal errors.
+WITH-OPTION:[warning] No bitcode: x86_64
+WITH-OPTION:[warning] Strict Mode enabled: warning messages are treated as fatal errors. Exiting now.
+WITH-OPTION-EMPTY:
 **/

--- a/tests-lit/tests/tutorials/hello-world/step-1-version/sample.cpp
+++ b/tests-lit/tests/tutorials/hello-world/step-1-version/sample.cpp
@@ -1,10 +1,10 @@
 /**
-; RUN: %MULL_EXEC -version 2>&1 | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK:Mull: LLVM-based mutation testing
-; CHECK:https://github.com/mull-project/mull
-; CHECK:{{^Version: \d+\.\d+.\d+(-pr[0-9]+|-trunk[0-9]+)?$}}
-; CHECK:{{^Commit: [a-h0-9]+$}}
-; CHECK:{{^Date: .*$}}
-; CHECK:{{^LLVM: \d+\.\d+.\d+$}}
-; CHECK-EMPTY:
+RUN: %MULL_EXEC -version 2>&1 | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK:Mull: LLVM-based mutation testing
+CHECK:https://github.com/mull-project/mull
+CHECK:{{^Version: \d+\.\d+.\d+(-pr[0-9]+|-trunk[0-9]+)?$}}
+CHECK:{{^Commit: [a-h0-9]+$}}
+CHECK:{{^Date: .*$}}
+CHECK:{{^LLVM: \d+\.\d+.\d+$}}
+CHECK-EMPTY:
 */

--- a/tests-lit/tests/tutorials/hello-world/step-2-no-test-framework/sample.cpp
+++ b/tests-lit/tests/tutorials/hello-world/step-2-no-test-framework/sample.cpp
@@ -1,11 +1,11 @@
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: (%MULL_EXEC %s.exe 2>&1; test $? = 1) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: cd / && %CLANG_EXEC -fembed-bitcode %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: (%MULL_EXEC %s.exe 2>&1; test $? = 1) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
 
-; NOTE: LLVM 9.0.0 suddenly prints 2 extra spaces and one extra "-" so adding a
-; NOTE: regex to accommodate.
-; CHECK:mull-cxx: for the{{ {1,3}-?}}-test-framework option: must be specified at least once!
+NOTE: LLVM 9.0.0 suddenly prints 2 extra spaces and one extra "-" so adding a
+NOTE: regex to accommodate.
+CHECK:mull-cxx: for the{{ {1,3}-?}}-test-framework option: must be specified at least once!
 **/
 
 int main() {

--- a/tests-lit/tests/tutorials/hello-world/step-3-no-bitcode/sample.cpp
+++ b/tests-lit/tests/tutorials/hello-world/step-3-no-bitcode/sample.cpp
@@ -1,9 +1,9 @@
 /**
-; RUN: cd / && %CLANG_EXEC %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK:[warning] No bitcode: x86_64
-; CHECK:[info] No mutants found. Mutation score: infinitely high
+RUN: cd / && %CLANG_EXEC %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK:[warning] No bitcode: x86_64
+CHECK:[info] No mutants found. Mutation score: infinitely high
 **/
 
 int main() {

--- a/tests-lit/tests/tutorials/hello-world/step-4-no-mutations-found/sample.cpp
+++ b/tests-lit/tests/tutorials/hello-world/step-4-no-mutations-found/sample.cpp
@@ -1,9 +1,9 @@
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{.*No bitcode: x86_64.*}}
-; CHECK:[info] No mutants found. Mutation score: infinitely high
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{.*No bitcode: x86_64.*}}
+CHECK:[info] No mutants found. Mutation score: infinitely high
 **/
 
 int main() {

--- a/tests-lit/tests/tutorials/hello-world/step-5-one-survived-mutations/sample.cpp
+++ b/tests-lit/tests/tutorials/hello-world/step-5-one-survived-mutations/sample.cpp
@@ -1,12 +1,12 @@
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -ide-reporter-show-killed %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK:[info] Killed mutants (1/2):
-; CHECK:{{^.*}}sample.cpp:13:11: warning: Killed: Replaced >= with < [cxx_ge_to_lt]{{$}}
-; CHECK:[info] Survived mutants (1/2):
-; CHECK:{{^.*}}sample.cpp:13:11: warning: Survived: Replaced >= with > [cxx_ge_to_gt]{{$}}
-; CHECK:[info] Mutation score: 50%
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -ide-reporter-show-killed %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK:[info] Killed mutants (1/2):
+CHECK:{{^.*}}sample.cpp:13:11: warning: Killed: Replaced >= with < [cxx_ge_to_lt]{{$}}
+CHECK:[info] Survived mutants (1/2):
+CHECK:{{^.*}}sample.cpp:13:11: warning: Survived: Replaced >= with > [cxx_ge_to_gt]{{$}}
+CHECK:[info] Mutation score: 50%
 **/
 
 bool valid_age(int age) {

--- a/tests-lit/tests/tutorials/hello-world/step-6-no-survived-mutations/sample.cpp
+++ b/tests-lit/tests/tutorials/hello-world/step-6-no-survived-mutations/sample.cpp
@@ -1,12 +1,12 @@
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -ide-reporter-show-killed %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK:[info] Killed mutants (2/2):
-; CHECK:{{^.*}}sample.cpp:13:11: warning: Killed: Replaced >= with > [cxx_ge_to_gt]{{$}}
-; CHECK:{{^.*}}sample.cpp:13:11: warning: Killed: Replaced >= with < [cxx_ge_to_lt]{{$}}
-; CHECK:[info] All mutations have been killed
-; CHECK:[info] Mutation score: 100%
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -ide-reporter-show-killed %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK:[info] Killed mutants (2/2):
+CHECK:{{^.*}}sample.cpp:13:11: warning: Killed: Replaced >= with > [cxx_ge_to_gt]{{$}}
+CHECK:{{^.*}}sample.cpp:13:11: warning: Killed: Replaced >= with < [cxx_ge_to_lt]{{$}}
+CHECK:[info] All mutations have been killed
+CHECK:[info] Mutation score: 100%
 **/
 
 bool valid_age(int age) {

--- a/tests-lit/tests/white-ast-search/arithmetic/01_add_to_sub/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic/01_add_to_sub/sample.cpp
@@ -7,27 +7,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Add to Sub": {{.*}}sample.cpp:2:12
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Add to Sub": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Add to Sub": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Add to Sub": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Add to Sub": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Add to Sub": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced + with - [cxx_add_to_sub]{{$}}
-; CHECK:  return a + b;
-; CHECK:           ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced + with - [cxx_add_to_sub]{{$}}
+CHECK:  return a + b;
+CHECK:           ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/arithmetic/02_sub_to_add/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic/02_sub_to_add/sample.cpp
@@ -7,27 +7,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_sub_to_add -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_sub_to_add -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Sub to Add": {{.*}}sample.cpp:2:12
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Sub to Add": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Sub to Add": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Sub to Add": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Sub to Add": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Sub to Add": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced - with + [cxx_sub_to_add]{{$}}
-; CHECK:  return a - b;
-; CHECK:           ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced - with + [cxx_sub_to_add]{{$}}
+CHECK:  return a - b;
+CHECK:           ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/arithmetic/03_mul_to_div/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic/03_mul_to_div/sample.cpp
@@ -7,27 +7,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_mul_to_div -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_mul_to_div -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Mul to Div": {{.*}}sample.cpp:2:12
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Mul to Div": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Mul to Div": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Mul to Div": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Mul to Div": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Mul to Div": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced * with / [cxx_mul_to_div]{{$}}
-; CHECK:  return a * b;
-; CHECK:           ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced * with / [cxx_mul_to_div]{{$}}
+CHECK:  return a * b;
+CHECK:           ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/arithmetic/04_div_to_mul/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic/04_div_to_mul/sample.cpp
@@ -7,27 +7,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_div_to_mul -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_div_to_mul -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Div to Mul": {{.*}}sample.cpp:2:12
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Div to Mul": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Div to Mul": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Div to Mul": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Div to Mul": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Div to Mul": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced / with * [cxx_div_to_mul]{{$}}
-; CHECK:  return a / b;
-; CHECK:           ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced / with * [cxx_div_to_mul]{{$}}
+CHECK:  return a / b;
+CHECK:           ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/arithmetic/05_rem_to_div/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic/05_rem_to_div/sample.cpp
@@ -7,27 +7,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_rem_to_div -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_rem_to_div -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Rem to Div": {{.*}}sample.cpp:2:12
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Rem to Div": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Rem to Div": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Rem to Div": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Rem to Div": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Rem to Div": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced % with / [cxx_rem_to_div]{{$}}
-; CHECK:  return a % b;
-; CHECK:           ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced % with / [cxx_rem_to_div]{{$}}
+CHECK:  return a % b;
+CHECK:           ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/arithmetic/06_unary_minus_to_noop/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic/06_unary_minus_to_noop/sample.cpp
@@ -7,27 +7,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_minus_to_noop -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_minus_to_noop -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Unary Minus to Noop": {{.*}}sample.cpp:2:10
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Unary Minus to Noop": {{.*}}sample.cpp:2:10
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Unary Minus to Noop": {{.*}}sample.cpp:2:10
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Unary Minus to Noop": {{.*}}sample.cpp:2:10
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Unary Minus to Noop": {{.*}}sample.cpp:2:10
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Unary Minus to Noop": {{.*}}sample.cpp:2:10
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:10: warning: Killed: Replaced -x with x [cxx_minus_to_noop]{{$}}
-; CHECK:  return -x;
-; CHECK:         ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:10: warning: Killed: Replaced -x with x [cxx_minus_to_noop]{{$}}
+CHECK:  return -x;
+CHECK:         ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/arithmetic_assignment/01_add_assign_to_sub_assign/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic_assignment/01_add_assign_to_sub_assign/sample.cpp
@@ -8,27 +8,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_add_assign_to_sub_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_add_assign_to_sub_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Add-Assign to Sub-Assign": {{.*}}sample.cpp:2:5
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Add-Assign to Sub-Assign": {{.*}}sample.cpp:2:5
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Add-Assign to Sub-Assign": {{.*}}sample.cpp:2:5
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Add-Assign to Sub-Assign": {{.*}}sample.cpp:2:5
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Add-Assign to Sub-Assign": {{.*}}sample.cpp:2:5
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Add-Assign to Sub-Assign": {{.*}}sample.cpp:2:5
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:5: warning: Killed: Replaced += with -= [cxx_add_assign_to_sub_assign]{{$}}
-; CHECK:  a += b;
-; CHECK:    ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:5: warning: Killed: Replaced += with -= [cxx_add_assign_to_sub_assign]{{$}}
+CHECK:  a += b;
+CHECK:    ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/arithmetic_assignment/02_sub_assign_to_add_assign/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic_assignment/02_sub_assign_to_add_assign/sample.cpp
@@ -8,27 +8,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_sub_assign_to_add_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_sub_assign_to_add_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Sub-Assign to Add-Assign": {{.*}}sample.cpp:2:5
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Sub-Assign to Add-Assign": {{.*}}sample.cpp:2:5
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Sub-Assign to Add-Assign": {{.*}}sample.cpp:2:5
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Sub-Assign to Add-Assign": {{.*}}sample.cpp:2:5
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Sub-Assign to Add-Assign": {{.*}}sample.cpp:2:5
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Sub-Assign to Add-Assign": {{.*}}sample.cpp:2:5
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:5: warning: Killed: Replaced -= with += [cxx_sub_assign_to_add_assign]{{$}}
-; CHECK:  a -= b;
-; CHECK:    ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:5: warning: Killed: Replaced -= with += [cxx_sub_assign_to_add_assign]{{$}}
+CHECK:  a -= b;
+CHECK:    ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/arithmetic_assignment/03_mul_assign_to_div_assign/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic_assignment/03_mul_assign_to_div_assign/sample.cpp
@@ -8,27 +8,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_mul_assign_to_div_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_mul_assign_to_div_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Mul-Assign to Div-Assign": {{.*}}sample.cpp:2:5
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Mul-Assign to Div-Assign": {{.*}}sample.cpp:2:5
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Mul-Assign to Div-Assign": {{.*}}sample.cpp:2:5
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Mul-Assign to Div-Assign": {{.*}}sample.cpp:2:5
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Mul-Assign to Div-Assign": {{.*}}sample.cpp:2:5
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Mul-Assign to Div-Assign": {{.*}}sample.cpp:2:5
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:5: warning: Killed: Replaced *= with /= [cxx_mul_assign_to_div_assign]{{$}}
-; CHECK:  a *= b;
-; CHECK:    ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:5: warning: Killed: Replaced *= with /= [cxx_mul_assign_to_div_assign]{{$}}
+CHECK:  a *= b;
+CHECK:    ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/arithmetic_assignment/04_div_assign_to_mul_assign/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic_assignment/04_div_assign_to_mul_assign/sample.cpp
@@ -8,27 +8,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_div_assign_to_mul_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_div_assign_to_mul_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Div-Assign to Mul-Assign": {{.*}}sample.cpp:2:5
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Div-Assign to Mul-Assign": {{.*}}sample.cpp:2:5
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Div-Assign to Mul-Assign": {{.*}}sample.cpp:2:5
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Div-Assign to Mul-Assign": {{.*}}sample.cpp:2:5
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Div-Assign to Mul-Assign": {{.*}}sample.cpp:2:5
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Div-Assign to Mul-Assign": {{.*}}sample.cpp:2:5
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:5: warning: Killed: Replaced /= with *= [cxx_div_assign_to_mul_assign]{{$}}
-; CHECK:  a /= b;
-; CHECK:    ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:5: warning: Killed: Replaced /= with *= [cxx_div_assign_to_mul_assign]{{$}}
+CHECK:  a /= b;
+CHECK:    ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/arithmetic_assignment/05_rem_assign_to_div_assign/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic_assignment/05_rem_assign_to_div_assign/sample.cpp
@@ -8,27 +8,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_rem_assign_to_div_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_rem_assign_to_div_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Rem-Assign to Div-Assign": {{.*}}sample.cpp:2:5
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Rem-Assign to Div-Assign": {{.*}}sample.cpp:2:5
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Rem-Assign to Div-Assign": {{.*}}sample.cpp:2:5
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Rem-Assign to Div-Assign": {{.*}}sample.cpp:2:5
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Rem-Assign to Div-Assign": {{.*}}sample.cpp:2:5
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Rem-Assign to Div-Assign": {{.*}}sample.cpp:2:5
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:5: warning: Killed: Replaced %= with /= [cxx_rem_assign_to_div_assign]{{$}}
-; CHECK:  a %= b;
-; CHECK:    ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:5: warning: Killed: Replaced %= with /= [cxx_rem_assign_to_div_assign]{{$}}
+CHECK:  a %= b;
+CHECK:    ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/bitwise/01_and_to_or/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise/01_and_to_or/sample.cpp
@@ -7,27 +7,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_and_to_or -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_and_to_or -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Bitwise And to Or": {{.*}}sample.cpp:2:12
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Bitwise And to Or": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Bitwise And to Or": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Bitwise And to Or": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Bitwise And to Or": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Bitwise And to Or": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced & with | [cxx_and_to_or]{{$}}
-; CHECK:  return a & b;
-; CHECK:           ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced & with | [cxx_and_to_or]{{$}}
+CHECK:  return a & b;
+CHECK:           ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/bitwise/02_or_to_and/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise/02_or_to_and/sample.cpp
@@ -7,27 +7,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_or_to_and -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_or_to_and -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Bitwise Or to And": {{.*}}sample.cpp:2:12
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Bitwise Or to And": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Bitwise Or to And": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Bitwise Or to And": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Bitwise Or to And": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Bitwise Or to And": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced | with & [cxx_or_to_and]{{$}}
-; CHECK:  return a | b;
-; CHECK:           ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced | with & [cxx_or_to_and]{{$}}
+CHECK:  return a | b;
+CHECK:           ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/bitwise/03_xor_to_or/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise/03_xor_to_or/sample.cpp
@@ -7,27 +7,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_xor_to_or -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_xor_to_or -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Bitwise Xor to Or": {{.*}}sample.cpp:2:12
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Bitwise Xor to Or": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Bitwise Xor to Or": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Bitwise Xor to Or": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Bitwise Xor to Or": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Bitwise Xor to Or": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced ^ with | [cxx_xor_to_or]{{$}}
-; CHECK:  return a ^ b;
-; CHECK:           ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced ^ with | [cxx_xor_to_or]{{$}}
+CHECK:  return a ^ b;
+CHECK:           ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/bitwise/04_left_shift_to_right_shift/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise/04_left_shift_to_right_shift/sample.cpp
@@ -7,27 +7,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_lshift_to_rshift -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_lshift_to_rshift -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Left Shift to Right Shift": {{.*}}sample.cpp:2:12
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Left Shift to Right Shift": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Left Shift to Right Shift": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Left Shift to Right Shift": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Left Shift to Right Shift": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Left Shift to Right Shift": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced << with >> [cxx_lshift_to_rshift]{{$}}
-; CHECK:  return a << b;
-; CHECK:           ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced << with >> [cxx_lshift_to_rshift]{{$}}
+CHECK:  return a << b;
+CHECK:           ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/bitwise/05_right_shift_to_left_shift/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise/05_right_shift_to_left_shift/sample.cpp
@@ -7,27 +7,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_rshift_to_lshift -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_rshift_to_lshift -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Right Shift to Left Shift": {{.*}}sample.cpp:2:12
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Right Shift to Left Shift": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Right Shift to Left Shift": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Right Shift to Left Shift": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Right Shift to Left Shift": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Right Shift to Left Shift": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced >> with << [cxx_rshift_to_lshift]{{$}}
-; CHECK:  return a >> b;
-; CHECK:           ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced >> with << [cxx_rshift_to_lshift]{{$}}
+CHECK:  return a >> b;
+CHECK:           ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/bitwise_assignment/01_and_assign_to_or_assign/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise_assignment/01_and_assign_to_or_assign/sample.cpp
@@ -9,27 +9,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_and_assign_to_or_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_and_assign_to_or_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Bitwise And-Assign to Or-Assign": {{.*}}sample.cpp:3:5
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Bitwise And-Assign to Or-Assign": {{.*}}sample.cpp:3:5
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Bitwise And-Assign to Or-Assign": {{.*}}sample.cpp:3:5
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Bitwise And-Assign to Or-Assign": {{.*}}sample.cpp:3:5
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Bitwise And-Assign to Or-Assign": {{.*}}sample.cpp:3:5
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Bitwise And-Assign to Or-Assign": {{.*}}sample.cpp:3:5
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:3:5: warning: Killed: Replaced &= with |= [cxx_and_assign_to_or_assign]{{$}}
-; CHECK:  c &= b;
-; CHECK:    ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:3:5: warning: Killed: Replaced &= with |= [cxx_and_assign_to_or_assign]{{$}}
+CHECK:  c &= b;
+CHECK:    ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/bitwise_assignment/02_or_to_and/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise_assignment/02_or_to_and/sample.cpp
@@ -9,27 +9,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_or_assign_to_and_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_or_assign_to_and_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Bitwise Or-Assign to And-Assign": {{.*}}sample.cpp:3:5
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Bitwise Or-Assign to And-Assign": {{.*}}sample.cpp:3:5
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Bitwise Or-Assign to And-Assign": {{.*}}sample.cpp:3:5
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Bitwise Or-Assign to And-Assign": {{.*}}sample.cpp:3:5
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Bitwise Or-Assign to And-Assign": {{.*}}sample.cpp:3:5
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Bitwise Or-Assign to And-Assign": {{.*}}sample.cpp:3:5
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:3:5: warning: Killed: Replaced |= with &= [cxx_or_assign_to_and_assign]{{$}}
-; CHECK:  c |= b;
-; CHECK:    ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:3:5: warning: Killed: Replaced |= with &= [cxx_or_assign_to_and_assign]{{$}}
+CHECK:  c |= b;
+CHECK:    ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/bitwise_assignment/03_xor_to_or/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise_assignment/03_xor_to_or/sample.cpp
@@ -9,27 +9,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_xor_assign_to_or_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_xor_assign_to_or_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Bitwise Xor-Assign to Or-Assign": {{.*}}sample.cpp:3:5
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Bitwise Xor-Assign to Or-Assign": {{.*}}sample.cpp:3:5
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Bitwise Xor-Assign to Or-Assign": {{.*}}sample.cpp:3:5
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Bitwise Xor-Assign to Or-Assign": {{.*}}sample.cpp:3:5
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Bitwise Xor-Assign to Or-Assign": {{.*}}sample.cpp:3:5
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Bitwise Xor-Assign to Or-Assign": {{.*}}sample.cpp:3:5
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:3:5: warning: Killed: Replaced ^= with |= [cxx_xor_assign_to_or_assign]{{$}}
-; CHECK:  c ^= b;
-; CHECK:    ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:3:5: warning: Killed: Replaced ^= with |= [cxx_xor_assign_to_or_assign]{{$}}
+CHECK:  c ^= b;
+CHECK:    ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/bitwise_assignment/04_left_shift_to_right_shift/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise_assignment/04_left_shift_to_right_shift/sample.cpp
@@ -9,27 +9,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_lshift_assign_to_rshift_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_lshift_assign_to_rshift_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Left Shift-Assign to Right Shift-Assign": {{.*}}sample.cpp:3:5
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Left Shift-Assign to Right Shift-Assign": {{.*}}sample.cpp:3:5
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Left Shift-Assign to Right Shift-Assign": {{.*}}sample.cpp:3:5
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Left Shift-Assign to Right Shift-Assign": {{.*}}sample.cpp:3:5
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Left Shift-Assign to Right Shift-Assign": {{.*}}sample.cpp:3:5
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Left Shift-Assign to Right Shift-Assign": {{.*}}sample.cpp:3:5
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:3:5: warning: Killed: Replaced <<= with >>= [cxx_lshift_assign_to_rshift_assign]{{$}}
-; CHECK:  c <<= b;
-; CHECK:    ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:3:5: warning: Killed: Replaced <<= with >>= [cxx_lshift_assign_to_rshift_assign]{{$}}
+CHECK:  c <<= b;
+CHECK:    ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/bitwise_assignment/05_right_shift_to_left_shift/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise_assignment/05_right_shift_to_left_shift/sample.cpp
@@ -9,27 +9,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_rshift_assign_to_lshift_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_rshift_assign_to_lshift_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Right Shift-Assign to Left Shift-Assign": {{.*}}sample.cpp:3:5
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Right Shift-Assign to Left Shift-Assign": {{.*}}sample.cpp:3:5
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Right Shift-Assign to Left Shift-Assign": {{.*}}sample.cpp:3:5
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Right Shift-Assign to Left Shift-Assign": {{.*}}sample.cpp:3:5
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Right Shift-Assign to Left Shift-Assign": {{.*}}sample.cpp:3:5
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Right Shift-Assign to Left Shift-Assign": {{.*}}sample.cpp:3:5
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:3:5: warning: Killed: Replaced >>= with <<= [cxx_rshift_assign_to_lshift_assign]{{$}}
-; CHECK:  c >>= b;
-; CHECK:    ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:3:5: warning: Killed: Replaced >>= with <<= [cxx_rshift_assign_to_lshift_assign]{{$}}
+CHECK:  c >>= b;
+CHECK:    ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/boundary/01_greater_than_to_greater_than_or_equal/sample.cpp
+++ b/tests-lit/tests/white-ast-search/boundary/01_greater_than_to_greater_than_or_equal/sample.cpp
@@ -7,27 +7,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_gt_to_ge -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_gt_to_ge -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Greater Than to Greater or Equal": {{.*}}sample.cpp:2:12
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Greater Than to Greater or Equal": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Greater Than to Greater or Equal": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Greater Than to Greater or Equal": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Greater Than to Greater or Equal": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Greater Than to Greater or Equal": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced > with >= [cxx_gt_to_ge]{{$}}
-; CHECK:  return a > b;
-; CHECK:           ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced > with >= [cxx_gt_to_ge]{{$}}
+CHECK:  return a > b;
+CHECK:           ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/boundary/02_less_than_to_less_than_or_equal/sample.cpp
+++ b/tests-lit/tests/white-ast-search/boundary/02_less_than_to_less_than_or_equal/sample.cpp
@@ -7,27 +7,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_lt_to_le -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_lt_to_le -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Less Than to Less Or Equal": {{.*}}sample.cpp:2:12
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Less Than to Less Or Equal": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Less Than to Less Or Equal": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Less Than to Less Or Equal": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Less Than to Less Or Equal": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Less Than to Less Or Equal": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced < with <= [cxx_lt_to_le]{{$}}
-; CHECK:  return a < b;
-; CHECK:           ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced < with <= [cxx_lt_to_le]{{$}}
+CHECK:  return a < b;
+CHECK:           ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/boundary/03_greater_or_equal_to_greater_than/sample.cpp
+++ b/tests-lit/tests/white-ast-search/boundary/03_greater_or_equal_to_greater_than/sample.cpp
@@ -7,27 +7,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_ge_to_gt -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_ge_to_gt -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Greater Or Equal to Greater Than": {{.*}}sample.cpp:2:12
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Greater Or Equal to Greater Than": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Greater Or Equal to Greater Than": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Greater Or Equal to Greater Than": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Greater Or Equal to Greater Than": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Greater Or Equal to Greater Than": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced >= with > [cxx_ge_to_gt]{{$}}
-; CHECK:  return a >= b;
-; CHECK:           ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced >= with > [cxx_ge_to_gt]{{$}}
+CHECK:  return a >= b;
+CHECK:           ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/boundary/04_less_or_equal_to_less_than/sample.cpp
+++ b/tests-lit/tests/white-ast-search/boundary/04_less_or_equal_to_less_than/sample.cpp
@@ -7,27 +7,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_le_to_lt -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_le_to_lt -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Less Or Equal to Less Than": {{.*}}sample.cpp:2:12
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Less Or Equal to Less Than": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Less Or Equal to Less Than": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Less Or Equal to Less Than": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Less Or Equal to Less Than": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Less Or Equal to Less Than": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced <= with < [cxx_le_to_lt]{{$}}
-; CHECK:  return a <= b;
-; CHECK:           ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced <= with < [cxx_le_to_lt]{{$}}
+CHECK:  return a <= b;
+CHECK:           ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/comparison/01_equal_to_not_equal/sample.cpp
+++ b/tests-lit/tests/white-ast-search/comparison/01_equal_to_not_equal/sample.cpp
@@ -7,27 +7,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_eq_to_ne -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_eq_to_ne -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Equal to Not Equal": {{.*}}sample.cpp:2:12
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Equal to Not Equal": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Equal to Not Equal": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Equal to Not Equal": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Equal to Not Equal": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Equal to Not Equal": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced == with != [cxx_eq_to_ne]{{$}}
-; CHECK:  return a == b;
-; CHECK:           ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced == with != [cxx_eq_to_ne]{{$}}
+CHECK:  return a == b;
+CHECK:           ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/comparison/02_not_equal_to_equal/sample.cpp
+++ b/tests-lit/tests/white-ast-search/comparison/02_not_equal_to_equal/sample.cpp
@@ -7,27 +7,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_ne_to_eq -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_ne_to_eq -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Not Equal to Equal": {{.*}}sample.cpp:2:12
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Not Equal to Equal": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Not Equal to Equal": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Not Equal to Equal": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Not Equal to Equal": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Not Equal to Equal": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced != with == [cxx_ne_to_eq]{{$}}
-; CHECK:  return a != b;
-; CHECK:           ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced != with == [cxx_ne_to_eq]{{$}}
+CHECK:  return a != b;
+CHECK:           ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/comparison/03_greater_than_to_less_than_or_equal/sample.cpp
+++ b/tests-lit/tests/white-ast-search/comparison/03_greater_than_to_less_than_or_equal/sample.cpp
@@ -7,27 +7,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_gt_to_le -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_gt_to_le -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Greater Than to Less Or Equal": {{.*}}sample.cpp:2:12
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Greater Than to Less Or Equal": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Greater Than to Less Or Equal": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Greater Than to Less Or Equal": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Greater Than to Less Or Equal": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Greater Than to Less Or Equal": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced > with <= [cxx_gt_to_le]{{$}}
-; CHECK:  return a > b;
-; CHECK:           ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced > with <= [cxx_gt_to_le]{{$}}
+CHECK:  return a > b;
+CHECK:           ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/comparison/04_less_than_to_greater_than_or_equal/sample.cpp
+++ b/tests-lit/tests/white-ast-search/comparison/04_less_than_to_greater_than_or_equal/sample.cpp
@@ -7,27 +7,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_lt_to_ge -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_lt_to_ge -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Less Than to Greater Or Equal": {{.*}}sample.cpp:2:12
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Less Than to Greater Or Equal": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Less Than to Greater Or Equal": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Less Than to Greater Or Equal": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Less Than to Greater Or Equal": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Less Than to Greater Or Equal": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced < with >= [cxx_lt_to_ge]{{$}}
-; CHECK:  return a < b;
-; CHECK:           ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced < with >= [cxx_lt_to_ge]{{$}}
+CHECK:  return a < b;
+CHECK:           ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/comparison/05_greater_or_equal_to_less_than/sample.cpp
+++ b/tests-lit/tests/white-ast-search/comparison/05_greater_or_equal_to_less_than/sample.cpp
@@ -7,27 +7,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_ge_to_lt -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_ge_to_lt -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Greater Or Equal to Less Than": {{.*}}sample.cpp:2:12
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Greater Or Equal to Less Than": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Greater Or Equal to Less Than": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Greater Or Equal to Less Than": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Greater Or Equal to Less Than": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Greater Or Equal to Less Than": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced >= with < [cxx_ge_to_lt]{{$}}
-; CHECK:  return a >= b;
-; CHECK:           ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced >= with < [cxx_ge_to_lt]{{$}}
+CHECK:  return a >= b;
+CHECK:           ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/comparison/06_less_or_equal_to_greater_than/sample.cpp
+++ b/tests-lit/tests/white-ast-search/comparison/06_less_or_equal_to_greater_than/sample.cpp
@@ -7,27 +7,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_le_to_gt -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_le_to_gt -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Less Or Equal To Greater Than": {{.*}}sample.cpp:2:12
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Less Or Equal To Greater Than": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Less Or Equal To Greater Than": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Less Or Equal To Greater Than": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Less Or Equal To Greater Than": {{.*}}sample.cpp:2:12
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Less Or Equal To Greater Than": {{.*}}sample.cpp:2:12
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced <= with > [cxx_le_to_gt]{{$}}
-; CHECK:  return a <= b;
-; CHECK:           ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced <= with > [cxx_le_to_gt]{{$}}
+CHECK:  return a <= b;
+CHECK:           ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/const_assignment/01_init_const/sample.cpp
+++ b/tests-lit/tests/white-ast-search/const_assignment/01_init_const/sample.cpp
@@ -10,27 +10,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_init_const -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_init_const -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Init Const": {{.*}}sample.cpp:4:7
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Init Const": {{.*}}sample.cpp:4:7
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Init Const": {{.*}}sample.cpp:4:7
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Init Const": {{.*}}sample.cpp:4:7
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Init Const": {{.*}}sample.cpp:4:7
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Init Const": {{.*}}sample.cpp:4:7
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:4:7: warning: Killed: Replaced 'T a = b' with 'T a = 42' [cxx_init_const]{{$}}
-; CHECK:  int var = 0;
-; CHECK:      ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:4:7: warning: Killed: Replaced 'T a = b' with 'T a = 42' [cxx_init_const]{{$}}
+CHECK:  int var = 0;
+CHECK:      ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/const_assignment/02_assign_const/sample.cpp
+++ b/tests-lit/tests/white-ast-search/const_assignment/02_assign_const/sample.cpp
@@ -11,27 +11,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_assign_const -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_assign_const -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Assign Const": {{.*}}sample.cpp:5:7
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Assign Const": {{.*}}sample.cpp:5:7
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Assign Const": {{.*}}sample.cpp:5:7
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Assign Const": {{.*}}sample.cpp:5:7
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Assign Const": {{.*}}sample.cpp:5:7
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Assign Const": {{.*}}sample.cpp:5:7
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:5:7: warning: Killed: Replaced 'a = b' with 'a = 42' [cxx_assign_const]{{$}}
-; CHECK:  var = 0;
-; CHECK:      ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:5:7: warning: Killed: Replaced 'a = b' with 'a = 42' [cxx_assign_const]{{$}}
+CHECK:  var = 0;
+CHECK:      ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/experimental/remove_void/01_basic/sample.cpp
+++ b/tests-lit/tests/white-ast-search/experimental/remove_void/01_basic/sample.cpp
@@ -13,27 +13,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=remove_void_function_mutator -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=remove_void_function_mutator -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Remove Void": {{.*}}sample.cpp:7:3
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Remove Void": {{.*}}sample.cpp:7:3
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Remove Void": {{.*}}sample.cpp:7:3
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Remove Void": {{.*}}sample.cpp:7:3
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Remove Void": {{.*}}sample.cpp:7:3
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Remove Void": {{.*}}sample.cpp:7:3
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:7:3: warning: Killed: Remove Void Call: removed _Z12voidFunctionv [remove_void_function_mutator]{{$}}
-; CHECK:  voidFunction();
-; CHECK:  ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:7:3: warning: Killed: Remove Void Call: removed _Z12voidFunctionv [remove_void_function_mutator]{{$}}
+CHECK:  voidFunction();
+CHECK:  ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/experimental/replace_call/01_basic/sample.cpp
+++ b/tests-lit/tests/white-ast-search/experimental/replace_call/01_basic/sample.cpp
@@ -11,27 +11,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=replace_call_mutator -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=replace_call_mutator -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Replace Call": {{.*}}sample.cpp:6:10
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Replace Call": {{.*}}sample.cpp:6:10
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Replace Call": {{.*}}sample.cpp:6:10
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Replace Call": {{.*}}sample.cpp:6:10
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Replace Call": {{.*}}sample.cpp:6:10
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Replace Call": {{.*}}sample.cpp:6:10
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:6:10: warning: Killed: Replace Call: replaced a call to function _Z6calleev with 42 [replace_call_mutator]{{$}}
-; CHECK:  return callee();
-; CHECK:         ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:6:10: warning: Killed: Replace Call: replaced a call to function _Z6calleev with 42 [replace_call_mutator]{{$}}
+CHECK:  return callee();
+CHECK:         ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/logical/01_and_to_or/sample.cpp
+++ b/tests-lit/tests/white-ast-search/logical/01_and_to_or/sample.cpp
@@ -11,27 +11,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_logical_and_to_or -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_logical_and_to_or -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Logical And to Or": {{.*}}sample.cpp:2:9
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Logical And to Or": {{.*}}sample.cpp:2:9
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Logical And to Or": {{.*}}sample.cpp:2:9
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Logical And to Or": {{.*}}sample.cpp:2:9
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Logical And to Or": {{.*}}sample.cpp:2:9
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Logical And to Or": {{.*}}sample.cpp:2:9
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:9: warning: Killed: AND-OR Replacement [cxx_logical_and_to_or]{{$}}
-; CHECK:  if (a && b) {
-; CHECK:        ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:9: warning: Killed: AND-OR Replacement [cxx_logical_and_to_or]{{$}}
+CHECK:  if (a && b) {
+CHECK:        ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/logical/02_or_to_and/sample.cpp
+++ b/tests-lit/tests/white-ast-search/logical/02_or_to_and/sample.cpp
@@ -11,27 +11,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_logical_or_to_and -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_logical_or_to_and -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Logical Or to And": {{.*}}sample.cpp:2:9
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Logical Or to And": {{.*}}sample.cpp:2:9
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Logical Or to And": {{.*}}sample.cpp:2:9
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Logical Or to And": {{.*}}sample.cpp:2:9
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Logical Or to And": {{.*}}sample.cpp:2:9
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Logical Or to And": {{.*}}sample.cpp:2:9
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:9: warning: Killed: OR-AND Replacement [cxx_logical_or_to_and]{{$}}
-; CHECK:  if (a || b) {
-; CHECK:        ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:9: warning: Killed: OR-AND Replacement [cxx_logical_or_to_and]{{$}}
+CHECK:  if (a || b) {
+CHECK:        ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/logical/cxx_remove_negation/01_unary_negated_to_unary/sample.cpp
+++ b/tests-lit/tests/white-ast-search/logical/cxx_remove_negation/01_unary_negated_to_unary/sample.cpp
@@ -7,27 +7,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_remove_negation -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_remove_negation -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Remove Unary Negation": {{.*}}sample.cpp:2:10
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Remove Unary Negation": {{.*}}sample.cpp:2:10
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Remove Unary Negation": {{.*}}sample.cpp:2:10
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Remove Unary Negation": {{.*}}sample.cpp:2:10
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Remove Unary Negation": {{.*}}sample.cpp:2:10
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Remove Unary Negation": {{.*}}sample.cpp:2:10
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:10: warning: Killed: Replaced !a with a [cxx_remove_negation]{{$}}
-; CHECK:  return !a;
-; CHECK:         ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:10: warning: Killed: Replaced !a with a [cxx_remove_negation]{{$}}
+CHECK:  return !a;
+CHECK:         ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/scalar/01_return_value/sample.cpp
+++ b/tests-lit/tests/white-ast-search/scalar/01_return_value/sample.cpp
@@ -7,27 +7,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=scalar_value_mutator -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=scalar_value_mutator -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Scalar Value": {{.*}}sample.cpp:2:3
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Scalar Value": {{.*}}sample.cpp:2:3
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Scalar Value": {{.*}}sample.cpp:2:3
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Scalar Value": {{.*}}sample.cpp:2:3
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Scalar Value": {{.*}}sample.cpp:2:3
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Scalar Value": {{.*}}sample.cpp:2:3
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:2:3: warning: Killed: Replacing scalar with 0 or 42 [scalar_value_mutator]{{$}}
-; CHECK:  return 0;
-; CHECK:  ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:2:3: warning: Killed: Replacing scalar with 0 or 42 [scalar_value_mutator]{{$}}
+CHECK:  return 0;
+CHECK:  ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/

--- a/tests-lit/tests/white-ast-search/scalar/02_binary_operand/sample.cpp
+++ b/tests-lit/tests/white-ast-search/scalar/02_binary_operand/sample.cpp
@@ -9,27 +9,27 @@ int main() {
 }
 
 /**
-; RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
-; RUN: cd %CURRENT_DIR
-; RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-; RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=scalar_value_mutator -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
-; CHECK-NOT:{{^.*[Ee]rror.*$}}
-; CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=scalar_value_mutator -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+CHECK-NOT:{{^.*[Ee]rror.*$}}
+CHECK-NOT:{{^.*[Ww]arning.*$}}
 
-; CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
-; CHECK:[debug] AST Search: recording mutation "Scalar Value": {{.*}}sample.cpp:4:12
+CHECK:[info] AST Search: looking for mutations in the source files (threads: 1)
+CHECK:[debug] AST Search: recording mutation "Scalar Value": {{.*}}sample.cpp:4:12
 
-; CHECK:[info] Applying filter: AST mutation filter (threads: 1)
-; CHECK:[debug] ASTMutationFilter: whitelisting mutation "Scalar Value": {{.*}}sample.cpp:4:12
+CHECK:[info] Applying filter: AST mutation filter (threads: 1)
+CHECK:[debug] ASTMutationFilter: whitelisting mutation "Scalar Value": {{.*}}sample.cpp:4:12
 
-; CHECK:[info] Applying filter: junk (threads: 1)
-; CHECK:[debug] ASTMutationStorage: recording mutation "Scalar Value": {{.*}}sample.cpp:4:12
+CHECK:[info] Applying filter: junk (threads: 1)
+CHECK:[debug] ASTMutationStorage: recording mutation "Scalar Value": {{.*}}sample.cpp:4:12
 
-; CHECK:[info] Killed mutants (1/1):
-; CHECK:{{^.*}}sample.cpp:4:12: warning: Killed: Replacing scalar with 0 or 42 [scalar_value_mutator]{{$}}
-; CHECK:  return a + 5;
-; CHECK:           ^
-; CHECK:[info] Mutation score: 100%
-; CHECK:[info] Total execution time: {{.*}}
-; CHECK-EMPTY:
+CHECK:[info] Killed mutants (1/1):
+CHECK:{{^.*}}sample.cpp:4:12: warning: Killed: Replacing scalar with 0 or 42 [scalar_value_mutator]{{$}}
+CHECK:  return a + 5;
+CHECK:           ^
+CHECK:[info] Mutation score: 100%
+CHECK:[info] Total execution time: {{.*}}
+CHECK-EMPTY:
 **/


### PR DESCRIPTION
This change removes all semicolons that were massively introduced by me before. When I started working with LIT tests I saw that many tests had `;` before RUN/CHECK statements so I assumed that it was sort of a visual convention used by the LLVM developers. As pointed out by @AlexDenisov, these semicolons simply indicate comment lines in the LLVM IR syntax and they don't have any special meaning for the LIT tests.

No recent PRs touched the LIT tests to it seems safe to remove them all at once.