### PR TITLE
 tests-lit: use --dump-input=fail option everywhere 

### DIFF
--- a/infrastructure/helpers/lit-tests.yaml
+++ b/infrastructure/helpers/lit-tests.yaml
@@ -3,7 +3,7 @@
   pip:
     name:
       - lit==0.9.0
-      - filecheck==0.0.13
+      - filecheck==0.0.16
     executable: pip3
 
 - name: Run LIT tests (Debug)

--- a/tests-lit/tests/invalid-input/01-no-bitcode/sample.cpp
+++ b/tests-lit/tests/invalid-input/01-no-bitcode/sample.cpp
@@ -1,7 +1,7 @@
 /**
 RUN: cd / && %CLANG_EXEC %s -o %s.exe
 RUN: cd %CURRENT_DIR
-RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK:[warning] No bitcode: x86_64
 CHECK:[info] No mutants found. Mutation score: infinitely high
 **/

--- a/tests-lit/tests/invalid-input/02-no-debug-information/sample.cpp
+++ b/tests-lit/tests/invalid-input/02-no-debug-information/sample.cpp
@@ -2,14 +2,14 @@
 /// Without debug information we see the error message.
 RUN: cd / && %CLANG_EXEC -fembed-bitcode %s -o %s.exe
 RUN: cd %CURRENT_DIR
-RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-DEBUG
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-DEBUG
 WITHOUT-DEBUG:[warning] Bitcode module does not have debug information.
 WITHOUT-DEBUG:[info] No mutants found. Mutation score: infinitely high
 
 /// With debug information we do not see the error message.
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
-RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-DEBUG
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-DEBUG
 WITH-DEBUG-NOT:[warning] Bitcode module does not have debug information.
 WITH-DEBUG:[info] Running mutants (threads: 1)
 WITHOUT-OPTION:{{^       \[################################\] 1/1\. Finished .*}}

--- a/tests-lit/tests/junk_detection/00_error_compilation_flags_database_does_not_match_real_flags/sample.cpp
+++ b/tests-lit/tests/junk_detection/00_error_compilation_flags_database_does_not_match_real_flags/sample.cpp
@@ -15,9 +15,9 @@ RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 -DFLAG=1 %s -o %s.exe
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.no_flag.json.template > %S/compile_commands.no_flag.json
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.with_flag.json.template > %S/compile_commands.with_flag.json
 RUN: cd %CURRENT_DIR
-RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
-RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.no_flag.json %s.exe 2>&1 | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-NO-FLAG
-RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.with_flag.json %s.exe 2>&1 | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAG
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE %s.exe | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.no_flag.json %s.exe 2>&1 | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-NO-FLAG
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.with_flag.json %s.exe 2>&1 | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAG
 
 WITHOUT-JUNK-DETECTION:{{^.*}}sample.cpp:5:13: warning: Survived: Remove Void Call: removed llvm.dbg.declare [remove_void_function_mutator]{{$}}
 

--- a/tests-lit/tests/junk_detection/01_junk_detection/sample.cpp
+++ b/tests-lit/tests/junk_detection/01_junk_detection/sample.cpp
@@ -10,8 +10,8 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
 RUN: sed -e "s:%PWD:%s:g" %S/compile_commands.json.template > %S/compile_commands.json
 RUN: cd %CURRENT_DIR
-RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
-RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE %s.exe | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION
 
 WITHOUT-JUNK-DETECTION-NOT:{{^.*}}[info] Running mutants (threads: 1){{$}}
 WITHOUT-JUNK-DETECTION:{{^.*}}sample.cpp:1:13: warning: Survived: Remove Void Call: removed llvm.dbg.declare [remove_void_function_mutator]{{$}}

--- a/tests-lit/tests/junk_detection/02_junk_detection_using_extra_flags/sample.cpp
+++ b/tests-lit/tests/junk_detection/02_junk_detection_using_extra_flags/sample.cpp
@@ -13,9 +13,9 @@ int main() {
 /**
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 -DFLAG=1 %s -o %s.exe
 RUN: cd %CURRENT_DIR
-RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
-RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compilation-flags '-DWRONG_FLAG=1' %s.exe 2>&1 | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-NO-FLAG
-RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compilation-flags '-DFLAG=1' %s.exe 2>&1 | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAG
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE %s.exe | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compilation-flags '-DWRONG_FLAG=1' %s.exe 2>&1 | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-NO-FLAG
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compilation-flags '-DFLAG=1' %s.exe 2>&1 | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAG
 
 WITHOUT-JUNK-DETECTION:{{^.*}}sample.cpp:5:13: warning: Survived: Remove Void Call: removed llvm.dbg.declare [remove_void_function_mutator]{{$}}
 

--- a/tests-lit/tests/junk_detection/03_junk_detection_merging_comp_db_and_extra_flags/sample.cpp
+++ b/tests-lit/tests/junk_detection/03_junk_detection_merging_comp_db_and_extra_flags/sample.cpp
@@ -18,8 +18,8 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 -DFLAG_VIA_COMP_DB=1 -DFLAG_VIA_EXTRA_FLAGS=1 %s -o %s.exe
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
 RUN: cd %CURRENT_DIR
-RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
-RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json -compilation-flags '-DFLAG_VIA_EXTRA_FLAGS=1' %s.exe 2>&1 | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAGS
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE %s.exe | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json -compilation-flags '-DFLAG_VIA_EXTRA_FLAGS=1' %s.exe 2>&1 | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAGS
 
 WITHOUT-JUNK-DETECTION:{{^.*}}sample.cpp:9:13: warning: Survived: Remove Void Call: removed llvm.dbg.declare [remove_void_function_mutator]{{$}}
 

--- a/tests-lit/tests/junk_detection/04_junk_detection_using_bitcode_compilation_flags_via_record_command_line_flag/sample.cpp
+++ b/tests-lit/tests/junk_detection/04_junk_detection_using_bitcode_compilation_flags_via_record_command_line_flag/sample.cpp
@@ -14,13 +14,13 @@ int main() {
 REQUIRES: LLVM_8_OR_HIGHER
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -DFLAG=1 %s -o %s.exe
 RUN: cd %CURRENT_DIR
-RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-RECORD-COMMAND-LINE
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-RECORD-COMMAND-LINE
 WITHOUT-RECORD-COMMAND-LINE-NOT:Found compilation flags in the input bitcode
 WITHOUT-RECORD-COMMAND-LINE:{{^.*}}sample.cpp:5:13: warning: Survived: Remove Void Call: removed llvm.dbg.declare [remove_void_function_mutator]{{$}}
 
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -DFLAG=1 -grecord-command-line %s -o %s.exe
 RUN: cd %CURRENT_DIR
-RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-RECORD-COMMAND-LINE
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-RECORD-COMMAND-LINE
 WITH-RECORD-COMMAND-LINE:[info] Found compilation flags in the input bitcode
 WITH-RECORD-COMMAND-LINE-NOT:{{^.*[Ee]rror.*$}}
 WITH-RECORD-COMMAND-LINE:[info] Killed mutants (1/1):

--- a/tests-lit/tests/junk_detection/05_compilation_database_escaped_path/sample.cpp
+++ b/tests-lit/tests/junk_detection/05_compilation_database_escaped_path/sample.cpp
@@ -17,7 +17,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode %TEST_CXX_FLAGS -g -O0 -DESCAPED_DEFINITION_STUB=/src/builds/amd64-mull %s -o %s.exe
 RUN: sed -e "s:%PWD:%S:g" -e "s:#TEST_CXX_FLAGS:%TEST_CXX_FLAGS:g" %S/compile_commands.json.template > %S/compile_commands.json
 RUN: cd %CURRENT_DIR
-RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1 | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=all -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1 | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 **/

--- a/tests-lit/tests/mutations/logical/cxx_remove_negation/main.cpp
+++ b/tests-lit/tests/mutations/logical/cxx_remove_negation/main.cpp
@@ -14,7 +14,7 @@ int main() {
 /**
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
 RUN: cd %CURRENT_DIR
-RUN: %MULL_EXEC -test-framework CustomTest -workers=1 -mutators=cxx_remove_negation --ide-reporter-show-killed -reporters=IDE %s.exe | %FILECHECK_EXEC %s
+RUN: %MULL_EXEC -test-framework CustomTest -workers=1 -mutators=cxx_remove_negation --ide-reporter-show-killed -reporters=IDE %s.exe | %FILECHECK_EXEC %s --dump-input=fail
 CHECK:[info] Running mutants (threads: 1)
 CHECK:{{^       \[################################\] 2/2\. Finished .*}}
 CHECK:[info] Killed mutants (1/2):

--- a/tests-lit/tests/mutations/math/cxx_add_to_sub/01_no_mutations/sample.cpp
+++ b/tests-lit/tests/mutations/math/cxx_add_to_sub/01_no_mutations/sample.cpp
@@ -1,7 +1,7 @@
 /**
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
 RUN: cd %CURRENT_DIR
-RUN: %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -compdb-path %S/compile_commands.json -compilation-flags="" -reporters=Elements -report-dir=%S -report-name=01_no_mutations %s.exe | %FILECHECK_EXEC %s
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -compdb-path %S/compile_commands.json -compilation-flags="" -reporters=Elements -report-dir=%S -report-name=01_no_mutations %s.exe | %FILECHECK_EXEC %s --dump-input=fail
 CHECK:[info] No mutants found. Mutation score: infinitely high
 **/
 

--- a/tests-lit/tests/mutations/math/cxx_add_to_sub/02_basic/sample.cpp
+++ b/tests-lit/tests/mutations/math/cxx_add_to_sub/02_basic/sample.cpp
@@ -1,7 +1,7 @@
 /**
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
 RUN: cd %CURRENT_DIR
-RUN: %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE %s.exe | %FILECHECK_EXEC %s
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE %s.exe | %FILECHECK_EXEC %s --dump-input=fail
 CHECK:[info] Running mutants (threads: 1)
 CHECK:{{^       \[################################\] 1/1\. Finished .*}}
 CHECK:[info] All mutations have been killed

--- a/tests-lit/tests/options/-debug/01-debug-option/sample.cpp
+++ b/tests-lit/tests/options/-debug/01-debug-option/sample.cpp
@@ -9,8 +9,8 @@ int main() {
 /**
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
 RUN: cd %CURRENT_DIR
-RUN: %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-DEBUG
-RUN: %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed %s.exe -debug | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-DEBUG
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-DEBUG
+RUN: %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed %s.exe -debug | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-DEBUG
 
 WITHOUT-DEBUG-NOT:{{^.*\[debug\].*$}}
 WITHOUT-DEBUG:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced + with - [cxx_add_to_sub]{{$}}

--- a/tests-lit/tests/options/-ide-reporter-show-killed/01_one_killed/sample.cpp
+++ b/tests-lit/tests/options/-ide-reporter-show-killed/01_one_killed/sample.cpp
@@ -6,15 +6,15 @@ RUN: cd %CURRENT_DIR
 /// 1) when -reporters=IDE is not provided
 /// 2) when -reporters=IDE is provided
 
-RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
-RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub %s.exe | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE %s.exe | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
 WITHOUT-OPTION:[info] Running mutants (threads: 1)
 WITHOUT-OPTION:{{^       \[################################\] 1/1\. Finished .*}}
 WITHOUT-OPTION-NEXT:[info] All mutations have been killed
 WITHOUT-OPTION-NEXT:[info] Mutation score: 100%
 
-RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
-RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
 WITH-OPTION:[info] Running mutants (threads: 1)
 WITH-OPTION:{{^       \[################################\] 1/1\. Finished .*}}
 WITH-OPTION:[info] Killed mutants (1/1):

--- a/tests-lit/tests/options/-ide-reporter-show-killed/02_one_survived/sample.cpp
+++ b/tests-lit/tests/options/-ide-reporter-show-killed/02_one_survived/sample.cpp
@@ -6,8 +6,8 @@ RUN: cd %CURRENT_DIR
 /// 1) when -reporters=IDE is not provided
 /// 2) when -reporters=IDE is provided
 
-RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
-RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub %s.exe | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE %s.exe | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
 WITHOUT-OPTION:[info] Running mutants (threads: 1)
 WITHOUT-OPTION:{{^       \[################################\] 1/1\. Finished .*}}
 WITHOUT-OPTION:[info] Survived mutants (1/1):
@@ -16,8 +16,8 @@ WITHOUT-OPTION-NEXT:  int result = a + b;
 WITHOUT-OPTION-NEXT:                 ^
 WITHOUT-OPTION-NEXT:[info] Mutation score: 0%
 
-RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
-RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
 WITH-OPTION:[info] Running mutants (threads: 1)
 WITH-OPTION:{{^       \[################################\] 1/1\. Finished .*}}
 WITH-OPTION:[info] Survived mutants (1/1):

--- a/tests-lit/tests/options/-ide-reporter-show-killed/03_one_surviving_one_killed/sample.cpp
+++ b/tests-lit/tests/options/-ide-reporter-show-killed/03_one_surviving_one_killed/sample.cpp
@@ -6,8 +6,8 @@ RUN: cd %CURRENT_DIR
 /// 1) when -reporters=IDE is not provided
 /// 2) when -reporters=IDE is provided
 
-RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
-RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub %s.exe | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE %s.exe | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
 WITHOUT-OPTION:[info] Running mutants (threads: 2)
 WITHOUT-OPTION:{{^       \[################################\] 2/2\. Finished .*}}
 WITHOUT-OPTION:[info] Survived mutants (1/2):
@@ -16,8 +16,8 @@ WITHOUT-OPTION-NEXT:  result = result + 0;
 WITHOUT-OPTION-NEXT:                  ^
 WITHOUT-OPTION-NEXT:[info] Mutation score: 50%
 
-RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
-RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed %s.exe | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
 WITH-OPTION:[info] Running mutants (threads: 2)
 WITH-OPTION:{{^       \[################################\] 2/2\. Finished .*}}
 WITH-OPTION:[info] Killed mutants (1/2):

--- a/tests-lit/tests/options/-strict/01-strict-mode/sample.cpp
+++ b/tests-lit/tests/options/-strict/01-strict-mode/sample.cpp
@@ -5,8 +5,8 @@ int main() {
 /**
 RUN: cd / && %CLANG_EXEC %s -o %s.exe
 RUN: cd %CURRENT_DIR
-RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION
-RUN: (unset TERM; %MULL_EXEC -strict -test-framework CustomTest %s.exe 2>&1; test $? = 1) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION
+RUN: (unset TERM; %MULL_EXEC -strict -test-framework CustomTest %s.exe 2>&1; test $? = 1) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION
 
 WITHOUT-OPTION:[warning] No bitcode: x86_64
 WITHOUT-OPTION:[info] No mutants found. Mutation score: infinitely high

--- a/tests-lit/tests/tutorials/hello-world/step-1-version/sample.cpp
+++ b/tests-lit/tests/tutorials/hello-world/step-1-version/sample.cpp
@@ -1,5 +1,5 @@
 /**
-RUN: %MULL_EXEC -version 2>&1 | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: %MULL_EXEC -version 2>&1 | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK:Mull: LLVM-based mutation testing
 CHECK:https://github.com/mull-project/mull
 CHECK:{{^Version: \d+\.\d+.\d+(-pr[0-9]+|-trunk[0-9]+)?$}}

--- a/tests-lit/tests/tutorials/hello-world/step-2-no-test-framework/sample.cpp
+++ b/tests-lit/tests/tutorials/hello-world/step-2-no-test-framework/sample.cpp
@@ -1,7 +1,7 @@
 /**
 RUN: cd / && %CLANG_EXEC -fembed-bitcode %s -o %s.exe
 RUN: cd %CURRENT_DIR
-RUN: (%MULL_EXEC %s.exe 2>&1; test $? = 1) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (%MULL_EXEC %s.exe 2>&1; test $? = 1) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 
 NOTE: LLVM 9.0.0 suddenly prints 2 extra spaces and one extra "-" so adding a
 NOTE: regex to accommodate.

--- a/tests-lit/tests/tutorials/hello-world/step-3-no-bitcode/sample.cpp
+++ b/tests-lit/tests/tutorials/hello-world/step-3-no-bitcode/sample.cpp
@@ -1,7 +1,7 @@
 /**
 RUN: cd / && %CLANG_EXEC %s -o %s.exe
 RUN: cd %CURRENT_DIR
-RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK:[warning] No bitcode: x86_64
 CHECK:[info] No mutants found. Mutation score: infinitely high
 **/

--- a/tests-lit/tests/tutorials/hello-world/step-4-no-mutations-found/sample.cpp
+++ b/tests-lit/tests/tutorials/hello-world/step-4-no-mutations-found/sample.cpp
@@ -1,7 +1,7 @@
 /**
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
 RUN: cd %CURRENT_DIR
-RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{.*No bitcode: x86_64.*}}
 CHECK:[info] No mutants found. Mutation score: infinitely high
 **/

--- a/tests-lit/tests/tutorials/hello-world/step-5-one-survived-mutations/sample.cpp
+++ b/tests-lit/tests/tutorials/hello-world/step-5-one-survived-mutations/sample.cpp
@@ -1,7 +1,7 @@
 /**
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
 RUN: cd %CURRENT_DIR
-RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -ide-reporter-show-killed %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -ide-reporter-show-killed %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK:[info] Killed mutants (1/2):
 CHECK:{{^.*}}sample.cpp:13:11: warning: Killed: Replaced >= with < [cxx_ge_to_lt]{{$}}
 CHECK:[info] Survived mutants (1/2):

--- a/tests-lit/tests/tutorials/hello-world/step-6-no-survived-mutations/sample.cpp
+++ b/tests-lit/tests/tutorials/hello-world/step-6-no-survived-mutations/sample.cpp
@@ -1,7 +1,7 @@
 /**
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
 RUN: cd %CURRENT_DIR
-RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -ide-reporter-show-killed %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -test-framework CustomTest -ide-reporter-show-killed %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK:[info] Killed mutants (2/2):
 CHECK:{{^.*}}sample.cpp:13:11: warning: Killed: Replaced >= with > [cxx_ge_to_gt]{{$}}
 CHECK:{{^.*}}sample.cpp:13:11: warning: Killed: Replaced >= with < [cxx_ge_to_lt]{{$}}

--- a/tests-lit/tests/white-ast-search/arithmetic/01_add_to_sub/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic/01_add_to_sub/sample.cpp
@@ -10,7 +10,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/arithmetic/02_sub_to_add/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic/02_sub_to_add/sample.cpp
@@ -10,7 +10,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_sub_to_add -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_sub_to_add -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/arithmetic/03_mul_to_div/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic/03_mul_to_div/sample.cpp
@@ -10,7 +10,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_mul_to_div -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_mul_to_div -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/arithmetic/04_div_to_mul/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic/04_div_to_mul/sample.cpp
@@ -10,7 +10,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_div_to_mul -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_div_to_mul -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/arithmetic/05_rem_to_div/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic/05_rem_to_div/sample.cpp
@@ -10,7 +10,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_rem_to_div -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_rem_to_div -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/arithmetic/06_unary_minus_to_noop/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic/06_unary_minus_to_noop/sample.cpp
@@ -10,7 +10,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_minus_to_noop -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_minus_to_noop -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/arithmetic_assignment/01_add_assign_to_sub_assign/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic_assignment/01_add_assign_to_sub_assign/sample.cpp
@@ -11,7 +11,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_add_assign_to_sub_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_add_assign_to_sub_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/arithmetic_assignment/02_sub_assign_to_add_assign/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic_assignment/02_sub_assign_to_add_assign/sample.cpp
@@ -11,7 +11,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_sub_assign_to_add_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_sub_assign_to_add_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/arithmetic_assignment/03_mul_assign_to_div_assign/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic_assignment/03_mul_assign_to_div_assign/sample.cpp
@@ -11,7 +11,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_mul_assign_to_div_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_mul_assign_to_div_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/arithmetic_assignment/04_div_assign_to_mul_assign/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic_assignment/04_div_assign_to_mul_assign/sample.cpp
@@ -11,7 +11,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_div_assign_to_mul_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_div_assign_to_mul_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/arithmetic_assignment/05_rem_assign_to_div_assign/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic_assignment/05_rem_assign_to_div_assign/sample.cpp
@@ -11,7 +11,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_rem_assign_to_div_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_rem_assign_to_div_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/bitwise/01_and_to_or/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise/01_and_to_or/sample.cpp
@@ -10,7 +10,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_and_to_or -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_and_to_or -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/bitwise/02_or_to_and/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise/02_or_to_and/sample.cpp
@@ -10,7 +10,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_or_to_and -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_or_to_and -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/bitwise/03_xor_to_or/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise/03_xor_to_or/sample.cpp
@@ -10,7 +10,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_xor_to_or -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_xor_to_or -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/bitwise/04_left_shift_to_right_shift/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise/04_left_shift_to_right_shift/sample.cpp
@@ -10,7 +10,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_lshift_to_rshift -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_lshift_to_rshift -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/bitwise/05_right_shift_to_left_shift/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise/05_right_shift_to_left_shift/sample.cpp
@@ -10,7 +10,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_rshift_to_lshift -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_rshift_to_lshift -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/bitwise_assignment/01_and_assign_to_or_assign/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise_assignment/01_and_assign_to_or_assign/sample.cpp
@@ -12,7 +12,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_and_assign_to_or_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_and_assign_to_or_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/bitwise_assignment/02_or_to_and/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise_assignment/02_or_to_and/sample.cpp
@@ -12,7 +12,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_or_assign_to_and_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_or_assign_to_and_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/bitwise_assignment/03_xor_to_or/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise_assignment/03_xor_to_or/sample.cpp
@@ -12,7 +12,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_xor_assign_to_or_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_xor_assign_to_or_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/bitwise_assignment/04_left_shift_to_right_shift/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise_assignment/04_left_shift_to_right_shift/sample.cpp
@@ -12,7 +12,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_lshift_assign_to_rshift_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_lshift_assign_to_rshift_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/bitwise_assignment/05_right_shift_to_left_shift/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise_assignment/05_right_shift_to_left_shift/sample.cpp
@@ -12,7 +12,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_rshift_assign_to_lshift_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_rshift_assign_to_lshift_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/boundary/01_greater_than_to_greater_than_or_equal/sample.cpp
+++ b/tests-lit/tests/white-ast-search/boundary/01_greater_than_to_greater_than_or_equal/sample.cpp
@@ -10,7 +10,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_gt_to_ge -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_gt_to_ge -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/boundary/02_less_than_to_less_than_or_equal/sample.cpp
+++ b/tests-lit/tests/white-ast-search/boundary/02_less_than_to_less_than_or_equal/sample.cpp
@@ -10,7 +10,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_lt_to_le -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_lt_to_le -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/boundary/03_greater_or_equal_to_greater_than/sample.cpp
+++ b/tests-lit/tests/white-ast-search/boundary/03_greater_or_equal_to_greater_than/sample.cpp
@@ -10,7 +10,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_ge_to_gt -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_ge_to_gt -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/boundary/04_less_or_equal_to_less_than/sample.cpp
+++ b/tests-lit/tests/white-ast-search/boundary/04_less_or_equal_to_less_than/sample.cpp
@@ -10,7 +10,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_le_to_lt -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_le_to_lt -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/boundary/05_greater_than_to_2_mutations/sample.cpp
+++ b/tests-lit/tests/white-ast-search/boundary/05_greater_than_to_2_mutations/sample.cpp
@@ -10,7 +10,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_gt_to_ge -mutators=cxx_gt_to_le -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_gt_to_ge -mutators=cxx_gt_to_le -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/comparison/01_equal_to_not_equal/sample.cpp
+++ b/tests-lit/tests/white-ast-search/comparison/01_equal_to_not_equal/sample.cpp
@@ -10,7 +10,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_eq_to_ne -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_eq_to_ne -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/comparison/02_not_equal_to_equal/sample.cpp
+++ b/tests-lit/tests/white-ast-search/comparison/02_not_equal_to_equal/sample.cpp
@@ -10,7 +10,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_ne_to_eq -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_ne_to_eq -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/comparison/03_greater_than_to_less_than_or_equal/sample.cpp
+++ b/tests-lit/tests/white-ast-search/comparison/03_greater_than_to_less_than_or_equal/sample.cpp
@@ -10,7 +10,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_gt_to_le -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_gt_to_le -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/comparison/04_less_than_to_greater_than_or_equal/sample.cpp
+++ b/tests-lit/tests/white-ast-search/comparison/04_less_than_to_greater_than_or_equal/sample.cpp
@@ -10,7 +10,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_lt_to_ge -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_lt_to_ge -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/comparison/05_greater_or_equal_to_less_than/sample.cpp
+++ b/tests-lit/tests/white-ast-search/comparison/05_greater_or_equal_to_less_than/sample.cpp
@@ -10,7 +10,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_ge_to_lt -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_ge_to_lt -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/comparison/06_less_or_equal_to_greater_than/sample.cpp
+++ b/tests-lit/tests/white-ast-search/comparison/06_less_or_equal_to_greater_than/sample.cpp
@@ -10,7 +10,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_le_to_gt -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_le_to_gt -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/const_assignment/01_init_const/sample.cpp
+++ b/tests-lit/tests/white-ast-search/const_assignment/01_init_const/sample.cpp
@@ -13,7 +13,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_init_const -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_init_const -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/const_assignment/02_assign_const/sample.cpp
+++ b/tests-lit/tests/white-ast-search/const_assignment/02_assign_const/sample.cpp
@@ -14,7 +14,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_assign_const -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_assign_const -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/experimental/remove_void/01_basic/sample.cpp
+++ b/tests-lit/tests/white-ast-search/experimental/remove_void/01_basic/sample.cpp
@@ -16,7 +16,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=remove_void_function_mutator -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=remove_void_function_mutator -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/experimental/replace_call/01_basic/sample.cpp
+++ b/tests-lit/tests/white-ast-search/experimental/replace_call/01_basic/sample.cpp
@@ -14,7 +14,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=replace_call_mutator -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=replace_call_mutator -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/logical/01_and_to_or/sample.cpp
+++ b/tests-lit/tests/white-ast-search/logical/01_and_to_or/sample.cpp
@@ -14,7 +14,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_logical_and_to_or -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_logical_and_to_or -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/logical/02_or_to_and/sample.cpp
+++ b/tests-lit/tests/white-ast-search/logical/02_or_to_and/sample.cpp
@@ -14,7 +14,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_logical_or_to_and -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_logical_or_to_and -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/logical/cxx_remove_negation/01_unary_negated_to_unary/sample.cpp
+++ b/tests-lit/tests/white-ast-search/logical/cxx_remove_negation/01_unary_negated_to_unary/sample.cpp
@@ -10,7 +10,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_remove_negation -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=cxx_remove_negation -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/scalar/01_return_value/sample.cpp
+++ b/tests-lit/tests/white-ast-search/scalar/01_return_value/sample.cpp
@@ -10,7 +10,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=scalar_value_mutator -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=scalar_value_mutator -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 

--- a/tests-lit/tests/white-ast-search/scalar/02_binary_operand/sample.cpp
+++ b/tests-lit/tests/white-ast-search/scalar/02_binary_operand/sample.cpp
@@ -12,7 +12,7 @@ int main() {
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=scalar_value_mutator -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --strict-whitespace --match-full-lines
+RUN: (unset TERM; %MULL_EXEC -debug -enable-ast -test-framework CustomTest -mutators=scalar_value_mutator -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{^.*[Ee]rror.*$}}
 CHECK-NOT:{{^.*[Ww]arning.*$}}
 


### PR DESCRIPTION
As reported in https://github.com/mull-project/mull/issues/734, the LIT test suite contains flaky tests.

This change is the upgrade of FileCheck.py to the latest version where the simplified version of LLVM FileCheck's `--dump-input=fail` option is implemented. 

Without this option, FileCheck prints just a few lines of a failed check's context which makes it hard to understand what exactly went wrong.

With this option, FileCheck prints full input to the console when a test fails. This should provide better visibility for investigating failing LIT tests.