### PR TITLE
cmake: Search for SQLite3 during configuration phase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.14)
 
 if (NOT MULL_VERSION)
 set (MULL_VERSION 0.8.0)

--- a/infrastructure/ubuntu-playbook.yaml
+++ b/infrastructure/ubuntu-playbook.yaml
@@ -42,7 +42,7 @@
 
     - name: Download CMake
       get_url:
-        url: https://github.com/Kitware/CMake/releases/download/v3.12.4/cmake-3.12.4-Linux-x86_64.sh
+        url: https://github.com/Kitware/CMake/releases/download/v3.16.9/cmake-3.16.9-Linux-x86_64.sh
         dest: "{{ working_dir }}/cmake.sh"
       register: download_cmake
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -172,10 +172,11 @@ else ()
 endif ()
 
 find_package(Threads REQUIRED)
+find_package(SQLite3 REQUIRED)
 
 target_link_libraries(mull
   ${MULL_LLVM_LIBRARIES}
-  sqlite3
+  SQLite::SQLite3
   clangTooling
   Threads::Threads
   irm


### PR DESCRIPTION
Signal an error immediately in CMake instead of failing during
compilation if SQLite is not installed.