### PR TITLE
Do not return value from a void stub

### DIFF
--- a/include/mull/Toolchain/Compiler.h
+++ b/include/mull/Toolchain/Compiler.h
@@ -13,12 +13,17 @@ class TargetMachine;
 namespace mull {
 
 class Bitcode;
+class Diagnostics;
 
 class Compiler {
 public:
-  llvm::object::OwningBinary<llvm::object::ObjectFile>
-  compileBitcode(const Bitcode &bitcode, llvm::TargetMachine &machine);
-  llvm::object::OwningBinary<llvm::object::ObjectFile>
-  compileModule(llvm::Module *module, llvm::TargetMachine &machine);
+  explicit Compiler(Diagnostics &diagnostics);
+  llvm::object::OwningBinary<llvm::object::ObjectFile> compileBitcode(const Bitcode &bitcode,
+                                                                      llvm::TargetMachine &machine);
+  llvm::object::OwningBinary<llvm::object::ObjectFile> compileModule(llvm::Module *module,
+                                                                     llvm::TargetMachine &machine);
+
+private:
+  Diagnostics &diagnostics;
 };
 } // namespace mull

--- a/lib/Toolchain/Compiler.cpp
+++ b/lib/Toolchain/Compiler.cpp
@@ -2,22 +2,31 @@
 
 #include "LLVMCompatibility.h"
 #include "mull/Bitcode.h"
+#include "mull/Diagnostics/Diagnostics.h"
 
 #include <llvm/ExecutionEngine/Orc/CompileUtils.h>
 #include <llvm/IR/Module.h>
+#include <llvm/IR/Verifier.h>
 
 using namespace llvm;
 using namespace llvm::object;
 using namespace mull;
 
-OwningBinary<ObjectFile> Compiler::compileBitcode(const Bitcode &bitcode,
-                                                  TargetMachine &machine) {
+Compiler::Compiler(Diagnostics &diagnostics) : diagnostics(diagnostics) {}
+
+OwningBinary<ObjectFile> Compiler::compileBitcode(const Bitcode &bitcode, TargetMachine &machine) {
   return compileModule(bitcode.getModule(), machine);
 }
 
-OwningBinary<ObjectFile> Compiler::compileModule(Module *module,
-                                                 TargetMachine &machine) {
+OwningBinary<ObjectFile> Compiler::compileModule(Module *module, TargetMachine &machine) {
   assert(module);
+
+  std::string error;
+  llvm::raw_string_ostream stream(error);
+  if (llvm::verifyModule(*module, &stream)) {
+    stream.flush();
+    diagnostics.error(error);
+  }
 
   if (module->getDataLayout().isDefault()) {
     module->setDataLayout(machine.createDataLayout());
@@ -25,8 +34,7 @@ OwningBinary<ObjectFile> Compiler::compileModule(Module *module,
 
   orc::SimpleCompiler compiler(machine);
 
-  OwningBinary<ObjectFile> objectFile =
-      llvm_compat::compileModule(compiler, *module);
+  OwningBinary<ObjectFile> objectFile = llvm_compat::compileModule(compiler, *module);
 
   return objectFile;
 }

--- a/lib/Toolchain/Toolchain.cpp
+++ b/lib/Toolchain/Toolchain.cpp
@@ -20,8 +20,8 @@ Toolchain::NativeTarget::NativeTarget() {
 Toolchain::Toolchain(Diagnostics &diagnostics, const Configuration &config)
     : nativeTarget(), machine(llvm::EngineBuilder().selectTarget(
                           llvm::Triple(), "", "", llvm::SmallVector<std::string, 1>())),
-      objectCache(diagnostics, config.cacheEnabled, config.cacheDirectory), simpleCompiler(),
-      nameMangler(machine->createDataLayout()) {}
+      objectCache(diagnostics, config.cacheEnabled, config.cacheDirectory),
+      simpleCompiler(diagnostics), nameMangler(machine->createDataLayout()) {}
 
 ObjectCache &Toolchain::cache() {
   return objectCache;

--- a/tests-lit/tests/mutations/math/cxx_add_to_sub/03_no_ret/sample.cpp
+++ b/tests-lit/tests/mutations/math/cxx_add_to_sub/03_no_ret/sample.cpp
@@ -1,0 +1,17 @@
+// clang-format off
+
+void sum_noop(int a, int b) {
+  a + b;
+}
+
+int main() {
+  sum_noop(-2, 2);
+  return 0;
+}
+
+/**
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
+RUN: cd %CURRENT_DIR
+RUN: unset TERM; %MULL_EXEC -test-framework CustomTest -disable-cache -mutators=cxx_add_to_sub -reporters=IDE %s.exe | %FILECHECK_EXEC %s --dump-input=fail
+CHECK-NOT:[error]
+**/

--- a/tests/CompilerTests.cpp
+++ b/tests/CompilerTests.cpp
@@ -22,8 +22,8 @@ TEST(Compiler, CompileModule) {
   std::unique_ptr<TargetMachine> targetMachine(
       EngineBuilder().selectTarget(Triple(), "", "", SmallVector<std::string, 1>()));
 
-  Compiler compiler;
   Diagnostics diagnostics;
+  Compiler compiler(diagnostics);
   LLVMContext llvmContext;
   BitcodeLoader loader;
   auto bitcode = loader.loadBitcodeAtPath(


### PR DESCRIPTION
Without this fix Mull could generate the following code:

```
define void @foo_mutated() { ... }
define void @foo() {
  call void @foo_mutated()
  ret void <badref>
}
```

attempting to return the result of the stub call.
I could not find a case when it breaks the code in an observable way, but I believe we could've badly miscompiled some of the mutants 😬 