### PR TITLE
cmake: Check for clang-cpp availability in recent Clang versions

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -176,12 +176,20 @@ find_package(Threads REQUIRED)
 target_link_libraries(mull
   ${MULL_LLVM_LIBRARIES}
   sqlite3
-  clangTooling
   Threads::Threads
   irm
   mull-cxx-mutators
   Diagnostics
   )
+
+if (TARGET clang-cpp)
+  # Clang >= 9 provides a monolithic clang-cpp library which provides all clang
+  # library functions previously spread across different libraries
+  target_link_libraries(mull clang-cpp)
+else()
+  target_link_libraries(mull clangTooling)
+endif()
+
 target_include_directories(mull PUBLIC
   ${MULL_INCLUDE_DIRS}
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,8 +76,13 @@ target_link_libraries(mull-tests
   mull
   google-test
   json11
-  clangCodeGen
 )
+
+if (TARGET clang-cpp)
+  target_link_libraries(mull-tests clang-cpp)
+else()
+  target_link_libraries(mull-tests clangCodeGen)
+endif()
 
 target_include_directories(mull-tests PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}
@@ -94,4 +99,3 @@ set_target_properties(mull-tests PROPERTIES
   )
 get_property(dependencies GLOBAL PROPERTY TEST_FIXTURES_DEPENDENCIES)
 add_dependencies(mull-tests ${dependencies})
-


### PR DESCRIPTION
Clang >= 9 provides a monolithic clang-cpp library which provides all clang library functions previously spread across different libraries