### PR TITLE
Docs: add a page with a list of key features

### DIFF
--- a/docs/Features.rst
+++ b/docs/Features.rst
@@ -1,0 +1,9 @@
+Features
+========
+
+Key features are:
+
+- Support of a number of unit testing frameworks: `Google Test <https://github.com/google/googletest>`, `CppUTest <http://cpputest.github.io/>`.
+- Support of a number of `mutation operators <SupportedMutations.html>`_.
+- Generate results in a different formats: compiler-like warnings printed to standard output, SQLite DB	and JSON file that conforms `mutation-testing-elements schema <https://github.com/stryker-mutator/mutation-testing-elements/tree/master/packages/mutation-testing-report-schema>`.
+- Parallel running of tests

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,6 +5,7 @@ Welcome to Mull's documentation!
    :maxdepth: 2
 
    GettingStarted
+   Features
    MutationTestingIntro
    Installation
    Tutorials


### PR DESCRIPTION
It would be helpful for newcomers to describe Mull key features in a documentation.