### PR TITLE
Deduplicate mutations by introducing a separate, higher-level entity

### DIFF
--- a/include/mull/Driver.h
+++ b/include/mull/Driver.h
@@ -56,12 +56,15 @@ private:
   void selectInstructions(std::vector<FunctionUnderTest> &functions);
 
   std::vector<std::unique_ptr<MutationResult>>
-  runMutations(std::vector<MutationPoint *> &mutationPoints);
+  runMutations(std::vector<MutationPoint *> &mutationPoints,
+               std::vector<std::unique_ptr<Mutant>> &mutants);
 
   std::vector<std::unique_ptr<MutationResult>>
-  dryRunMutations(const std::vector<MutationPoint *> &mutationPoints);
+  dryRunMutations(const std::vector<MutationPoint *> &mutationPoints,
+                  std::vector<std::unique_ptr<Mutant>> &mutants);
   std::vector<std::unique_ptr<MutationResult>>
-  normalRunMutations(const std::vector<MutationPoint *> &mutationPoints);
+  normalRunMutations(const std::vector<MutationPoint *> &mutationPoints,
+                     std::vector<std::unique_ptr<Mutant>> &mutants);
 
   std::vector<FunctionUnderTest> getFunctionsUnderTest();
 };

--- a/include/mull/Mutant.h
+++ b/include/mull/Mutant.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace mull {
+
+class MutationPoint;
+struct SourceLocation;
+
+class Mutant {
+public:
+  Mutant(std::string identifier, std::vector<MutationPoint *> points);
+
+  const std::string &getIdentifier() const;
+  const std::vector<MutationPoint *> &getMutationPoints() const;
+  const SourceLocation &getSourceLocation() const;
+  const std::string &getDiagnostics() const;
+  const std::string &getReplacement() const;
+  const std::string &getMutatorIdentifier() const;
+
+private:
+  std::string identifier;
+  std::string mutatorIdentifier;
+  std::vector<MutationPoint *> points;
+};
+
+struct MutantComparator {
+  bool operator()(std::unique_ptr<Mutant> &lhs, std::unique_ptr<Mutant> &rhs);
+  bool operator()(Mutant &lhs, Mutant &rhs);
+};
+
+} // namespace mull

--- a/include/mull/MutationResult.h
+++ b/include/mull/MutationResult.h
@@ -1,24 +1,27 @@
 #pragma once
 
-#include "ExecutionResult.h"
-#include "MutationPoint.h"
+#include "mull/ExecutionResult.h"
 #include <utility>
 
 namespace mull {
 
-class MutationResult {
-  ExecutionResult Result;
-  MutationPoint *MutPoint;
+class Mutant;
 
+class MutationResult {
 public:
-  MutationResult(ExecutionResult R, MutationPoint *MP) : Result(std::move(R)), MutPoint(MP) {}
+  MutationResult(ExecutionResult result, Mutant *mutant)
+      : result(std::move(result)), mutant(mutant) {}
 
   ExecutionResult &getExecutionResult() {
-    return Result;
+    return result;
   }
-  MutationPoint *getMutationPoint() {
-    return MutPoint;
+  Mutant *getMutant() {
+    return mutant;
   }
+
+private:
+  ExecutionResult result;
+  Mutant *mutant;
 };
 
 } // namespace mull

--- a/include/mull/Parallelization/Tasks/DryRunMutantExecutionTask.h
+++ b/include/mull/Parallelization/Tasks/DryRunMutantExecutionTask.h
@@ -1,18 +1,17 @@
 #pragma once
 
-#include <mull/MutationResult.h>
+#include "mull/Mutant.h"
+#include "mull/MutationResult.h"
 
 namespace mull {
 class progress_counter;
-class MutationPoint;
 
 class DryRunMutantExecutionTask {
 public:
-  using In = const std::vector<MutationPoint *>;
+  using In = const std::vector<std::unique_ptr<Mutant>>;
   using Out = std::vector<std::unique_ptr<MutationResult>>;
   using iterator = In::const_iterator;
 
-  void operator()(iterator begin, iterator end, Out &storage,
-                  progress_counter &counter);
+  void operator()(iterator begin, iterator end, Out &storage, progress_counter &counter);
 };
 } // namespace mull

--- a/include/mull/Parallelization/Tasks/MutantExecutionTask.h
+++ b/include/mull/Parallelization/Tasks/MutantExecutionTask.h
@@ -1,18 +1,17 @@
 #pragma once
 
+#include "mull/Mutant.h"
 #include "mull/MutationResult.h"
 
 namespace mull {
 
-class MutationPoint;
 class progress_counter;
 class Diagnostics;
-
 struct Configuration;
 
 class MutantExecutionTask {
 public:
-  using In = const std::vector<MutationPoint *>;
+  using In = const std::vector<std::unique_ptr<Mutant>>;
   using Out = std::vector<std::unique_ptr<MutationResult>>;
   using iterator = In::const_iterator;
 

--- a/include/mull/Result.h
+++ b/include/mull/Result.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Mutant.h"
 #include "MutationPoint.h"
 #include "MutationResult.h"
 #include <vector>
@@ -7,13 +8,16 @@
 namespace mull {
 
 class Result {
-  std::vector<std::unique_ptr<MutationResult>> mutationResults;
-  std::vector<MutationPoint *> mutationPoints;
-
 public:
-  Result(std::vector<std::unique_ptr<MutationResult>> mutationResults,
+  Result(std::vector<std::unique_ptr<Mutant>> mutants,
+         std::vector<std::unique_ptr<MutationResult>> mutationResults,
          std::vector<MutationPoint *> mutationPoints)
-      : mutationResults(std::move(mutationResults)), mutationPoints(std::move(mutationPoints)) {}
+      : mutants(std::move(mutants)), mutationResults(std::move(mutationResults)),
+        mutationPoints(std::move(mutationPoints)) {}
+
+  std::vector<std::unique_ptr<Mutant>> const &getMutants() const {
+    return mutants;
+  }
 
   std::vector<std::unique_ptr<MutationResult>> const &getMutationResults() const {
     return mutationResults;
@@ -22,5 +26,10 @@ public:
   std::vector<MutationPoint *> const &getMutationPoints() const {
     return mutationPoints;
   }
+
+private:
+  std::vector<std::unique_ptr<Mutant>> mutants;
+  std::vector<std::unique_ptr<MutationResult>> mutationResults;
+  std::vector<MutationPoint *> mutationPoints;
 };
 } // namespace mull

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -14,6 +14,7 @@ set(mull_sources
   BitcodeLoader.cpp
   BitcodeMetadataReader.cpp
   MutationsFinder.cpp
+  Mutant.cpp
 
   Parallelization/Tasks/LoadBitcodeFromBinaryTask.cpp
 

--- a/lib/Mutant.cpp
+++ b/lib/Mutant.cpp
@@ -1,0 +1,44 @@
+#include "mull/Mutant.h"
+#include "mull/MutationPoint.h"
+#include "mull/SourceLocation.h"
+
+using namespace mull;
+
+Mutant::Mutant(std::string identifier, std::vector<MutationPoint *> points)
+    : identifier(std::move(identifier)), mutatorIdentifier(points.front()->getMutatorIdentifier()),
+      points(std::move(points)) {}
+
+const std::string &Mutant::getIdentifier() const {
+  return identifier;
+}
+
+const std::vector<MutationPoint *> &Mutant::getMutationPoints() const {
+  return points;
+}
+
+const SourceLocation &Mutant::getSourceLocation() const {
+  return points.front()->getSourceLocation();
+}
+
+const std::string &Mutant::getDiagnostics() const {
+  return points.front()->getDiagnostics();
+}
+
+const std::string &Mutant::getMutatorIdentifier() const {
+  return mutatorIdentifier;
+}
+
+const std::string &Mutant::getReplacement() const {
+  return points.front()->getReplacement();
+}
+
+bool MutantComparator::operator()(std::unique_ptr<Mutant> &lhs, std::unique_ptr<Mutant> &rhs) {
+  return operator()(*lhs, *rhs);
+}
+
+bool MutantComparator::operator()(Mutant &lhs, Mutant &rhs) {
+  const SourceLocation &l = lhs.getSourceLocation();
+  const SourceLocation &r = rhs.getSourceLocation();
+  return std::tie(l.filePath, l.line, l.column, lhs.getMutatorIdentifier()) <
+         std::tie(r.filePath, r.line, r.column, rhs.getMutatorIdentifier());
+}

--- a/lib/Parallelization/Tasks/DryRunMutantExecutionTask.cpp
+++ b/lib/Parallelization/Tasks/DryRunMutantExecutionTask.cpp
@@ -1,5 +1,4 @@
 #include "mull/Parallelization/Tasks/DryRunMutantExecutionTask.h"
-
 #include "mull/Parallelization/Progress.h"
 
 using namespace mull;
@@ -7,9 +6,9 @@ using namespace mull;
 void DryRunMutantExecutionTask::operator()(iterator begin, iterator end, Out &storage,
                                            progress_counter &counter) {
   for (auto it = begin; it != end; it++, counter.increment()) {
-    auto mutationPoint = *it;
+    auto &mutant = *it;
     ExecutionResult result;
     result.status = DryRun;
-    storage.push_back(std::make_unique<MutationResult>(result, mutationPoint));
+    storage.push_back(std::make_unique<MutationResult>(result, mutant.get()));
   }
 }

--- a/lib/Parallelization/Tasks/MutantExecutionTask.cpp
+++ b/lib/Parallelization/Tasks/MutantExecutionTask.cpp
@@ -18,13 +18,13 @@ void MutantExecutionTask::operator()(iterator begin, iterator end, Out &storage,
                                      progress_counter &counter) {
   Runner runner(diagnostics);
   for (auto it = begin; it != end; ++it, counter.increment()) {
-    MutationPoint *mutationPoint = *it;
+    auto &mutant = *it;
     ExecutionResult result = runner.runProgram(executable,
                                                {},
-                                               { mutationPoint->getUserIdentifier() },
+                                               { mutant->getIdentifier() },
                                                baseline.runningTime * 10,
                                                configuration.captureMutantOutput);
 
-    storage.push_back(std::make_unique<MutationResult>(result, mutationPoint));
+    storage.push_back(std::make_unique<MutationResult>(result, mutant.get()));
   }
 }

--- a/lib/Reporters/IDEReporter.cpp
+++ b/lib/Reporters/IDEReporter.cpp
@@ -1,6 +1,7 @@
 #include "mull/Reporters/IDEReporter.h"
 
 #include "mull/Diagnostics/Diagnostics.h"
+#include "mull/Mutant.h"
 #include "mull/MutationResult.h"
 #include "mull/Mutators/Mutator.h"
 #include "mull/Reporters/SourceCodeReader.h"
@@ -19,7 +20,7 @@ static bool mutantSurvived(const ExecutionStatus &status) {
 }
 
 static void printMutant(Diagnostics &diagnostics, SourceCodeReader &sourceCodeReader,
-                        const MutationPoint &mutant, bool survived) {
+                        const Mutant &mutant, bool survived) {
   auto &sourceLocation = mutant.getSourceLocation();
   assert(!sourceLocation.isNull() && "Debug information is missing?");
 
@@ -39,14 +40,14 @@ IDEReporter::IDEReporter(Diagnostics &diagnostics, bool showKilled)
     : diagnostics(diagnostics), showKilled(showKilled), sourceCodeReader() {}
 
 void IDEReporter::reportResults(const Result &result) {
-  if (result.getMutationPoints().empty()) {
+  if (result.getMutants().empty()) {
     diagnostics.info("No mutants found. Mutation score: infinitely high");
     return;
   }
 
-  std::set<MutationPoint *> killedMutants;
+  std::set<Mutant *> killedMutants;
   for (auto &mutationResult : result.getMutationResults()) {
-    auto mutant = mutationResult->getMutationPoint();
+    auto mutant = mutationResult->getMutant();
     auto &executionResult = mutationResult->getExecutionResult();
 
     if (!mutantSurvived(executionResult.status)) {
@@ -54,7 +55,7 @@ void IDEReporter::reportResults(const Result &result) {
     }
   }
 
-  auto survivedMutantsCount = result.getMutationPoints().size() - killedMutants.size();
+  auto survivedMutantsCount = result.getMutants().size() - killedMutants.size();
   auto killedMutantsCount = killedMutants.size();
 
   /// It is important that below we iterate over result.getMutationPoints()
@@ -62,11 +63,11 @@ void IDEReporter::reportResults(const Result &result) {
   /// Optimizing this here was a bad idea: https://github.com/mull-project/mull/pull/640.
   if (showKilled && killedMutantsCount > 0) {
     std::stringstream stringstream;
-    stringstream << "Killed mutants (" << killedMutantsCount << "/"
-                 << result.getMutationPoints().size() << "):";
+    stringstream << "Killed mutants (" << killedMutantsCount << "/" << result.getMutants().size()
+                 << "):";
     diagnostics.info(stringstream.str());
-    for (auto &mutant : result.getMutationPoints()) {
-      if (killedMutants.find(mutant) != killedMutants.end()) {
+    for (auto &mutant : result.getMutants()) {
+      if (killedMutants.find(mutant.get()) != killedMutants.end()) {
         printMutant(diagnostics, sourceCodeReader, *mutant, false);
       }
     }
@@ -75,11 +76,11 @@ void IDEReporter::reportResults(const Result &result) {
   if (survivedMutantsCount > 0) {
     std::stringstream stringstream;
     stringstream << "Survived mutants (" << survivedMutantsCount << "/"
-                 << result.getMutationPoints().size() << "):";
+                 << result.getMutants().size() << "):";
     diagnostics.info(stringstream.str());
 
-    for (auto &mutant : result.getMutationPoints()) {
-      if (killedMutants.find(mutant) == killedMutants.end()) {
+    for (auto &mutant : result.getMutants()) {
+      if (killedMutants.find(mutant.get()) == killedMutants.end()) {
         printMutant(diagnostics, sourceCodeReader, *mutant, true);
       }
     }
@@ -87,7 +88,7 @@ void IDEReporter::reportResults(const Result &result) {
     diagnostics.info("All mutations have been killed");
   }
 
-  auto rawScore = double(killedMutants.size()) / double(result.getMutationPoints().size());
+  auto rawScore = double(killedMutants.size()) / double(result.getMutants().size());
   auto score = uint(rawScore * 100);
   diagnostics.info(std::string("Mutation score: ") + std::to_string(score) + '%');
 }

--- a/lib/Reporters/SQLiteReporter.cpp
+++ b/lib/Reporters/SQLiteReporter.cpp
@@ -3,6 +3,7 @@
 #include "mull/Bitcode.h"
 #include "mull/Diagnostics/Diagnostics.h"
 #include "mull/ExecutionResult.h"
+#include "mull/Mutant.h"
 #include "mull/MutationResult.h"
 #include "mull/Mutators/Mutator.h"
 #include "mull/Result.h"
@@ -85,8 +86,7 @@ void mull::SQLiteReporter::reportResults(const Result &result) {
   sqlite3_prepare(database, insertExecutionResultQuery, -1, &insertExecutionResultStmt, nullptr);
 
   for (auto &mutationResult : result.getMutationResults()) {
-    MutationPoint *mutationPoint = mutationResult->getMutationPoint();
-    const std::string &pointId = mutationPoint->getUserIdentifier();
+    const std::string &pointId = mutationResult->getMutant()->getIdentifier();
 
     ExecutionResult mutationExecutionResult = mutationResult->getExecutionResult();
 
@@ -114,8 +114,7 @@ void mull::SQLiteReporter::reportResults(const Result &result) {
   }
 
   const char *insertMutationPointQuery =
-      "INSERT OR IGNORE INTO mutation_point VALUES (?1, ?2, ?3, ?4, ?5, ?6, "
-      "?7, ?8, ?9, ?10, ?11, ?12)";
+      "INSERT INTO mutation_point VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)";
   sqlite3_stmt *insertMutationPointStmt;
   sqlite3_prepare(database, insertMutationPointQuery, -1, &insertMutationPointStmt, nullptr);
 
@@ -197,7 +196,7 @@ CREATE TABLE mutation_point (
   ideDiagnostics TEXT,
   line_number INT,
   column_number INT,
-  unique_id TEXT UNIQUE
+  unique_id TEXT
 );
 )CreateTables";
 

--- a/tests-lit/tests/deduplication/01/main.cpp
+++ b/tests-lit/tests/deduplication/01/main.cpp
@@ -1,0 +1,25 @@
+template <typename T> T doSomething(T arg1, T arg2) {
+  return arg1 + arg2;
+}
+
+int main() {
+  if (doSomething(2, 3) != 5) {
+    return 1;
+  }
+  if (doSomething(2.0, 0.0) != 2.0) {
+    return 1;
+  }
+  return 0;
+}
+
+// clang-format off
+
+// RUN: cd / && %clang_cxx %s -fembed-bitcode -g -o %s.exe
+// RUN: cd %CURRENT_DIR
+
+// RUN: unset TERM; %MULL_EXEC -linker=%clang_cxx -mutators=cxx_add_to_sub -ide-reporter-show-killed %s.exe 2>&1 | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
+// CHECK:[info] Killed mutants (1/1):
+// CHECK:{{.*}}main.cpp:2:15: warning: Killed: Replaced + with - [cxx_add_to_sub]
+// CHECK:  return arg1 + arg2;
+// CHECK:              ^
+// CHECK:[info] Mutation score: 100%

--- a/tests/MutationTestingElementsReporterTest.cpp
+++ b/tests/MutationTestingElementsReporterTest.cpp
@@ -96,14 +96,18 @@ TEST(MutationTestingElementsReporterTest, integrationTest) {
   mutatedTestExecutionResult.stdoutOutput = "mutatedTestExecutionResult.STDOUT";
   mutatedTestExecutionResult.stderrOutput = "mutatedTestExecutionResult.STDERR";
 
-  auto mutationResult = std::make_unique<MutationResult>(mutatedTestExecutionResult, mutationPoint);
+  auto mutant = std::make_unique<Mutant>(mutationPoint->getUserIdentifier(), mutationPoints);
+  auto mutationResult = std::make_unique<MutationResult>(mutatedTestExecutionResult, mutant.get());
+
+  std::vector<std::unique_ptr<Mutant>> mutants;
+  mutants.push_back(std::move(mutant));
 
   std::vector<std::unique_ptr<MutationResult>> mutationResults;
   mutationResults.push_back(std::move(mutationResult));
 
   MetricsMeasure resultTime;
 
-  Result result(std::move(mutationResults), mutationPoints);
+  Result result(std::move(mutants), std::move(mutationResults), mutationPoints);
 
   /// STEP2. Reporting results to JSON
   MockASTSourceInfoProvider sourceInfoProvider;

--- a/tests/SQLiteReporterTest.cpp
+++ b/tests/SQLiteReporterTest.cpp
@@ -4,6 +4,7 @@
 #include "mull/BitcodeLoader.h"
 #include "mull/Config/Configuration.h"
 #include "mull/Metrics/MetricsMeasure.h"
+#include "mull/Mutant.h"
 #include "mull/MutationsFinder.h"
 #include "mull/Program/Program.h"
 #include "mull/ReachableFunction.h"
@@ -68,14 +69,18 @@ TEST(SQLiteReporter, integrationTest) {
   mutatedTestExecutionResult.stdoutOutput = "mutatedTestExecutionResult.STDOUT";
   mutatedTestExecutionResult.stderrOutput = "mutatedTestExecutionResult.STDERR";
 
-  auto mutationResult = std::make_unique<MutationResult>(mutatedTestExecutionResult, mutationPoint);
+  auto mutant = std::make_unique<Mutant>(mutationPoint->getUserIdentifier(), mutationPoints);
+  auto mutationResult = std::make_unique<MutationResult>(mutatedTestExecutionResult, mutant.get());
+
+  std::vector<std::unique_ptr<Mutant>> mutants;
+  mutants.push_back(std::move(mutant));
 
   std::vector<std::unique_ptr<MutationResult>> mutationResults;
   mutationResults.push_back(std::move(mutationResult));
 
   MetricsMeasure resultTime;
 
-  Result result(std::move(mutationResults), mutationPoints);
+  Result result(std::move(mutants), std::move(mutationResults), mutationPoints);
 
   /// STEP2. Reporting results to SQLite
   SQLiteReporter reporter(diagnostics, "integration test", "");


### PR DESCRIPTION
Closes #782

Now, the mutation point corresponds to the mutation on the bitcode level, while the mutant represents mutation on the source code level.
Ideally, we should move most of the properties to the mutant and leave the mutation point only with bitcode/mutator related info. But I think it makes sense to submit this move as a separate PR.