### PR TITLE
Add support for not covered mutants

### DIFF
--- a/docs/generated/CLIOptions.rst
+++ b/docs/generated/CLIOptions.rst
@@ -44,6 +44,8 @@
 
 --coverage-info string		Path to the coverage info file (LLVM's profdata)
 
+--include-not-covered		Include (but do not run) not covered mutants. Disabled by default
+
 --include-path regex		File/directory paths to whitelist (supports regex)
 
 --exclude-path regex		File/directory paths to ignore (supports regex)

--- a/include/mull/Config/Configuration.h
+++ b/include/mull/Config/Configuration.h
@@ -16,6 +16,7 @@ struct Configuration {
   bool captureTestOutput;
   bool captureMutantOutput;
   bool skipSanityCheckRun;
+  bool includeNotCovered;
 
   int timeout;
   unsigned linkerTimeout;

--- a/include/mull/ExecutionResult.h
+++ b/include/mull/ExecutionResult.h
@@ -11,7 +11,8 @@ enum ExecutionStatus {
   Crashed = 4,
   AbnormalExit = 5,
   DryRun = 6,
-  FailFast = 7
+  FailFast = 7,
+  NotCovered = 8
 };
 
 static std::string executionStatusAsString(ExecutionStatus status) {
@@ -34,6 +35,8 @@ static std::string executionStatusAsString(ExecutionStatus status) {
     return "DryRun";
   case FailFast:
     return "FailFast";
+  case NotCovered:
+    return "NotCovered";
   }
 }
 

--- a/include/mull/FunctionUnderTest.h
+++ b/include/mull/FunctionUnderTest.h
@@ -13,15 +13,17 @@ class Bitcode;
 
 class FunctionUnderTest {
 public:
-  explicit FunctionUnderTest(llvm::Function *function, Bitcode *bitcode);
+  FunctionUnderTest(llvm::Function *function, Bitcode *bitcode, bool covered = true);
   llvm::Function *getFunction() const;
   Bitcode *getBitcode() const;
   const std::vector<llvm::Instruction *> &getSelectedInstructions() const;
+  bool isCovered() const;
   void selectInstructions(const std::vector<InstructionFilter *> &filters);
 
 private:
   llvm::Function *function;
   Bitcode *bitcode;
+  bool covered;
   std::vector<llvm::Instruction *> selectedInstructions;
 };
 

--- a/include/mull/Mutant.h
+++ b/include/mull/Mutant.h
@@ -19,6 +19,7 @@ public:
   const std::string &getDiagnostics() const;
   const std::string &getReplacement() const;
   const std::string &getMutatorIdentifier() const;
+  bool isCovered() const;
 
 private:
   std::string identifier;

--- a/include/mull/MutationPoint.h
+++ b/include/mull/MutationPoint.h
@@ -64,12 +64,16 @@ class MutationPoint {
   const SourceLocation sourceLocation;
   irm::IRMutation *irMutator;
   std::string userIdentifier;
+  bool covered;
 
 public:
   MutationPoint(Mutator *mutator, irm::IRMutation *irMutator, llvm::Instruction *instruction,
                 std::string replacement, Bitcode *m, std::string diagnostics);
 
   ~MutationPoint() = default;
+
+  void setCovered(bool isCovered);
+  bool isCovered();
 
   Mutator *getMutator();
   Mutator *getMutator() const;

--- a/include/mull/MutationsFinder.h
+++ b/include/mull/MutationsFinder.h
@@ -3,8 +3,8 @@
 #include <map>
 #include <vector>
 
+#include "FunctionUnderTest.h"
 #include "MutationPoint.h"
-#include "ReachableFunction.h"
 #include "mull/Mutators/Mutator.h"
 
 namespace mull {

--- a/include/mull/Mutators/CXX/TrivialCXXMutator.h
+++ b/include/mull/Mutators/CXX/TrivialCXXMutator.h
@@ -3,7 +3,7 @@
 #include "mull/Mutators/Mutator.h"
 #include <irm/irm.h>
 #include <memory>
-#include <mull/ReachableFunction.h>
+#include <mull/FunctionUnderTest.h>
 #include <vector>
 
 namespace mull {

--- a/include/mull/Mutators/NegateConditionMutator.h
+++ b/include/mull/Mutators/NegateConditionMutator.h
@@ -3,7 +3,7 @@
 #include "Mutator.h"
 #include <irm/irm.h>
 #include <memory>
-#include <mull/ReachableFunction.h>
+#include <mull/FunctionUnderTest.h>
 #include <vector>
 
 namespace llvm {

--- a/include/mull/Mutators/RemoveVoidFunctionMutator.h
+++ b/include/mull/Mutators/RemoveVoidFunctionMutator.h
@@ -3,7 +3,7 @@
 #include "Mutator.h"
 #include <irm/irm.h>
 #include <memory>
-#include <mull/ReachableFunction.h>
+#include <mull/FunctionUnderTest.h>
 #include <vector>
 
 namespace llvm {

--- a/include/mull/Mutators/ReplaceCallMutator.h
+++ b/include/mull/Mutators/ReplaceCallMutator.h
@@ -3,7 +3,7 @@
 #include "Mutator.h"
 #include <irm/irm.h>
 #include <memory>
-#include <mull/ReachableFunction.h>
+#include <mull/FunctionUnderTest.h>
 #include <vector>
 
 namespace mull {

--- a/include/mull/Mutators/ScalarValueMutator.h
+++ b/include/mull/Mutators/ScalarValueMutator.h
@@ -3,7 +3,7 @@
 #include "Mutator.h"
 #include <irm/irm.h>
 #include <memory>
-#include <mull/ReachableFunction.h>
+#include <mull/FunctionUnderTest.h>
 #include <vector>
 
 namespace llvm {

--- a/include/mull/Parallelization/Tasks/FunctionFilterTask.h
+++ b/include/mull/Parallelization/Tasks/FunctionFilterTask.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "mull/ReachableFunction.h"
+#include "mull/FunctionUnderTest.h"
 #include <vector>
 
 namespace mull {

--- a/include/mull/Parallelization/Tasks/InstructionSelectionTask.h
+++ b/include/mull/Parallelization/Tasks/InstructionSelectionTask.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "mull/ReachableFunction.h"
+#include "mull/FunctionUnderTest.h"
 #include <vector>
 
 namespace mull {

--- a/include/mull/Parallelization/Tasks/SearchMutationPointsTask.h
+++ b/include/mull/Parallelization/Tasks/SearchMutationPointsTask.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "mull/FunctionUnderTest.h"
 #include "mull/MutationPoint.h"
 #include "mull/Mutators/Mutator.h"
-#include "mull/ReachableFunction.h"
 
 namespace mull {
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -34,7 +34,7 @@ set(mull_sources
 
   Bitcode.cpp
   MutationPoint.cpp
-  ReachableFunction.cpp
+  FunctionUnderTest.cpp
 
   IDEDiagnostics.cpp
 

--- a/lib/Config/Configuration.cpp
+++ b/lib/Config/Configuration.cpp
@@ -17,7 +17,7 @@ unsigned MullDefaultLinkerTimeoutMilliseconds = 30000;
 
 Configuration::Configuration()
     : debugEnabled(false), dryRunEnabled(false), captureTestOutput(true), captureMutantOutput(true),
-      skipSanityCheckRun(false), timeout(MullDefaultTimeoutMilliseconds),
+      skipSanityCheckRun(false), includeNotCovered(false), timeout(MullDefaultTimeoutMilliseconds),
       linkerTimeout(MullDefaultLinkerTimeoutMilliseconds), diagnostics(IDEDiagnosticsKind::None),
       parallelization(singleThreadParallelization()) {}
 

--- a/lib/Driver.cpp
+++ b/lib/Driver.cpp
@@ -4,12 +4,12 @@
 #include "mull/Diagnostics/Diagnostics.h"
 #include "mull/Filters/Filters.h"
 #include "mull/Filters/FunctionFilter.h"
+#include "mull/FunctionUnderTest.h"
 #include "mull/Mutant.h"
 #include "mull/MutationResult.h"
 #include "mull/MutationsFinder.h"
 #include "mull/Parallelization/Parallelization.h"
 #include "mull/Program/Program.h"
-#include "mull/ReachableFunction.h"
 #include "mull/Result.h"
 #include "mull/Toolchain/Runner.h"
 
@@ -334,10 +334,15 @@ std::vector<FunctionUnderTest> Driver::getFunctionsUnderTest() {
           }
           if (covered) {
             functionsUnderTest.emplace_back(&function, bitcode.get());
+          } else if (config.includeNotCovered) {
+            functionsUnderTest.emplace_back(&function, bitcode.get(), false);
           }
         }
       }
     } else {
+      if (config.includeNotCovered) {
+        diagnostics.warning("-include-not-covered is enabled, but there is no coverage info!");
+      }
       for (auto &bitcode : program.bitcode()) {
         for (llvm::Function &function : *bitcode->getModule()) {
           functionsUnderTest.emplace_back(&function, bitcode.get());

--- a/lib/FunctionUnderTest.cpp
+++ b/lib/FunctionUnderTest.cpp
@@ -1,12 +1,12 @@
-#include "mull/ReachableFunction.h"
+#include "mull/FunctionUnderTest.h"
 #include "mull/Filters/InstructionFilter.h"
 
 #include <llvm/IR/InstIterator.h>
 
 using namespace mull;
 
-FunctionUnderTest::FunctionUnderTest(llvm::Function *function, Bitcode *bitcode)
-    : function(function), bitcode(bitcode) {}
+FunctionUnderTest::FunctionUnderTest(llvm::Function *function, Bitcode *bitcode, bool covered)
+    : function(function), bitcode(bitcode), covered(covered) {}
 
 llvm::Function *FunctionUnderTest::getFunction() const {
   return function;
@@ -18,6 +18,10 @@ mull::Bitcode *FunctionUnderTest::getBitcode() const {
 
 const std::vector<llvm::Instruction *> &FunctionUnderTest::getSelectedInstructions() const {
   return selectedInstructions;
+}
+
+bool FunctionUnderTest::isCovered() const {
+  return covered;
 }
 
 void FunctionUnderTest::selectInstructions(const std::vector<InstructionFilter *> &filters) {

--- a/lib/Mutant.cpp
+++ b/lib/Mutant.cpp
@@ -32,6 +32,16 @@ const std::string &Mutant::getReplacement() const {
   return points.front()->getReplacement();
 }
 
+bool Mutant::isCovered() const {
+  for (MutationPoint *point : points) {
+    /// Consider a mutant covered if at least one of the mutation points is covered
+    if (point->isCovered()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool MutantComparator::operator()(std::unique_ptr<Mutant> &lhs, std::unique_ptr<Mutant> &rhs) {
   return operator()(*lhs, *rhs);
 }

--- a/lib/MutationPoint.cpp
+++ b/lib/MutationPoint.cpp
@@ -80,10 +80,19 @@ MutationPoint::MutationPoint(Mutator *mutator, irm::IRMutation *irMutator,
     : mutator(mutator), address(MutationPointAddress::addressFromInstruction(instruction)),
       bitcode(m), originalFunction(instruction->getFunction()), mutatedFunction(nullptr),
       diagnostics(std::move(diagnostics)), replacement(std::move(replacement)),
-      sourceLocation(SourceLocation::locationFromInstruction(instruction)), irMutator(irMutator) {
+      sourceLocation(SourceLocation::locationFromInstruction(instruction)), irMutator(irMutator),
+      covered(true) {
   userIdentifier = mutator->getUniqueIdentifier() + ':' + sourceLocation.filePath + ':' +
                    std::to_string(sourceLocation.line) + ':' +
                    std::to_string(sourceLocation.column);
+}
+
+void MutationPoint::setCovered(bool isCovered) {
+  covered = isCovered;
+}
+
+bool MutationPoint::isCovered() {
+  return covered;
 }
 
 Mutator *MutationPoint::getMutator() {

--- a/lib/MutationsFinder.cpp
+++ b/lib/MutationsFinder.cpp
@@ -1,9 +1,9 @@
 #include "mull/MutationsFinder.h"
 
 #include "mull/Config/Configuration.h"
+#include "mull/FunctionUnderTest.h"
 #include "mull/Parallelization/Parallelization.h"
 #include "mull/Program/Program.h"
-#include "mull/ReachableFunction.h"
 
 using namespace mull;
 using namespace llvm;

--- a/lib/Mutators/CXX/LogicalAndToOr.cpp
+++ b/lib/Mutators/CXX/LogicalAndToOr.cpp
@@ -1,7 +1,7 @@
 #include "mull/Mutators/CXX/LogicalAndToOr.h"
 
+#include "mull/FunctionUnderTest.h"
 #include "mull/MutationPoint.h"
-#include "mull/ReachableFunction.h"
 #include "mull/SourceLocation.h"
 
 #include <iterator>

--- a/lib/Mutators/CXX/LogicalOrToAnd.cpp
+++ b/lib/Mutators/CXX/LogicalOrToAnd.cpp
@@ -1,7 +1,7 @@
 #include "mull/Mutators/CXX/LogicalOrToAnd.h"
 
+#include "mull/FunctionUnderTest.h"
 #include "mull/MutationPoint.h"
-#include "mull/ReachableFunction.h"
 #include "mull/SourceLocation.h"
 
 #include <iterator>

--- a/lib/Mutators/CXX/TrivialCXXMutator.cpp
+++ b/lib/Mutators/CXX/TrivialCXXMutator.cpp
@@ -1,6 +1,6 @@
 #include "mull/Mutators/CXX/TrivialCXXMutator.h"
+#include "mull/FunctionUnderTest.h"
 #include "mull/MutationPoint.h"
-#include "mull/ReachableFunction.h"
 #include <irm/irm.h>
 
 using namespace mull;

--- a/lib/Mutators/NegateConditionMutator.cpp
+++ b/lib/Mutators/NegateConditionMutator.cpp
@@ -1,6 +1,6 @@
 #include "mull/Mutators/NegateConditionMutator.h"
+#include "mull/FunctionUnderTest.h"
 #include "mull/MutationPoint.h"
-#include "mull/ReachableFunction.h"
 #include <cassert>
 #include <irm/irm.h>
 #include <sstream>

--- a/lib/Mutators/RemoveVoidFunctionMutator.cpp
+++ b/lib/Mutators/RemoveVoidFunctionMutator.cpp
@@ -1,6 +1,6 @@
 #include "mull/Mutators/RemoveVoidFunctionMutator.h"
+#include "mull/FunctionUnderTest.h"
 #include "mull/MutationPoint.h"
-#include "mull/ReachableFunction.h"
 #include <irm/irm.h>
 #include <llvm/IR/Instructions.h>
 #include <sstream>

--- a/lib/Mutators/ReplaceCallMutator.cpp
+++ b/lib/Mutators/ReplaceCallMutator.cpp
@@ -1,6 +1,6 @@
 #include "mull/Mutators/ReplaceCallMutator.h"
+#include "mull/FunctionUnderTest.h"
 #include "mull/MutationPoint.h"
-#include "mull/ReachableFunction.h"
 #include <cassert>
 #include <irm/irm.h>
 #include <llvm/IR/Instructions.h>

--- a/lib/Mutators/ScalarValueMutator.cpp
+++ b/lib/Mutators/ScalarValueMutator.cpp
@@ -1,6 +1,6 @@
 #include "mull/Mutators/ScalarValueMutator.h"
+#include "mull/FunctionUnderTest.h"
 #include "mull/MutationPoint.h"
-#include "mull/ReachableFunction.h"
 #include <irm/irm.h>
 
 using namespace llvm;

--- a/lib/Parallelization/Tasks/ApplyMutationTask.cpp
+++ b/lib/Parallelization/Tasks/ApplyMutationTask.cpp
@@ -9,6 +9,8 @@ void ApplyMutationTask::operator()(iterator begin, iterator end, Out &storage,
                                    progress_counter &counter) {
   for (auto it = begin; it != end; ++it, counter.increment()) {
     auto point = *it;
-    point->applyMutation();
+    if (point->isCovered()) {
+      point->applyMutation();
+    }
   }
 }

--- a/lib/Parallelization/Tasks/InstructionSelectionTask.cpp
+++ b/lib/Parallelization/Tasks/InstructionSelectionTask.cpp
@@ -1,6 +1,6 @@
 #include "mull/Parallelization/Tasks/InstructionSelectionTask.h"
+#include "mull/FunctionUnderTest.h"
 #include "mull/Parallelization/Progress.h"
-#include "mull/ReachableFunction.h"
 #include <cassert>
 
 using namespace mull;

--- a/lib/Parallelization/Tasks/MutantExecutionTask.cpp
+++ b/lib/Parallelization/Tasks/MutantExecutionTask.cpp
@@ -19,12 +19,16 @@ void MutantExecutionTask::operator()(iterator begin, iterator end, Out &storage,
   Runner runner(diagnostics);
   for (auto it = begin; it != end; ++it, counter.increment()) {
     auto &mutant = *it;
-    ExecutionResult result = runner.runProgram(executable,
-                                               {},
-                                               { mutant->getIdentifier() },
-                                               baseline.runningTime * 10,
-                                               configuration.captureMutantOutput);
-
+    ExecutionResult result;
+    if (mutant->isCovered()) {
+      result = runner.runProgram(executable,
+                                 {},
+                                 { mutant->getIdentifier() },
+                                 baseline.runningTime * 10,
+                                 configuration.captureMutantOutput);
+    } else {
+      result.status = NotCovered;
+    }
     storage.push_back(std::make_unique<MutationResult>(result, mutant.get()));
   }
 }

--- a/lib/Parallelization/Tasks/SearchMutationPointsTask.cpp
+++ b/lib/Parallelization/Tasks/SearchMutationPointsTask.cpp
@@ -23,6 +23,7 @@ void SearchMutationPointsTask::operator()(iterator begin, iterator end, Out &sto
     for (auto &mutator : mutators) {
       auto mutants = mutator->getMutations(bitcode, functionUnderTest);
       for (auto mutant : mutants) {
+        mutant->setCovered(functionUnderTest.isCovered());
         storage.push_back(std::unique_ptr<MutationPoint>(mutant));
       }
     }

--- a/tests-lit/tests/coverage/02/main.c
+++ b/tests-lit/tests/coverage/02/main.c
@@ -1,0 +1,19 @@
+void noop(int a, int b) {
+  a + b;
+}
+
+int main() {
+  return 0;
+}
+
+// clang-format off
+
+// RUN: cd / && %clang_cc %s -fembed-bitcode -g -fprofile-instr-generate -fcoverage-mapping -o %s.exe
+// RUN: cd %CURRENT_DIR
+// RUN: env LLVM_PROFILE_FILE=%s.profraw %s.exe
+// RUN: %llvm_profdata merge %s.profraw -o %s.profdata
+
+// RUN: unset TERM; %MULL_EXEC -linker=%clang_cc -coverage-info=%s.profdata -ide-reporter-show-killed -include-not-covered -linker-flags="-fprofile-instr-generate" -mutators=cxx_add_to_sub %s.exe 2>&1 | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
+// CHECK:[info] Not Covered mutants (1/1):
+// CHECK:{{^.*}}main.c:2:5: warning: Not Covered: Replaced + with - [cxx_add_to_sub]
+// CHECK:[info] Mutation score: 0%

--- a/tests/Helpers/MutationTestBed.cpp
+++ b/tests/Helpers/MutationTestBed.cpp
@@ -3,9 +3,9 @@
 #include "mull/AST/ASTVisitor.h"
 #include "mull/Bitcode.h"
 #include "mull/Diagnostics/Diagnostics.h"
+#include "mull/FunctionUnderTest.h"
 #include "mull/JunkDetection/CXX/ASTStorage.h"
 #include "mull/JunkDetection/CXX/CXXJunkDetector.h"
-#include "mull/ReachableFunction.h"
 
 using namespace mull;
 using namespace mull_test;

--- a/tests/JunkDetection/CXXJunkDetectorTests.cpp
+++ b/tests/JunkDetection/CXXJunkDetectorTests.cpp
@@ -1,12 +1,12 @@
 #include "FixturePaths.h"
 #include "mull/BitcodeLoader.h"
+#include "mull/FunctionUnderTest.h"
 #include "mull/JunkDetection/CXX/CXXJunkDetector.h"
 #include "mull/MutationPoint.h"
 #include "mull/Mutators/NegateConditionMutator.h"
 #include "mull/Mutators/RemoveVoidFunctionMutator.h"
 #include "mull/Mutators/ReplaceCallMutator.h"
 #include "mull/Mutators/ScalarValueMutator.h"
-#include "mull/ReachableFunction.h"
 #include <mull/Diagnostics/Diagnostics.h>
 #include <mull/Mutators/CXX/ArithmeticMutators.h>
 #include <mull/Mutators/CXX/BitwiseMutators.h>

--- a/tests/MutationPointTests.cpp
+++ b/tests/MutationPointTests.cpp
@@ -2,11 +2,11 @@
 #include "TestModuleFactory.h"
 #include "mull/BitcodeLoader.h"
 #include "mull/Config/Configuration.h"
+#include "mull/FunctionUnderTest.h"
 #include "mull/MutationPoint.h"
 #include "mull/Mutators/CXX/LogicalAndToOr.h"
 #include "mull/Mutators/ReplaceCallMutator.h"
 #include "mull/Mutators/ScalarValueMutator.h"
-#include "mull/ReachableFunction.h"
 
 #include <llvm/IR/InstrTypes.h>
 #include <llvm/IR/Instructions.h>

--- a/tests/MutationTestingElementsReporterTest.cpp
+++ b/tests/MutationTestingElementsReporterTest.cpp
@@ -6,11 +6,11 @@
 #include "mull/Bitcode.h"
 #include "mull/BitcodeLoader.h"
 #include "mull/Config/Configuration.h"
+#include "mull/FunctionUnderTest.h"
 #include "mull/JunkDetection/CXX/ASTStorage.h"
 #include "mull/Metrics/MetricsMeasure.h"
 #include "mull/MutationsFinder.h"
 #include "mull/Program/Program.h"
-#include "mull/ReachableFunction.h"
 #include "mull/Reporters/ASTSourceInfoProvider.h"
 #include "mull/Result.h"
 #include <mull/Mutators/CXX/ArithmeticMutators.h>

--- a/tests/Mutators/ConditionalsBoundaryMutatorTests.cpp
+++ b/tests/Mutators/ConditionalsBoundaryMutatorTests.cpp
@@ -2,8 +2,8 @@
 #include <gtest/gtest.h>
 #include <mull/BitcodeLoader.h>
 #include <mull/Diagnostics/Diagnostics.h>
+#include <mull/FunctionUnderTest.h>
 #include <mull/Mutators/CXX/RelationalMutators.h>
-#include <mull/ReachableFunction.h>
 
 using namespace mull;
 using namespace llvm;

--- a/tests/Mutators/NegateConditionMutatorTest.cpp
+++ b/tests/Mutators/NegateConditionMutatorTest.cpp
@@ -1,9 +1,9 @@
 #include "mull/Mutators/NegateConditionMutator.h"
 #include "FixturePaths.h"
 #include "TestModuleFactory.h"
+#include "mull/FunctionUnderTest.h"
 #include "mull/MutationPoint.h"
 #include "mull/Program/Program.h"
-#include "mull/ReachableFunction.h"
 
 #include <cassert>
 #include <llvm/IR/Function.h>

--- a/tests/Mutators/ScalarValueMutatorTest.cpp
+++ b/tests/Mutators/ScalarValueMutatorTest.cpp
@@ -2,8 +2,8 @@
 #include "FixturePaths.h"
 #include "TestModuleFactory.h"
 #include "mull/BitcodeLoader.h"
+#include "mull/FunctionUnderTest.h"
 #include "mull/MutationPoint.h"
-#include "mull/ReachableFunction.h"
 
 #include <gtest/gtest.h>
 #include <irm/irm.h>

--- a/tests/SQLiteReporterTest.cpp
+++ b/tests/SQLiteReporterTest.cpp
@@ -3,11 +3,11 @@
 #include "TestModuleFactory.h"
 #include "mull/BitcodeLoader.h"
 #include "mull/Config/Configuration.h"
+#include "mull/FunctionUnderTest.h"
 #include "mull/Metrics/MetricsMeasure.h"
 #include "mull/Mutant.h"
 #include "mull/MutationsFinder.h"
 #include "mull/Program/Program.h"
-#include "mull/ReachableFunction.h"
 #include "mull/Result.h"
 #include <mull/Mutators/CXX/ArithmeticMutators.h>
 

--- a/tools/mull-cxx/CLIOptions.cpp
+++ b/tools/mull-cxx/CLIOptions.cpp
@@ -139,6 +139,13 @@ opt<bool> tool::EnableAST(
   llvm::cl::desc("Enable \"white\" AST search (disabled by default)"),
   llvm::cl::cat(MullCXXCategory), llvm::cl::init(false));
 
+opt<bool> tool::IncludeNotCovered(
+    "include-not-covered",
+    desc("Include (but do not run) not covered mutants. Disabled by default"),
+    Optional,
+    init(false),
+    cat(MullCXXCategory));
+
 list<ReporterKind> tool::ReportersOption(
   "reporters",
   desc("Choose reporters:"),
@@ -328,6 +335,7 @@ void tool::dumpCLIInterface(Diagnostics &diagnostics) {
       &LinkerTimeout,
 
       &CoverageInfo,
+      &IncludeNotCovered,
 
       &(Option &)IncludePaths,
       &(Option &)ExcludePaths,

--- a/tools/mull-cxx/CLIOptions.h
+++ b/tools/mull-cxx/CLIOptions.h
@@ -52,6 +52,8 @@ extern opt<bool> EnableAST;
 extern list<std::string> ExcludePaths;
 extern list<std::string> IncludePaths;
 
+extern opt<bool> IncludeNotCovered;
+
 class MutatorsCLIOptions {
 public:
   MutatorsCLIOptions(Diagnostics &diagnostics, list<MutatorsOptionIndex> &parameter);

--- a/tools/mull-cxx/mull-cxx.cpp
+++ b/tools/mull-cxx/mull-cxx.cpp
@@ -97,6 +97,7 @@ int main(int argc, char **argv) {
 
   configuration.executable = tool::InputFile.getValue();
   configuration.coverageInfo = tool::CoverageInfo.getValue();
+  configuration.includeNotCovered = tool::IncludeNotCovered.getValue();
 
   if (tool::Workers) {
     mull::ParallelizationConfig parallelizationConfig;


### PR DESCRIPTION
By default Mull generates mutations for every function possible. There is an option (`-coverage-info`) to use the coverage information obtained from Clang (see the [docs](https://mull.readthedocs.io/en/latest/ControlMutationsTutorial.html#code-coverage) for more details) to not mutate unreachable code.

Without coverage information, Mull wastes CPU time by checking mutants that cannot be killed. With the coverage information Mull gives misleading reports saying that the mutation coverage is 100% even if only 10% of code was mutated.

This patch adds an option (`-include-not-covered`) to also include not covered mutants in the report even when code coverage is provided. The not-covered mutants will show up in the reports, but Mull won't actually mutate anything and won't run tests against not covered mutants.

This patch partially addresses #636.

P.S. This is up for review, but I'll do more testing soon as I may have missed some edge cases.

