### PR TITLE
Relax requirements for the Elements reporter

### DIFF
--- a/tests-lit/tests/invalid-input/05-elements-reporter-but-no-compdb/sample.cpp
+++ b/tests-lit/tests/invalid-input/05-elements-reporter-but-no-compdb/sample.cpp
@@ -13,8 +13,8 @@ RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %s -o %s.exe
 RUN: sed -e "s:%PWD:%s:g" %S/compile_commands.json.template > %S/compile_commands.json
 RUN: cd %CURRENT_DIR
 
-RUN: (unset TERM; %MULL_EXEC -linker=%clang_cxx -workers=1 -mutators=cxx_add_to_sub -reporters=Elements "%s.exe" 2>&1; test $? = 1) | %FILECHECK_EXEC "%s" --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-COMPDB-PROVIDED
-WITHOUT-COMPDB-PROVIDED:[error] Mutation Testing Elements Reporter requires compilation database. Please provide it using flags -compdb-path and -compdb-flags.
+RUN: (unset TERM; %MULL_EXEC -linker=%clang_cxx -workers=1 -mutators=cxx_add_to_sub -reporters=Elements "%s.exe" 2>&1; test $? = 0) | %FILECHECK_EXEC "%s" --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-COMPDB-PROVIDED
+WITHOUT-COMPDB-PROVIDED:[warning] Mutation Testing Elements Reporter may not work without compilation database. Consider providing -compdb-path or -compilation-flags.
 
 RUN: (unset TERM; %MULL_EXEC -linker=%clang_cxx -workers=1 -mutators=cxx_add_to_sub -reporters=Elements -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json "%s.exe" 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-COMPDB-PROVIDED
 WITH-COMPDB-PROVIDED:{{^.*}}[info] Running mutants (threads: 1){{$}}

--- a/tools/mull-cxx/CLIOptions.cpp
+++ b/tools/mull-cxx/CLIOptions.cpp
@@ -267,8 +267,8 @@ std::vector<std::unique_ptr<Reporter>> ReportersCLIOptions::reporters(ReporterPa
     } break;
     case ReporterKind::Elements: {
       if (!params.compilationDatabaseAvailable) {
-        diagnostics.error("Mutation Testing Elements Reporter requires compilation database."
-                          " Please provide it using flags -compdb-path and -compdb-flags.");
+        diagnostics.warning("Mutation Testing Elements Reporter may not work without compilation "
+                            "database. Consider providing -compdb-path or -compilation-flags.");
       }
       reporters.emplace_back(
           new mull::MutationTestingElementsReporter(diagnostics, directory, name, provider));


### PR DESCRIPTION
Strictly speaking, the compilation database is not required for the elements reporter to work.
Consider this simple example:
```
int sum(int a, int b) {
  return a + b;
}
int main() {
  return sum(15, -15);
}
```

The AST will be parsed just fine without any issues and the elements report will be generated correctly.
Having a strong requirement in this place forces me to provide a dummy `compilation-flags="-I."` which is a bit annoying.

Any objections @stanislaw? :)