### PR TITLE
Incremental mutation testing using GitDiffFilter

### DIFF
--- a/docs/Features.rst
+++ b/docs/Features.rst
@@ -23,6 +23,9 @@ Features
 
 - Parallelized execution of tests
 
+- `Incremental mutation testing <IncrementalMutationTesting.html>`_.
+  Working with mutations found in Git Diff changesets.
+
 - Mull requires test programs to be compiled with Clang/LLVM. Mull supports
   all LLVM versions starting from LLVM 6.
 

--- a/docs/IncrementalMutationTesting.rst
+++ b/docs/IncrementalMutationTesting.rst
@@ -1,0 +1,28 @@
+Incremental mutation testing
+============================
+
+Normally, Mull looks for mutations in all files of a project. Depending on a
+project's size, a number of mutations can be very large, so running Mull
+against all of them might be a rather slow process. Speed aside, an analysis of
+a large mutation data sets can be very time consuming work to be done by a
+user.
+
+Incremental mutation testing is a feature that enables running Mull only on the
+mutations found in Git Diff changesets. Instead of analysing all files and
+functions, Mull only finds mutations in the source lines that are covered by
+a particular Git Diff changeset.
+
+Example: if a Git diff is created from a project's Git tree and the diff is only
+one line, Mull will only find mutations in that line and will skip everything
+else.
+
+To enable incremental mutation testing, two arguments have to be provided to
+Mull: ``-git-diff-ref=<branch or commit>`` and ``-git-project-root=<path>``
+which is a path to a project's Git root path.
+
+An additional debug option ``-debug`` can be useful for a visualization of how
+exactly Mull whitelists or blacklists found source lines.
+
+**Note:** Incremental mutation testing is an experimental feature. Things might
+go wrong. If you encounter any issues, please report them on the
+`mull/issues <https://github.com/mull-project/mull/issues>`_ tracker.

--- a/docs/generated/CLIOptions.rst
+++ b/docs/generated/CLIOptions.rst
@@ -50,6 +50,10 @@
 
 --exclude-path regex		File/directory paths to ignore (supports regex)
 
+--git-diff-ref git commit		Git branch to run diff against (enables incremental testing)
+
+--git-project-root git project root		Path to project's Git root (used together with -git-diff-ref)
+
 --mutators mutator		Choose mutators:
 
     Groups:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ Welcome to Mull's documentation!
    Installation
    Tutorials
    SupportedMutations
+   IncrementalMutationTesting
    CommandLineReference
    HowMullWorks
    HackingOnMull

--- a/include/mull/Filters/GitDiffFilter.h
+++ b/include/mull/Filters/GitDiffFilter.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "mull/Diagnostics/Diagnostics.h"
+#include "mull/Filters/Filter.h"
+#include "mull/Filters/GitDiffReader.h"
+#include "mull/Filters/InstructionFilter.h"
+
+namespace mull {
+struct SourceLocation;
+class GitDiffFilter : public InstructionFilter {
+public:
+  static GitDiffFilter *createFromGitDiff(Diagnostics &diagnostics,
+                                          const std::string &gitProjectRoot,
+                                          const std::string &gitDiffBranch);
+
+  GitDiffFilter(Diagnostics &diagnostics, GitDiffInfo gitDiffInfo);
+
+  std::string name() override;
+  bool shouldSkip(llvm::Instruction *instruction) const override;
+
+private:
+  Diagnostics &diagnostics;
+  const GitDiffInfo gitDiffInfo;
+};
+} // namespace mull

--- a/include/mull/Filters/GitDiffReader.h
+++ b/include/mull/Filters/GitDiffReader.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "mull/Diagnostics/Diagnostics.h"
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace mull {
+class Diagnostics;
+
+typedef std::pair<int, int> GitDiffSourceFileRange;
+typedef std::vector<GitDiffSourceFileRange> GitDiffSourceFileRanges;
+typedef std::map<std::string, GitDiffSourceFileRanges> GitDiffInfo;
+
+class GitDiffReader {
+public:
+  GitDiffReader(Diagnostics &diagnostics, const std::string gitRepoPath);
+  GitDiffInfo readGitDiff(const std::string &gitBranch);
+  GitDiffInfo parseDiffContent(const std::string &diffContent);
+
+private:
+  Diagnostics &diagnostics;
+  const std::string gitRepoPath;
+};
+} // namespace mull

--- a/include/mull/Toolchain/Runner.h
+++ b/include/mull/Toolchain/Runner.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "mull/ExecutionResult.h"
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -13,7 +14,8 @@ public:
   explicit Runner(Diagnostics &diagnostics);
   ExecutionResult runProgram(const std::string &program, const std::vector<std::string> &arguments,
                              const std::vector<std::string> &environment, long long int timeout,
-                             bool captureOutput);
+                             bool captureOutput,
+                             std::optional<std::string> optionalWorkingDirectory);
 
 private:
   Diagnostics &diagnostics;

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -84,7 +84,11 @@ set(mull_sources
   Filters/JunkMutationFilter.cpp
   Filters/NoDebugInfoFilter.cpp
   Filters/FilePathFilter.cpp
-  JunkDetection/CXX/Visitors/ScalarValueVisitor.cpp)
+  Filters/GitDiffReader.cpp
+  Filters/GitDiffFilter.cpp
+
+  JunkDetection/CXX/Visitors/ScalarValueVisitor.cpp
+)
 
 set(MULL_INCLUDE_DIR ${MULL_SOURCE_DIR}/include/mull)
 

--- a/lib/Driver.cpp
+++ b/lib/Driver.cpp
@@ -58,8 +58,8 @@ std::vector<MutationPoint *> Driver::findMutationPoints() {
   if (!config.skipSanityCheckRun) {
     Runner runner(diagnostics);
     singleTask.execute("Sanity check run", [&]() {
-      ExecutionResult result =
-          runner.runProgram(config.executable, {}, {}, config.timeout, config.captureTestOutput);
+      ExecutionResult result = runner.runProgram(
+          config.executable, {}, {}, config.timeout, config.captureTestOutput, std::nullopt);
       if (result.status != Passed) {
         std::stringstream failureMessage;
         failureMessage << "Original test failed\n";
@@ -238,12 +238,13 @@ Driver::normalRunMutations(const std::vector<MutationPoint *> &mutationPoints,
   /// As we take the execution time as a baseline for timeout it makes sense to have an additional
   /// warm up run so that the next runs will be a bit faster
   singleTask.execute("Warm up run", [&]() {
-    runner.runProgram(executable, {}, {}, config.timeout, config.captureMutantOutput);
+    runner.runProgram(executable, {}, {}, config.timeout, config.captureMutantOutput, std::nullopt);
   });
 
   ExecutionResult baseline;
   singleTask.execute("Baseline run", [&]() {
-    baseline = runner.runProgram(executable, {}, {}, config.timeout, config.captureMutantOutput);
+    baseline = runner.runProgram(
+        executable, {}, {}, config.timeout, config.captureMutantOutput, std::nullopt);
   });
 
   std::vector<std::unique_ptr<MutationResult>> mutationResults;

--- a/lib/Filters/GitDiffFilter.cpp
+++ b/lib/Filters/GitDiffFilter.cpp
@@ -1,0 +1,82 @@
+#include "mull/Filters/GitDiffFilter.h"
+
+#include "mull/Diagnostics/Diagnostics.h"
+#include "mull/SourceLocation.h"
+#include "mull/Toolchain/Runner.h"
+
+#include "llvm/IR/InstIterator.h"
+#include <llvm/IR/DebugInfoMetadata.h>
+#include <llvm/IR/DebugLoc.h>
+#include <llvm/IR/Function.h>
+#include <llvm/Support/FileSystem.h>
+
+#include <iostream>
+#include <regex>
+#include <sstream>
+#include <unistd.h>
+
+using namespace mull;
+
+GitDiffFilter *GitDiffFilter::createFromGitDiff(Diagnostics &diagnostics,
+                                                const std::string &gitProjectRoot,
+                                                const std::string &gitDiffBranch) {
+  mull::GitDiffReader gitDiffReader(diagnostics, gitProjectRoot);
+  mull::GitDiffInfo gitDiffInfo = gitDiffReader.readGitDiff(gitDiffBranch);
+  return new GitDiffFilter(diagnostics, gitDiffInfo);
+}
+
+GitDiffFilter::GitDiffFilter(Diagnostics &diagnostics, GitDiffInfo gitDiffInfo)
+    : diagnostics(diagnostics), gitDiffInfo(gitDiffInfo) {}
+
+std::string GitDiffFilter::name() {
+  return "Git Diff";
+}
+
+bool GitDiffFilter::shouldSkip(llvm::Instruction *instruction) const {
+  SourceLocation sourceLocation = SourceLocation::locationFromInstruction(instruction);
+  if (sourceLocation.isNull()) {
+    return true;
+  }
+
+  /// If no diff, then filtering out.
+  if (gitDiffInfo.size() == 0) {
+    std::stringstream debugMessage;
+    debugMessage << "GitDiffFilter: git diff is empty. Skipping instruction: ";
+    debugMessage << sourceLocation.filePath << ":";
+    debugMessage << sourceLocation.line << ":" << sourceLocation.column;
+    diagnostics.debug(debugMessage.str());
+    return true;
+  }
+
+  /// If file is not in the diff, then filtering out.
+  if (gitDiffInfo.count(sourceLocation.filePath) == 0) {
+    std::stringstream debugMessage;
+    debugMessage << "GitDiffFilter: the file is not present in the git diff. ";
+    debugMessage << "Skipping instruction: ";
+    debugMessage << sourceLocation.filePath << ":";
+    debugMessage << sourceLocation.line << ":" << sourceLocation.column;
+    diagnostics.debug(debugMessage.str());
+    return true;
+  }
+
+  GitDiffSourceFileRanges ranges = gitDiffInfo.at(sourceLocation.filePath);
+  for (auto &range : ranges) {
+    int rangeEnd = range.first + range.second - 1;
+    if (range.first <= sourceLocation.line && sourceLocation.line <= rangeEnd) {
+      std::stringstream debugMessage;
+      debugMessage << "GitDiffFilter: whitelisting instruction: ";
+      debugMessage << sourceLocation.filePath << ":";
+      debugMessage << sourceLocation.line << ":" << sourceLocation.column;
+      diagnostics.debug(debugMessage.str());
+      return false;
+    }
+  }
+
+  std::stringstream debugMessage;
+  debugMessage << "GitDiffFilter: skipping instruction: ";
+  debugMessage << sourceLocation.filePath << ":";
+  debugMessage << sourceLocation.line << ":" << sourceLocation.column;
+  diagnostics.debug(debugMessage.str());
+
+  return true;
+}

--- a/lib/Filters/GitDiffReader.cpp
+++ b/lib/Filters/GitDiffReader.cpp
@@ -1,0 +1,76 @@
+#include "mull/Filters/GitDiffReader.h"
+
+#include "mull/Diagnostics/Diagnostics.h"
+#include <mull/Path.h>
+#include "mull/Toolchain/Runner.h"
+
+#include <iostream>
+#include <regex>
+#include <sstream>
+
+using namespace mull;
+
+GitDiffReader::GitDiffReader(Diagnostics &diagnostics, const std::string gitRepoPath)
+    : diagnostics(diagnostics), gitRepoPath(gitRepoPath) {}
+
+GitDiffInfo GitDiffReader::readGitDiff(const std::string &gitBranch) {
+  /// The implementation is borrowed from the git-clang-format Python tool.
+  /// https://opensource.apple.com/source/clang/clang-800.0.38/src/tools/clang/tools/clang-format/git-clang-format.auto.html
+  Runner runner(diagnostics);
+
+  std::vector<std::string> args = { "diff", "-U0", gitBranch };
+
+  ExecutionResult result =
+      runner.runProgram("git", args, {}, 5000, true, gitRepoPath);
+  if (result.exitStatus != 0) {
+    diagnostics.warning(
+        std::string("GitDiffReader: cannot get git diff information. Received output: ") +
+        result.stderrOutput);
+    return GitDiffInfo();
+  }
+
+  const std::string diffContent = result.stdoutOutput;
+  GitDiffInfo gitDiffInfo = parseDiffContent(diffContent);
+  return gitDiffInfo;
+}
+
+GitDiffInfo GitDiffReader::parseDiffContent(const std::string &diffContent) {
+  GitDiffInfo gitDiffInfo;
+  if (diffContent.empty()) {
+    return gitDiffInfo;
+  }
+
+  std::stringstream diffStream(diffContent);
+  std::string currentLine;
+
+  std::string currentFileName;
+
+  while (std::getline(diffStream, currentLine, '\n')) {
+    std::regex lineRegex("^\\+\\+\\+\\ [^/]+/(.*)");
+    std::regex rangeRegex("^@@ -[0-9,]+ \\+(\\d+)(,(\\d+))?");
+    std::smatch matches;
+
+    if (std::regex_search(currentLine, matches, lineRegex)) {
+      currentFileName = absoluteFilePath(this->gitRepoPath, matches[1].str());
+      continue;
+    }
+
+    if (std::regex_search(currentLine, matches, rangeRegex)) {
+      const std::string startLineStr = matches[1].str();
+      int startLine = std::stoi(startLineStr);
+
+      size_t lineCount = 1;
+      const std::string lineCountStr = matches[3].str();
+      if (lineCountStr.size() > 0) {
+        lineCount = std::stoi(lineCountStr);
+      }
+      if (lineCount > 0) {
+        if (gitDiffInfo.count(currentFileName) == 0) {
+          gitDiffInfo[currentFileName] = std::vector<GitDiffSourceFileRange>();
+        }
+        gitDiffInfo[currentFileName].push_back(std::pair<int, int>(startLine, lineCount));
+      }
+    }
+  }
+  return gitDiffInfo;
+}

--- a/lib/JunkDetection/CXX/ASTStorage.cpp
+++ b/lib/JunkDetection/CXX/ASTStorage.cpp
@@ -78,8 +78,12 @@ const clang::FileEntry *ThreadSafeASTUnit::findFileEntry(const std::string &file
   auto end = sourceManager.fileinfo_end();
   const clang::FileEntry *file = nullptr;
   for (auto it = begin; it != end; it++) {
-    StringRef name(it->first->getName());
-    if (name.equals(filePath)) {
+    llvm::StringRef currentSourceFilePath = it->first->getName();
+    /// In LLVM 6, it->first->getName() does not expand to full path for header files.
+    if (!llvm::sys::path::is_absolute(currentSourceFilePath)) {
+      currentSourceFilePath = it->first->tryGetRealPathName();
+    }
+    if (currentSourceFilePath.equals(filePath)) {
       file = it->first;
       break;
     }

--- a/lib/Parallelization/Tasks/MutantExecutionTask.cpp
+++ b/lib/Parallelization/Tasks/MutantExecutionTask.cpp
@@ -25,7 +25,8 @@ void MutantExecutionTask::operator()(iterator begin, iterator end, Out &storage,
                                  {},
                                  { mutant->getIdentifier() },
                                  baseline.runningTime * 10,
-                                 configuration.captureMutantOutput);
+                                 configuration.captureMutantOutput,
+                                 std::nullopt);
     } else {
       result.status = NotCovered;
     }

--- a/lib/Toolchain/Linker.cpp
+++ b/lib/Toolchain/Linker.cpp
@@ -29,8 +29,8 @@ std::string Linker::linkObjectFiles(const std::vector<std::string> &objects) {
   std::copy(std::begin(objects), std::end(objects), std::back_inserter(arguments));
   arguments.emplace_back("-o");
   arguments.push_back(resultPath.str().str());
-  ExecutionResult result =
-      runner.runProgram(configuration.linker, arguments, {}, configuration.linkerTimeout, true);
+  ExecutionResult result = runner.runProgram(
+      configuration.linker, arguments, {}, configuration.linkerTimeout, true, std::nullopt);
   std::stringstream commandStream;
   commandStream << configuration.linker;
   for (std::string &argument : arguments) {

--- a/lib/Toolchain/Runner.cpp
+++ b/lib/Toolchain/Runner.cpp
@@ -30,7 +30,8 @@ Runner::Runner(Diagnostics &diagnostics) : diagnostics(diagnostics) {}
 ExecutionResult Runner::runProgram(const std::string &program,
                                    const std::vector<std::string> &arguments,
                                    const std::vector<std::string> &environment,
-                                   long long int timeout, bool captureOutput) {
+                                   long long int timeout, bool captureOutput,
+                                   std::optional<std::string> optionalWorkingDirectory) {
   std::vector<std::pair<std::string, std::string>> env;
   env.reserve(environment.size());
   for (auto &e : environment) {
@@ -40,6 +41,9 @@ ExecutionResult Runner::runProgram(const std::string &program,
   reproc::options options;
   options.env.extra = reproc::env(env);
   options.redirect.err.type = reproc::redirect::type::pipe;
+  if (auto &workingDirectory = optionalWorkingDirectory) {
+    options.working_directory = workingDirectory->c_str();
+  }
 
   std::vector<std::string> allArguments{ program };
   std::copy(std::begin(arguments), std::end(arguments), std::back_inserter(allArguments));

--- a/tests-lit/.gitignore
+++ b/tests-lit/.gitignore
@@ -7,4 +7,5 @@
 *.tmp
 *.profdata
 *.profraw
+**/Output/**
 

--- a/tests-lit/CMakeLists.txt
+++ b/tests-lit/CMakeLists.txt
@@ -41,6 +41,7 @@ set(LIT_COMMAND
 )
 
 add_custom_target(tests-lit
+  COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && make clean
   COMMAND ${LIT_COMMAND}
   DEPENDS mull-cxx
 )

--- a/tests-lit/Makefile
+++ b/tests-lit/Makefile
@@ -23,7 +23,6 @@ test: ## Run integration tests
 CLEAN_FIND_CMD=find \
 	. \
 	-type f \( \
-		-name '*.exe' -or \
 		-name '*.html' -or \
 		-name '*.json' -or \
 		-name '*.o' -or \

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/01-reading-git-diff-and-filtering/compile_commands.json.template
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/01-reading-git-diff-and-filtering/compile_commands.json.template
@@ -1,0 +1,16 @@
+[
+  {
+    "arguments": [
+      "cc",
+      "-c",
+      "-fembed-bitcode",
+      "-g",
+      "-O0",
+      "-o",
+      "%PWD/sample.cpp.exe",
+      "%PWD/sample.cpp"
+    ],
+    "directory": "/",
+    "file": "%PWD/sample.cpp"
+  }
+]

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/01-reading-git-diff-and-filtering/sample.cpp.modified
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/01-reading-git-diff-and-filtering/sample.cpp.modified
@@ -1,0 +1,34 @@
+// clang-format off
+
+bool valid_age(int age) {
+  if (age >= 21) { /// This comment line creates a diff!
+    return true;
+  }
+  if (age >= 21) {
+    (void)0;
+  }
+  return false;
+}
+
+int main() {
+  bool test1 = valid_age(25) == true;
+  if (!test1) {
+    /// test failed
+    return 1;
+  }
+
+  bool test2 = valid_age(20) == false;
+  if (!test2) {
+    /// test failed
+    return 1;
+  }
+
+  bool test3 = valid_age(21) == true;
+  if (!test3) {
+     /// test failed
+     return 1;
+  }
+
+  /// success
+  return 0;
+}

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/01-reading-git-diff-and-filtering/sample.cpp.original
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/01-reading-git-diff-and-filtering/sample.cpp.original
@@ -1,0 +1,34 @@
+// clang-format off
+
+bool valid_age(int age) {
+  if (age >= 21) {
+    return true;
+  }
+  if (age >= 21) {
+    return true;
+  }
+  return false;
+}
+
+int main() {
+  bool test1 = valid_age(25) == true;
+  if (!test1) {
+    /// test failed
+    return 1;
+  }
+
+  bool test2 = valid_age(20) == false;
+  if (!test2) {
+    /// test failed
+    return 1;
+  }
+
+  bool test3 = valid_age(21) == true;
+  if (!test3) {
+     /// test failed
+     return 1;
+  }
+
+  /// success
+  return 0;
+}

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/01-reading-git-diff-and-filtering/test.itest
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/01-reading-git-diff-and-filtering/test.itest
@@ -1,0 +1,25 @@
+RUN: cd %S
+RUN: mkdir -p %S/Output/sandbox
+RUN: cp %S/sample.cpp.original %S/Output/sandbox/sample.cpp
+RUN: cd %S/Output/sandbox
+RUN: git init .
+RUN: git add sample.cpp
+RUN: git -c user.name='Mull' -c user.email=alex@lowlevelbits.org commit -m "Impersonation is evil."
+RUN: cp %S/sample.cpp.modified %S/Output/sandbox/sample.cpp
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %S/Output/sandbox/sample.cpp -o %S/Output/sample.cpp.exe
+RUN: cd %S/Output/sandbox && (unset TERM; %MULL_EXEC -debug -git-diff-ref=master -git-project-root=%S/Output/sandbox -linker=%clang_cxx -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed %S/Output/sample.cpp.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
+
+CHECK:[info] Incremental testing using Git Diff is enabled.
+CHECK:- Git ref: master
+CHECK:- Git project root: {{.*}}/Output/sandbox
+
+CHECK:[debug] GitDiffFilter: whitelisting instruction: {{.*}}/sample.cpp:4:7
+CHECK:[debug] GitDiffFilter: whitelisting instruction: {{.*}}/sample.cpp:4:11
+CHECK:[debug] GitDiffFilter: skipping instruction: {{.*}}/sample.cpp:7:7
+CHECK:[debug] GitDiffFilter: skipping instruction: {{.*}}/sample.cpp:7:11
+
+CHECK:[info] Killed mutants (2/2):
+CHECK:{{^.*}}sample.cpp:4:11: warning: Killed: Replaced >= with > [cxx_ge_to_gt]{{$}}
+CHECK:{{^.*}}sample.cpp:4:11: warning: Killed: Replaced >= with < [cxx_ge_to_lt]{{$}}
+CHECK:[info] All mutations have been killed
+CHECK:[info] Mutation score: 100%

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/02-reading-git-diff-and-not-filtering/compile_commands.json.template
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/02-reading-git-diff-and-not-filtering/compile_commands.json.template
@@ -1,0 +1,16 @@
+[
+  {
+    "arguments": [
+      "cc",
+      "-c",
+      "-fembed-bitcode",
+      "-g",
+      "-O0",
+      "-o",
+      "%PWD/sample.cpp.exe",
+      "%PWD/sample.cpp"
+    ],
+    "directory": "/",
+    "file": "%PWD/sample.cpp"
+  }
+]

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/02-reading-git-diff-and-not-filtering/sample.cpp.modified
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/02-reading-git-diff-and-not-filtering/sample.cpp.modified
@@ -1,0 +1,36 @@
+// clang-format off
+
+bool valid_age(int age) {
+  if (age >= 21) {
+    return true;
+  }
+  if (age >= 21) {
+    (void)0;
+  }
+  return false;
+}
+
+/// This comment line creates a diff!
+
+int main() {
+  bool test1 = valid_age(25) == true;
+  if (!test1) {
+    /// test failed
+    return 1;
+  }
+
+  bool test2 = valid_age(20) == false;
+  if (!test2) {
+    /// test failed
+    return 1;
+  }
+
+  bool test3 = valid_age(21) == true;
+  if (!test3) {
+     /// test failed
+     return 1;
+  }
+
+  /// success
+  return 0;
+}

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/02-reading-git-diff-and-not-filtering/sample.cpp.original
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/02-reading-git-diff-and-not-filtering/sample.cpp.original
@@ -1,0 +1,34 @@
+// clang-format off
+
+bool valid_age(int age) {
+  if (age >= 21) {
+    return true;
+  }
+  if (age >= 21) {
+    return true;
+  }
+  return false;
+}
+
+int main() {
+  bool test1 = valid_age(25) == true;
+  if (!test1) {
+    /// test failed
+    return 1;
+  }
+
+  bool test2 = valid_age(20) == false;
+  if (!test2) {
+    /// test failed
+    return 1;
+  }
+
+  bool test3 = valid_age(21) == true;
+  if (!test3) {
+     /// test failed
+     return 1;
+  }
+
+  /// success
+  return 0;
+}

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/02-reading-git-diff-and-not-filtering/test.itest
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/02-reading-git-diff-and-not-filtering/test.itest
@@ -1,0 +1,18 @@
+RUN: cd %S
+RUN: mkdir -p %S/Output/sandbox
+RUN: cp %S/sample.cpp.original %S/Output/sandbox/sample.cpp
+RUN: cd %S/Output/sandbox
+RUN: git init .
+RUN: git add sample.cpp
+RUN: git -c user.name='Mull' -c user.email=alex@lowlevelbits.org commit -m "Impersonation is evil."
+RUN: cp %S/sample.cpp.modified %S/Output/sandbox/sample.cpp
+RUN: cd / && %CLANG_EXEC -S -emit-llvm -g -O0 %S/Output/sandbox/sample.cpp -o %S/Output/sample.cpp.ll
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %S/Output/sandbox/sample.cpp -o %S/Output/sample.cpp.exe
+RUN: cd %S/Output/sandbox && (unset TERM; %MULL_EXEC -debug -git-diff-ref=master -git-project-root=%S/Output/sandbox -linker=%clang_cxx -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed %S/Output/sample.cpp.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
+
+CHECK:[debug] GitDiffFilter: skipping instruction: {{.*}}/sample.cpp:4:7
+CHECK:[debug] GitDiffFilter: skipping instruction: {{.*}}/sample.cpp:4:11
+CHECK:[debug] GitDiffFilter: skipping instruction: {{.*}}/sample.cpp:7:7
+CHECK:[debug] GitDiffFilter: skipping instruction: {{.*}}/sample.cpp:7:11
+
+CHECK:[info] No mutants found. Mutation score: infinitely high

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/03-reading-git-diff-and-filtering-compiled-from-nonroot/compile_commands.json.template
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/03-reading-git-diff-and-filtering-compiled-from-nonroot/compile_commands.json.template
@@ -1,0 +1,16 @@
+[
+  {
+    "arguments": [
+      "cc",
+      "-c",
+      "-fembed-bitcode",
+      "-g",
+      "-O0",
+      "-o",
+      "%PWD/sample.cpp.exe",
+      "%PWD/sample.cpp"
+    ],
+    "directory": "/",
+    "file": "%PWD/sample.cpp"
+  }
+]

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/03-reading-git-diff-and-filtering-compiled-from-nonroot/sample.cpp.modified
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/03-reading-git-diff-and-filtering-compiled-from-nonroot/sample.cpp.modified
@@ -1,0 +1,31 @@
+// clang-format off
+
+bool valid_age(int age) {
+  if (age >= 21) { /// This comment line creates a diff!
+    return true;
+  }
+  return false;
+}
+
+int main() {
+  bool test1 = valid_age(25) == true;
+  if (!test1) {
+    /// test failed
+    return 1;
+  }
+
+  bool test2 = valid_age(20) == false;
+  if (!test2) {
+    /// test failed
+    return 1;
+  }
+
+  bool test3 = valid_age(21) == true;
+  if (!test3) {
+     /// test failed
+     return 1;
+  }
+
+  /// success
+  return 0;
+}

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/03-reading-git-diff-and-filtering-compiled-from-nonroot/sample.cpp.original
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/03-reading-git-diff-and-filtering-compiled-from-nonroot/sample.cpp.original
@@ -1,0 +1,31 @@
+// clang-format off
+
+bool valid_age(int age) {
+  if (age >= 21) {
+    return true;
+  }
+  return false;
+}
+
+int main() {
+  bool test1 = valid_age(25) == true;
+  if (!test1) {
+    /// test failed
+    return 1;
+  }
+
+  bool test2 = valid_age(20) == false;
+  if (!test2) {
+    /// test failed
+    return 1;
+  }
+
+  bool test3 = valid_age(21) == true;
+  if (!test3) {
+     /// test failed
+     return 1;
+  }
+
+  /// success
+  return 0;
+}

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/03-reading-git-diff-and-filtering-compiled-from-nonroot/test.itest
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/03-reading-git-diff-and-filtering-compiled-from-nonroot/test.itest
@@ -1,0 +1,21 @@
+RUN: cd %S
+RUN: mkdir -p %S/Output/sandbox
+RUN: cp %S/sample.cpp.original %S/Output/sandbox/sample.cpp
+RUN: cd %S/Output/sandbox
+RUN: git init .
+RUN: git add sample.cpp
+RUN: git -c user.name='Mull' -c user.email=alex@lowlevelbits.org commit -m "Impersonation is evil."
+RUN: cp %S/sample.cpp.modified %S/Output/sandbox/sample.cpp
+
+/// We cd to the the test directory and compile using relative paths.
+RUN: cd %S; %CLANG_EXEC -fembed-bitcode -g -O0 Output/sandbox/sample.cpp -o Output/sample.cpp.exe
+
+RUN: cd %S/Output/sandbox && (unset TERM; %MULL_EXEC -debug -git-diff-ref=master -git-project-root=%S/Output/sandbox -linker=%clang_cxx -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed %S/Output/sample.cpp.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
+
+CHECK:[debug] GitDiffFilter: whitelisting instruction: {{.*}}/sample.cpp:4:7
+CHECK:[debug] GitDiffFilter: whitelisting instruction: {{.*}}/sample.cpp:4:11
+CHECK:[info] Killed mutants (2/2):
+CHECK:{{^.*}}sample.cpp:4:11: warning: Killed: Replaced >= with > [cxx_ge_to_gt]{{$}}
+CHECK:{{^.*}}sample.cpp:4:11: warning: Killed: Replaced >= with < [cxx_ge_to_lt]{{$}}
+CHECK:[info] All mutations have been killed
+CHECK:[info] Mutation score: 100%

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/04-reading-git-diff-and-filtering-from-header-file/compile_commands.json.template
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/04-reading-git-diff-and-filtering-from-header-file/compile_commands.json.template
@@ -1,0 +1,16 @@
+[
+  {
+    "arguments": [
+      "cc",
+      "-c",
+      "-fembed-bitcode",
+      "-g",
+      "-O0",
+      "-o",
+      "%PWD/sample.cpp.exe",
+      "%PWD/sample.cpp"
+    ],
+    "directory": "/",
+    "file": "%PWD/sample.cpp"
+  }
+]

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/04-reading-git-diff-and-filtering-from-header-file/sample.cpp.notest
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/04-reading-git-diff-and-filtering-from-header-file/sample.cpp.notest
@@ -1,0 +1,26 @@
+// clang-format off
+
+#include "valid_age.h"
+
+int main() {
+  bool test1 = valid_age(25) == true;
+  if (!test1) {
+    /// test failed
+    return 1;
+  }
+
+  bool test2 = valid_age(20) == false;
+  if (!test2) {
+    /// test failed
+    return 1;
+  }
+
+  bool test3 = valid_age(21) == true;
+  if (!test3) {
+     /// test failed
+     return 1;
+  }
+
+  /// success
+  return 0;
+}

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/04-reading-git-diff-and-filtering-from-header-file/test.itest
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/04-reading-git-diff-and-filtering-from-header-file/test.itest
@@ -1,0 +1,21 @@
+RUN: cd %S
+RUN: mkdir -p %S/Output/sandbox
+RUN: cp %S/sample.cpp.notest %S/Output/sandbox/sample.cpp
+RUN: cp %S/valid_age.h.original %S/Output/sandbox/valid_age.h
+RUN: cd %S/Output/sandbox
+RUN: git init .
+RUN: git add -A
+RUN: git -c user.name='Mull' -c user.email=alex@lowlevelbits.org commit -m "Impersonation is evil."
+RUN: cp %S/valid_age.h.modified %S/Output/sandbox/valid_age.h
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %S/Output/sandbox/sample.cpp -o %S/Output/sample.cpp.exe
+RUN: cd %S/Output/sandbox && (unset TERM; %MULL_EXEC -debug -git-diff-ref=master -git-project-root=%S/Output/sandbox -linker=%clang_cxx -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed %S/Output/sample.cpp.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
+
+CHECK:[debug] GitDiffFilter: whitelisting instruction: {{.*}}/valid_age.h:4:7
+CHECK:[debug] GitDiffFilter: whitelisting instruction: {{.*}}/valid_age.h:4:11
+CHECK:[info] Killed mutants (2/2):
+CHECK:{{^.*}}valid_age.h:4:11: warning: Killed: Replaced >= with > [cxx_ge_to_gt]{{$}}
+CHECK:  if (age >= 21) { // This comment line creates a diff!
+CHECK:{{^.*}}valid_age.h:4:11: warning: Killed: Replaced >= with < [cxx_ge_to_lt]{{$}}
+CHECK:  if (age >= 21) { // This comment line creates a diff!
+CHECK:[info] All mutations have been killed
+CHECK:[info] Mutation score: 100%

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/04-reading-git-diff-and-filtering-from-header-file/valid_age.h.modified
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/04-reading-git-diff-and-filtering-from-header-file/valid_age.h.modified
@@ -1,0 +1,8 @@
+#pragma once
+
+static bool valid_age(int age) {
+  if (age >= 21) { // This comment line creates a diff!
+    return true;
+  }
+  return false;
+}

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/04-reading-git-diff-and-filtering-from-header-file/valid_age.h.original
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/04-reading-git-diff-and-filtering-from-header-file/valid_age.h.original
@@ -1,0 +1,8 @@
+#pragma once
+
+static bool valid_age(int age) {
+  if (age >= 21) {
+    return true;
+  }
+  return false;
+}

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/05-reading-empty-git-diff-skipping-everything/compile_commands.json.template
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/05-reading-empty-git-diff-skipping-everything/compile_commands.json.template
@@ -1,0 +1,16 @@
+[
+  {
+    "arguments": [
+      "cc",
+      "-c",
+      "-fembed-bitcode",
+      "-g",
+      "-O0",
+      "-o",
+      "%PWD/sample.cpp.exe",
+      "%PWD/sample.cpp"
+    ],
+    "directory": "/",
+    "file": "%PWD/sample.cpp"
+  }
+]

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/05-reading-empty-git-diff-skipping-everything/sample.cpp.original
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/05-reading-empty-git-diff-skipping-everything/sample.cpp.original
@@ -1,0 +1,31 @@
+// clang-format off
+
+bool valid_age(int age) {
+  if (age >= 21) {
+    return true;
+  }
+  return false;
+}
+
+int main() {
+  bool test1 = valid_age(25) == true;
+  if (!test1) {
+    /// test failed
+    return 1;
+  }
+
+  bool test2 = valid_age(20) == false;
+  if (!test2) {
+    /// test failed
+    return 1;
+  }
+
+  bool test3 = valid_age(21) == true;
+  if (!test3) {
+     /// test failed
+     return 1;
+  }
+
+  /// success
+  return 0;
+}

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/05-reading-empty-git-diff-skipping-everything/test.itest
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/05-reading-empty-git-diff-skipping-everything/test.itest
@@ -1,0 +1,14 @@
+RUN: cd %S
+RUN: mkdir -p %S/Output/sandbox
+RUN: cp %S/sample.cpp.original %S/Output/sandbox/sample.cpp
+RUN: cd %S/Output/sandbox
+RUN: git init .
+RUN: git add sample.cpp
+RUN: git -c user.name='Mull' -c user.email=alex@lowlevelbits.org commit -m "Impersonation is evil."
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 %S/Output/sandbox/sample.cpp -o %S/Output/sample.cpp.exe
+RUN: cd %S/Output/sandbox && (unset TERM; %MULL_EXEC -debug -git-diff-ref=master -git-project-root=%S/Output/sandbox -linker=%clang_cxx -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed %S/Output/sample.cpp.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
+
+CHECK:[debug] GitDiffFilter: git diff is empty. Skipping instruction: {{.*}}/sample.cpp:4:7
+CHECK:[debug] GitDiffFilter: git diff is empty. Skipping instruction: {{.*}}/sample.cpp:4:11
+
+CHECK:[info] No mutants found. Mutation score: infinitely high

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/01-warning-when-git-diff-but-without-git-project-root/compile_commands.json.template
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/01-warning-when-git-diff-but-without-git-project-root/compile_commands.json.template
@@ -1,0 +1,16 @@
+[
+  {
+    "arguments": [
+      "cc",
+      "-c",
+      "-fembed-bitcode",
+      "-g",
+      "-O0",
+      "-o",
+      "%PWD/sample.cpp.exe",
+      "%PWD/sample.cpp"
+    ],
+    "directory": "/",
+    "file": "%PWD/sample.cpp"
+  }
+]

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/01-warning-when-git-diff-but-without-git-project-root/sample.cpp.modified
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/01-warning-when-git-diff-but-without-git-project-root/sample.cpp.modified
@@ -1,0 +1,32 @@
+// clang-format off
+
+bool valid_age(int age) {
+  /// This comment line creates a diff!
+  if (age >= 21) {
+    return true;
+  }
+  return false;
+}
+
+int main() {
+  bool test1 = valid_age(25) == true;
+  if (!test1) {
+    /// test failed
+    return 1;
+  }
+
+  bool test2 = valid_age(20) == false;
+  if (!test2) {
+    /// test failed
+    return 1;
+  }
+
+  bool test3 = valid_age(21) == true;
+  if (!test3) {
+     /// test failed
+     return 1;
+  }
+
+  /// success
+  return 0;
+}

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/01-warning-when-git-diff-but-without-git-project-root/sample.cpp.original
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/01-warning-when-git-diff-but-without-git-project-root/sample.cpp.original
@@ -1,0 +1,31 @@
+// clang-format off
+
+bool valid_age(int age) {
+  if (age >= 21) {
+    return true;
+  }
+  return false;
+}
+
+int main() {
+  bool test1 = valid_age(25) == true;
+  if (!test1) {
+    /// test failed
+    return 1;
+  }
+
+  bool test2 = valid_age(20) == false;
+  if (!test2) {
+    /// test failed
+    return 1;
+  }
+
+  bool test3 = valid_age(21) == true;
+  if (!test3) {
+     /// test failed
+     return 1;
+  }
+
+  /// success
+  return 0;
+}

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/01-warning-when-git-diff-but-without-git-project-root/test.itest
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/01-warning-when-git-diff-but-without-git-project-root/test.itest
@@ -1,0 +1,8 @@
+RUN: cd %S
+RUN: TEMPDIR=$(mktemp -d)
+RUN: cp %S/sample.cpp.modified $TEMPDIR/sample.cpp
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 $TEMPDIR/sample.cpp -o $TEMPDIR/sample.cpp.exe
+RUN: cd $TEMPDIR && (unset TERM; %MULL_EXEC -workers=1 -debug -git-diff-ref=master -linker=%clang_cxx -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed $TEMPDIR/sample.cpp.exe 2>&1; test $? = 0)
+RUN: cd $TEMPDIR && (unset TERM; %MULL_EXEC -workers=1 -debug -git-diff-ref=master -linker=%clang_cxx -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed $TEMPDIR/sample.cpp.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
+
+CHECK:[warning] -git-diff-ref option has been provided but the path to the Git project root has not been specified via -git-project-root. The incremental testing will be disabled.

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/02-warning-when-git-project-root-does-not-exist/compile_commands.json.template
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/02-warning-when-git-project-root-does-not-exist/compile_commands.json.template
@@ -1,0 +1,16 @@
+[
+  {
+    "arguments": [
+      "cc",
+      "-c",
+      "-fembed-bitcode",
+      "-g",
+      "-O0",
+      "-o",
+      "%PWD/sample.cpp.exe",
+      "%PWD/sample.cpp"
+    ],
+    "directory": "/",
+    "file": "%PWD/sample.cpp"
+  }
+]

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/02-warning-when-git-project-root-does-not-exist/sample.cpp.modified
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/02-warning-when-git-project-root-does-not-exist/sample.cpp.modified
@@ -1,0 +1,32 @@
+// clang-format off
+
+bool valid_age(int age) {
+  /// This comment line creates a diff!
+  if (age >= 21) {
+    return true;
+  }
+  return false;
+}
+
+int main() {
+  bool test1 = valid_age(25) == true;
+  if (!test1) {
+    /// test failed
+    return 1;
+  }
+
+  bool test2 = valid_age(20) == false;
+  if (!test2) {
+    /// test failed
+    return 1;
+  }
+
+  bool test3 = valid_age(21) == true;
+  if (!test3) {
+     /// test failed
+     return 1;
+  }
+
+  /// success
+  return 0;
+}

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/02-warning-when-git-project-root-does-not-exist/sample.cpp.original
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/02-warning-when-git-project-root-does-not-exist/sample.cpp.original
@@ -1,0 +1,31 @@
+// clang-format off
+
+bool valid_age(int age) {
+  if (age >= 21) {
+    return true;
+  }
+  return false;
+}
+
+int main() {
+  bool test1 = valid_age(25) == true;
+  if (!test1) {
+    /// test failed
+    return 1;
+  }
+
+  bool test2 = valid_age(20) == false;
+  if (!test2) {
+    /// test failed
+    return 1;
+  }
+
+  bool test3 = valid_age(21) == true;
+  if (!test3) {
+     /// test failed
+     return 1;
+  }
+
+  /// success
+  return 0;
+}

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/02-warning-when-git-project-root-does-not-exist/test.itest
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/02-warning-when-git-project-root-does-not-exist/test.itest
@@ -1,0 +1,7 @@
+RUN: cd %S
+RUN: TEMPDIR=$(mktemp -d)
+RUN: cp %S/sample.cpp.modified $TEMPDIR/sample.cpp
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 $TEMPDIR/sample.cpp -o $TEMPDIR/sample.cpp.exe
+RUN: cd $TEMPDIR && (unset TERM; %MULL_EXEC -debug -git-diff-ref=master -git-project-root=/tmp/does-not-exist -linker=%clang_cxx -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed $TEMPDIR/sample.cpp.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
+
+CHECK:[warning] directory provided by -git-project-root does not exist, the incremental testing will be disabled: /tmp/does-not-exist

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/03-warning-when-reading-git-diff-from-a-non-git-folder/compile_commands.json.template
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/03-warning-when-reading-git-diff-from-a-non-git-folder/compile_commands.json.template
@@ -1,0 +1,16 @@
+[
+  {
+    "arguments": [
+      "cc",
+      "-c",
+      "-fembed-bitcode",
+      "-g",
+      "-O0",
+      "-o",
+      "%PWD/sample.cpp.exe",
+      "%PWD/sample.cpp"
+    ],
+    "directory": "/",
+    "file": "%PWD/sample.cpp"
+  }
+]

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/03-warning-when-reading-git-diff-from-a-non-git-folder/sample.cpp.modified
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/03-warning-when-reading-git-diff-from-a-non-git-folder/sample.cpp.modified
@@ -1,0 +1,32 @@
+// clang-format off
+
+bool valid_age(int age) {
+  /// This comment line creates a diff!
+  if (age >= 21) {
+    return true;
+  }
+  return false;
+}
+
+int main() {
+  bool test1 = valid_age(25) == true;
+  if (!test1) {
+    /// test failed
+    return 1;
+  }
+
+  bool test2 = valid_age(20) == false;
+  if (!test2) {
+    /// test failed
+    return 1;
+  }
+
+  bool test3 = valid_age(21) == true;
+  if (!test3) {
+     /// test failed
+     return 1;
+  }
+
+  /// success
+  return 0;
+}

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/03-warning-when-reading-git-diff-from-a-non-git-folder/sample.cpp.original
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/03-warning-when-reading-git-diff-from-a-non-git-folder/sample.cpp.original
@@ -1,0 +1,31 @@
+// clang-format off
+
+bool valid_age(int age) {
+  if (age >= 21) {
+    return true;
+  }
+  return false;
+}
+
+int main() {
+  bool test1 = valid_age(25) == true;
+  if (!test1) {
+    /// test failed
+    return 1;
+  }
+
+  bool test2 = valid_age(20) == false;
+  if (!test2) {
+    /// test failed
+    return 1;
+  }
+
+  bool test3 = valid_age(21) == true;
+  if (!test3) {
+     /// test failed
+     return 1;
+  }
+
+  /// success
+  return 0;
+}

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/03-warning-when-reading-git-diff-from-a-non-git-folder/test.itest
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/03-warning-when-reading-git-diff-from-a-non-git-folder/test.itest
@@ -1,0 +1,7 @@
+RUN: cd %S
+RUN: TEMPDIR=$(mktemp -d)
+RUN: cp %S/sample.cpp.modified $TEMPDIR/sample.cpp
+RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 $TEMPDIR/sample.cpp -o $TEMPDIR/sample.cpp.exe
+RUN: cd $TEMPDIR && (unset TERM; %MULL_EXEC -git-diff-ref=master -git-project-root=$TEMPDIR -linker=%clang_cxx -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed $TEMPDIR/sample.cpp.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
+
+CHECK:[warning] GitDiffReader: cannot get git diff information. Received output: {{.*}}Not a git repository

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,7 +50,8 @@ set(mull_unittests_sources
 
   JunkDetection/CompilationDatabaseTests.cpp
   MutationFilters/MutationFilterTests.cpp
-  )
+  MutationFilters/GitDiffReaderTests.cpp
+)
 
 get_filename_component(factory_include_dir ${FACTORY_HEADER} DIRECTORY)
 

--- a/tests/MutationFilters/GitDiffReaderTests.cpp
+++ b/tests/MutationFilters/GitDiffReaderTests.cpp
@@ -1,0 +1,134 @@
+#include "mull/Filters/GitDiffReader.h"
+
+#include "mull/Diagnostics/Diagnostics.h"
+
+#include <gtest/gtest.h>
+
+using namespace mull;
+
+TEST(GitDiffReaderTest, 01_SingleFile_SingleLine) {
+  Diagnostics diagnostics;
+  GitDiffReader gitDiffReader(diagnostics, "/tmp/repo");
+
+  const std::string diff = std::string(R"(
+diff --git a/lib/Driver.cpp b/lib/Driver.cpp
+index 768daa6b..5ebc9315 100644
+--- a/lib/Driver.cpp
++++ b/lib/Driver.cpp
+@@ -93,0 +94 @@ std::vector<MutationPoint *> Driver::filterMutations(std::vector<MutationPoint *
++
+)");
+
+  GitDiffInfo gitDiffInfo = gitDiffReader.parseDiffContent(diff);
+
+  ASSERT_EQ(gitDiffInfo.size(), 1);
+
+  const GitDiffSourceFileRanges &fileRanges = gitDiffInfo["/tmp/repo/lib/Driver.cpp"];
+  ASSERT_EQ(fileRanges.size(), 1);
+  ASSERT_EQ(fileRanges[0].first, 94);
+  ASSERT_EQ(fileRanges[0].second, 1);
+}
+
+TEST(GitDiffReaderTest, 02_SingleFile_TwoLineDiff) {
+  Diagnostics diagnostics;
+  GitDiffReader gitDiffReader(diagnostics, "/tmp/repo");
+
+  const std::string diff = std::string(R"(
+diff --git a/lib/Driver.cpp b/lib/Driver.cpp
+index 768daa6b..5ebc9315 100644
+--- a/lib/Driver.cpp
++++ b/lib/Driver.cpp
+@@ -93,0 +94,2 @@ std::vector<MutationPoint *> Driver::filterMutations(std::vector<MutationPoint *
++
++
+)");
+
+  GitDiffInfo gitDiffInfo = gitDiffReader.parseDiffContent(diff);
+
+  ASSERT_EQ(gitDiffInfo.size(), 1);
+
+  const GitDiffSourceFileRanges &fileRanges = gitDiffInfo["/tmp/repo/lib/Driver.cpp"];
+  ASSERT_EQ(fileRanges.size(), 1);
+  ASSERT_EQ(fileRanges[0].first, 94);
+  ASSERT_EQ(fileRanges[0].second, 2);
+}
+
+TEST(GitDiffReaderTest, 03_SingleFile_ThreeRanges) {
+  Diagnostics diagnostics;
+  GitDiffReader gitDiffReader(diagnostics, "/tmp/repo");
+
+  const std::string diff = std::string(R"(
+diff --git a/lib/Driver.cpp b/lib/Driver.cpp
+index 768daa6b..045b1d03 100644
+--- a/lib/Driver.cpp
++++ b/lib/Driver.cpp
+@@ -38,0 +39,2 @@ std::unique_ptr<Result> Driver::run() {
++
++
+@@ -50,0 +53,2 @@ std::unique_ptr<Result> Driver::run() {
++
++
+@@ -93,0 +98,2 @@ std::vector<MutationPoint *> Driver::filterMutations(std::vector<MutationPoint *
++
++
+)");
+
+  GitDiffInfo gitDiffInfo = gitDiffReader.parseDiffContent(diff);
+
+  ASSERT_EQ(gitDiffInfo.size(), 1);
+
+  const GitDiffSourceFileRanges &fileRanges = gitDiffInfo["/tmp/repo/lib/Driver.cpp"];
+  ASSERT_EQ(fileRanges.size(), 3);
+  ASSERT_EQ(fileRanges[0].first, 39);
+  ASSERT_EQ(fileRanges[0].second, 2);
+  ASSERT_EQ(fileRanges[1].first, 53);
+  ASSERT_EQ(fileRanges[1].second, 2);
+  ASSERT_EQ(fileRanges[2].first, 98);
+  ASSERT_EQ(fileRanges[2].second, 2);
+}
+
+TEST(GitDiffReaderTest, 04_ThreeDifferentFilesOneRangeEach) {
+  Diagnostics diagnostics;
+  GitDiffReader gitDiffReader(diagnostics, "/tmp/repo");
+
+  const std::string diff = std::string(R"(
+diff --git a/lib/Bitcode.cpp b/lib/Bitcode.cpp
+index f04c8da3..09e7ad29 100644
+--- a/lib/Bitcode.cpp
++++ b/lib/Bitcode.cpp
+@@ -27,0 +28 @@ llvm::Module *Bitcode::getModule() const {
++
+diff --git a/lib/Driver.cpp b/lib/Driver.cpp
+index 768daa6b..16124670 100644
+--- a/lib/Driver.cpp
++++ b/lib/Driver.cpp
+@@ -93,0 +94,2 @@ std::vector<MutationPoint *> Driver::filterMutations(std::vector<MutationPoint *
++
++
+diff --git a/lib/Path.cpp b/lib/Path.cpp
+index 31b74f91..ea3c36a4 100644
+--- a/lib/Path.cpp
++++ b/lib/Path.cpp
+@@ -8,0 +9 @@ std::string mull::absoluteFilePath(const std::string &directory, const std::stri
++
+)");
+
+  GitDiffInfo gitDiffInfo = gitDiffReader.parseDiffContent(diff);
+
+  ASSERT_EQ(gitDiffInfo.size(), 3);
+
+  const GitDiffSourceFileRanges &file1Ranges = gitDiffInfo["/tmp/repo/lib/Bitcode.cpp"];
+  ASSERT_EQ(file1Ranges.size(), 1);
+  ASSERT_EQ(file1Ranges[0].first, 28);
+  ASSERT_EQ(file1Ranges[0].second, 1);
+
+  const GitDiffSourceFileRanges &file2Ranges = gitDiffInfo["/tmp/repo/lib/Driver.cpp"];
+  ASSERT_EQ(file2Ranges.size(), 1);
+  ASSERT_EQ(file2Ranges[0].first, 94);
+  ASSERT_EQ(file2Ranges[0].second, 2);
+
+  const GitDiffSourceFileRanges &file3Ranges = gitDiffInfo["/tmp/repo/lib/Path.cpp"];
+  ASSERT_EQ(file3Ranges.size(), 1);
+  ASSERT_EQ(file3Ranges[0].first, 9);
+  ASSERT_EQ(file3Ranges[0].second, 1);
+}

--- a/tools/mull-cxx/CLIOptions.cpp
+++ b/tools/mull-cxx/CLIOptions.cpp
@@ -139,6 +139,20 @@ opt<bool> tool::EnableAST(
   llvm::cl::desc("Enable \"white\" AST search (disabled by default)"),
   llvm::cl::cat(MullCXXCategory), llvm::cl::init(false));
 
+opt<std::string> tool::GitDiffRef(
+    "git-diff-ref",
+    desc("Git branch to run diff against (enables incremental testing)"),
+    Optional,
+    value_desc("git commit"),
+    cat(MullCXXCategory));
+
+opt<std::string> tool::GitProjectRoot(
+    "git-project-root",
+    desc("Path to project's Git root (used together with -git-diff-ref)"),
+    Optional,
+    value_desc("git project root"),
+    cat(MullCXXCategory));
+
 opt<bool> tool::IncludeNotCovered(
     "include-not-covered",
     desc("Include (but do not run) not covered mutants. Disabled by default"),
@@ -339,6 +353,9 @@ void tool::dumpCLIInterface(Diagnostics &diagnostics) {
 
       &(Option &)IncludePaths,
       &(Option &)ExcludePaths,
+
+      &(Option &)GitDiffRef,
+      &(Option &)GitProjectRoot,
 
       mutators,
   });

--- a/tools/mull-cxx/CLIOptions.h
+++ b/tools/mull-cxx/CLIOptions.h
@@ -49,6 +49,9 @@ extern opt<bool> NoMutantOutput;
 
 extern opt<bool> EnableAST;
 
+extern opt<std::string> GitDiffRef;
+extern opt<std::string> GitProjectRoot;
+
 extern list<std::string> ExcludePaths;
 extern list<std::string> IncludePaths;
 

--- a/tools/mull-cxx/mull-cxx.cpp
+++ b/tools/mull-cxx/mull-cxx.cpp
@@ -15,6 +15,7 @@
 #include "mull/Filters/FilePathFilter.h"
 #include "mull/Filters/Filter.h"
 #include "mull/Filters/Filters.h"
+#include "mull/Filters/GitDiffFilter.h"
 #include "mull/Filters/JunkMutationFilter.h"
 #include "mull/Filters/NoDebugInfoFilter.h"
 #include "mull/JunkDetection/CXX/CXXJunkDetector.h"
@@ -40,8 +41,8 @@ static void validateInputFile() {
 }
 
 static std::vector<std::string> splitFlags(const std::string &flags) {
-  std::istringstream s{flags};
-  return std::vector<std::string>(std::istream_iterator<std::string>{s}, {});
+  std::istringstream s{ flags };
+  return std::vector<std::string>(std::istream_iterator<std::string>{ s }, {});
 }
 
 int main(int argc, char **argv) {
@@ -176,12 +177,11 @@ int main(int argc, char **argv) {
       diagnostics, cxxCompilationDatabasePath, cxxCompilationFlags, bitcodeCompilationFlags);
 
   mull::ASTSourceInfoProvider sourceInfoProvider(astStorage);
-  tool::ReporterParameters params{
-      .reporterName = tool::ReportName.getValue(),
-      .reporterDirectory = tool::ReportDirectory.getValue(),
-      .sourceInfoProvider = sourceInfoProvider,
-      .compilationDatabaseAvailable = compilationDatabaseInfoAvailable
-  };
+  tool::ReporterParameters params{ .reporterName = tool::ReportName.getValue(),
+                                   .reporterDirectory = tool::ReportDirectory.getValue(),
+                                   .sourceInfoProvider = sourceInfoProvider,
+                                   .compilationDatabaseAvailable =
+                                       compilationDatabaseInfoAvailable };
   std::vector<std::unique_ptr<mull::Reporter>> reporters = reportersOption.reporters(params);
 
   mull::CXXJunkDetector junkDetector(astStorage);
@@ -209,6 +209,35 @@ int main(int argc, char **argv) {
   }
   for (const auto &regex : tool::IncludePaths) {
     filePathFilter->include(regex);
+  }
+
+  if (!tool::GitDiffRef.getValue().empty()) {
+    if (tool::GitProjectRoot.getValue().empty()) {
+      std::stringstream debugMessage;
+      debugMessage
+          << "-git-diff-ref option has been provided but the path to the Git project root has not "
+             "been specified via -git-project-root. The incremental testing will be disabled.";
+      diagnostics.warning(debugMessage.str());
+    } else if (!llvm::sys::fs::is_directory(tool::GitProjectRoot.getValue())) {
+      std::stringstream debugMessage;
+      debugMessage << "directory provided by -git-project-root does not exist, ";
+      debugMessage << "the incremental testing will be disabled: ";
+      debugMessage << tool::GitProjectRoot.getValue();
+      diagnostics.warning(debugMessage.str());
+    } else {
+      std::string gitProjectRoot = tool::GitProjectRoot.getValue();
+      std::string gitDiffBranch = tool::GitDiffRef.getValue();
+      diagnostics.info(std::string("Incremental testing using Git Diff is enabled.\n")
+                       + "- Git ref: " + gitDiffBranch + "\n"
+                       + "- Git project root: " + gitProjectRoot);
+      mull::GitDiffFilter *gitDiffFilter =
+          mull::GitDiffFilter::createFromGitDiff(diagnostics, gitProjectRoot, gitDiffBranch);
+
+      if (gitDiffFilter) {
+        filterStorage.emplace_back(gitDiffFilter);
+        filters.instructionFilters.push_back(gitDiffFilter);
+      }
+    }
   }
 
   if (tool::EnableAST && compilationDatabaseInfoAvailable) {


### PR DESCRIPTION
Mull runs ``git diff -U0`` under the hood which means getting diff with zero lines of context.

The implementation is inspired by the approach used by git-clang-format:

https://opensource.apple.com/source/clang/clang-800.0.38/src/tools/clang/tools/clang-format/git-clang-format.auto.html

---

TODO:

- [x] Agree on the CLI interface
- [x] Make sure that the full paths in the debug information are not messed up
- [x] Documentation