### PR TITLE
Copy call inst attributions and calling convention

### DIFF
--- a/lib/Parallelization/Tasks/MutantPreparationTasks.cpp
+++ b/lib/Parallelization/Tasks/MutantPreparationTasks.cpp
@@ -154,6 +154,8 @@ void InsertMutationTrampolinesTask::insertTrampolines(Bitcode &bitcode) {
                                         retVal);
     auto callInst =
         llvm::CallInst::Create(original->getFunctionType(), loadValue, args, "", retVal);
+    callInst->setAttributes(original->getAttributes());
+    callInst->setCallingConv(original->getCallingConv());
     if (!retType->isVoidTy()) {
       retVal->setOperand(0, callInst);
     }


### PR DESCRIPTION
Thanks for developing this awesome software!
I'm trying to use this for XCTest and Swift. Here is my WIP repository: https://github.com/kateinoigakukun/mull-xctest

Then Swift uses its own special calling convention and attributes, so call inst in trampoline func should also have those attributes.