### PR TITLE
[Refactoring] Remove Mutant dependency from reporters

### DIFF
--- a/include/mull/JunkDetection/CXX/ASTStorage.h
+++ b/include/mull/JunkDetection/CXX/ASTStorage.h
@@ -45,7 +45,7 @@ public:
              const std::string &cxxCompilationFlags,
              const std::map<std::string, std::string> &bitcodeCompilationFlags);
 
-  ThreadSafeASTUnit *findAST(const MutationPoint *point);
+  ThreadSafeASTUnit *findAST(const SourceLocation &sourceLocation);
   ThreadSafeASTUnit *findAST(const std::string &sourceFile);
 
   void setAST(const std::string &sourceFile, std::unique_ptr<ThreadSafeASTUnit> astUnit);

--- a/include/mull/Reporters/ASTSourceInfoProvider.h
+++ b/include/mull/Reporters/ASTSourceInfoProvider.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "mull/Mutators/MutatorKind.h"
+
 namespace mull {
 
 struct MutationPointSourceInfo {
@@ -12,11 +14,13 @@ struct MutationPointSourceInfo {
 class ASTStorage;
 class MutationPoint;
 class Diagnostics;
+struct SourceLocation;
 
 class SourceInfoProvider {
 public:
   virtual MutationPointSourceInfo getSourceInfo(Diagnostics &diagnostics,
-                                                MutationPoint *mutationPoint) = 0;
+                                                const SourceLocation &sourceLocation,
+                                                MutatorKind mutatorKind) = 0;
 };
 
 class ASTSourceInfoProvider : public SourceInfoProvider {
@@ -24,7 +28,8 @@ public:
   ~ASTSourceInfoProvider() = default;
   explicit ASTSourceInfoProvider(ASTStorage &astStorage);
   MutationPointSourceInfo getSourceInfo(Diagnostics &diagnostics,
-                                        MutationPoint *mutationPoint) override;
+                                        const SourceLocation &sourceLocation,
+                                        MutatorKind mutatorKind) override;
 
 private:
   ASTStorage &astStorage;

--- a/lib/JunkDetection/CXX/ASTStorage.cpp
+++ b/lib/JunkDetection/CXX/ASTStorage.cpp
@@ -175,17 +175,16 @@ ASTStorage::ASTStorage(Diagnostics &diagnostics, const std::string &cxxCompilati
           diagnostics, cxxCompilationDatabasePath, cxxCompilationFlags, bitcodeCompilationFlags)),
       mutations(diagnostics) {}
 
-ThreadSafeASTUnit *ASTStorage::findAST(const MutationPoint *point) {
-  assert(point);
-  assert(!point->getSourceLocation().isNull() && "Missing debug information?");
+ThreadSafeASTUnit *ASTStorage::findAST(const SourceLocation &sourceLocation) {
+  assert(!sourceLocation.isNull() && "Missing debug information?");
 
-  const std::string &sourceFile = point->getSourceLocation().unitFilePath;
+  const std::string &sourceFile = sourceLocation.unitFilePath;
   if (llvm::sys::fs::exists(sourceFile)) {
     return findAST(sourceFile);
   }
 
   if (sourceFile == "/in-memory-file.cc") {
-    const std::string &unitSourceFile = point->getSourceLocation().filePath;
+    const std::string &unitSourceFile = sourceLocation.filePath;
     return findAST(unitSourceFile);
   }
 

--- a/lib/JunkDetection/CXX/CXXJunkDetector.cpp
+++ b/lib/JunkDetection/CXX/CXXJunkDetector.cpp
@@ -189,7 +189,7 @@ bool CXXJunkDetector::isJunk(MutationPoint *point) {
     return true;
   }
 
-  ThreadSafeASTUnit *ast = astStorage.findAST(point);
+  ThreadSafeASTUnit *ast = astStorage.findAST(point->getSourceLocation());
   if (!ast) {
     return true;
   }

--- a/lib/Reporters/ASTSourceInfoProvider.cpp
+++ b/lib/Reporters/ASTSourceInfoProvider.cpp
@@ -13,22 +13,22 @@ using namespace mull;
 ASTSourceInfoProvider::ASTSourceInfoProvider(ASTStorage &astStorage) : astStorage(astStorage) {}
 
 MutationPointSourceInfo ASTSourceInfoProvider::getSourceInfo(Diagnostics &diagnostics,
-                                                             MutationPoint *mutationPoint) {
+                                                             const SourceLocation &sourceLocation,
+                                                             MutatorKind mutatorKind) {
   MutationPointSourceInfo info = MutationPointSourceInfo();
   clang::SourceRange sourceRange;
 
-  const SourceLocation &sourceLocation = mutationPoint->getSourceLocation();
   const std::string &sourceFile = sourceLocation.unitFilePath;
 
   const ASTMutation &astMutation =
       astStorage.getMutation(sourceFile,
-                             mutationPoint->getMutator()->mutatorKind(),
+                             mutatorKind,
                              sourceLocation.line,
                              sourceLocation.column);
 
   const clang::Stmt *const mutantASTNode = astMutation.stmt;
 
-  ThreadSafeASTUnit *astUnit = astStorage.findAST(mutationPoint);
+  ThreadSafeASTUnit *astUnit = astStorage.findAST(sourceLocation);
 
   if (mutantASTNode == nullptr) {
     diagnostics.warning("Cannot find an AST node for mutation point");

--- a/lib/Reporters/MutationTestingElementsReporter.cpp
+++ b/lib/Reporters/MutationTestingElementsReporter.cpp
@@ -60,8 +60,9 @@ static json11::Json createFiles(Diagnostics &diagnostics, const Result &result,
     Json::array mutantsEntries;
 
     for (Mutant *mutant : fileMutationPoints.second) {
+      auto mutatorKind = mutant->getMutationPoints().front()->getMutator()->mutatorKind();
       MutationPointSourceInfo sourceInfo =
-          sourceInfoProvider.getSourceInfo(diagnostics, mutant->getMutationPoints().front());
+          sourceInfoProvider.getSourceInfo(diagnostics, mutant->getSourceLocation(), mutatorKind);
 
       std::string status("Survived");
       if (killedMutants.count(mutant) != 0) {

--- a/tests/MutationTestingElementsReporterTest.cpp
+++ b/tests/MutationTestingElementsReporterTest.cpp
@@ -37,7 +37,8 @@ public:
   virtual ~MockASTSourceInfoProvider() = default;
 
   MutationPointSourceInfo getSourceInfo(Diagnostics &diagnostics,
-                                        MutationPoint *mutationPoint) override {
+                                        const SourceLocation &sourceLocation,
+                                        MutatorKind mutatorKind) override {
     MutationPointSourceInfo info;
     info.beginColumn = beginColumnStub;
     info.beginLine = beginLineStub;


### PR DESCRIPTION
I'm trying to separate modification and execution processes to support XCTest harness. 
Now reporters depend on `Mutant` type, and it makes it hard to separate processes even though they only use source location and mutator kind.

This PR changes to pass only essential things.