### PR TITLE
Teach mull-runner about separate test programs

### DIFF
--- a/include/mull/Config/Configuration.h
+++ b/include/mull/Config/Configuration.h
@@ -19,6 +19,7 @@ struct Configuration {
   bool includeNotCovered;
   bool keepObjectFiles;
   bool keepExecutable;
+  bool mutateOnly;
 
   int timeout;
   unsigned linkerTimeout;

--- a/include/mull/MutantRunner.h
+++ b/include/mull/MutantRunner.h
@@ -15,6 +15,9 @@ public:
   MutantRunner(Diagnostics &diagnostics, const Configuration &configuration);
   std::vector<std::unique_ptr<MutationResult>>
   runMutants(const std::string &executable, std::vector<std::unique_ptr<Mutant>> &mutants);
+  std::vector<std::unique_ptr<MutationResult>>
+  runMutants(const std::string &executable, const std::vector<std::string> &extraArgs,
+             std::vector<std::unique_ptr<Mutant>> &mutants);
 
 private:
   Diagnostics &diagnostics;

--- a/include/mull/Parallelization/Tasks/MutantExecutionTask.h
+++ b/include/mull/Parallelization/Tasks/MutantExecutionTask.h
@@ -16,7 +16,8 @@ public:
   using iterator = In::const_iterator;
 
   MutantExecutionTask(const Configuration &configuration, Diagnostics &diagnostics,
-                      const std::string &executable, ExecutionResult &baseline);
+                      const std::string &executable, ExecutionResult &baseline,
+                      const std::vector<std::string> &extraArgs);
 
   void operator()(iterator begin, iterator end, Out &storage, progress_counter &counter);
 
@@ -25,5 +26,6 @@ private:
   Diagnostics &diagnostics;
   const std::string &executable;
   ExecutionResult &baseline;
+  const std::vector<std::string> &extraArgs;
 };
 } // namespace mull

--- a/lib/Config/Configuration.cpp
+++ b/lib/Config/Configuration.cpp
@@ -18,7 +18,7 @@ unsigned MullDefaultLinkerTimeoutMilliseconds = 30000;
 Configuration::Configuration()
     : debugEnabled(false), dryRunEnabled(false), captureTestOutput(true), captureMutantOutput(true),
       skipSanityCheckRun(false), includeNotCovered(false), keepObjectFiles(false),
-      keepExecutable(false), timeout(MullDefaultTimeoutMilliseconds),
+      keepExecutable(false), mutateOnly(false), timeout(MullDefaultTimeoutMilliseconds),
       linkerTimeout(MullDefaultLinkerTimeoutMilliseconds), diagnostics(IDEDiagnosticsKind::None),
       parallelization(singleThreadParallelization()) {}
 

--- a/lib/Driver.cpp
+++ b/lib/Driver.cpp
@@ -254,10 +254,15 @@ Driver::normalRunMutations(std::vector<std::unique_ptr<Mutant>> &mutants) {
   singleTask.execute("Link mutated program",
                      [&]() { executable = toolchain.linker().linkObjectFiles(objectFiles); });
 
+  diagnostics.info("Mutated executable: "s + executable);
   if (!config.keepObjectFiles) {
     for (auto &objectFile : objectFiles) {
       llvm::sys::fs::remove(objectFile);
     }
+  }
+
+  if (config.mutateOnly) {
+    return std::vector<std::unique_ptr<MutationResult>>();
   }
 
   MutantRunner mutantRunner(diagnostics, config);

--- a/lib/MutantRunner.cpp
+++ b/lib/MutantRunner.cpp
@@ -10,26 +10,40 @@ MutantRunner::MutantRunner(Diagnostics &diagnostics, const Configuration &config
 std::vector<std::unique_ptr<MutationResult>>
 MutantRunner::runMutants(const std::string &executable,
                          std::vector<std::unique_ptr<Mutant>> &mutants) {
+  return runMutants(executable, {}, mutants);
+}
+
+std::vector<std::unique_ptr<MutationResult>>
+MutantRunner::runMutants(const std::string &executable, const std::vector<std::string> &extraArgs,
+                         std::vector<std::unique_ptr<Mutant>> &mutants) {
   SingleTaskExecutor singleTask(diagnostics);
   /// On macOS, sometimes newly compiled programs take more time to execute for the first run
   /// As we take the execution time as a baseline for timeout it makes sense to have an additional
   /// warm up run so that the next runs will be a bit faster
   singleTask.execute("Warm up run", [&]() {
-    runner.runProgram(
-        executable, {}, {}, configuration.timeout, configuration.captureMutantOutput, std::nullopt);
+    runner.runProgram(executable,
+                      extraArgs,
+                      {},
+                      configuration.timeout,
+                      configuration.captureMutantOutput,
+                      std::nullopt);
   });
 
   ExecutionResult baseline;
   singleTask.execute("Baseline run", [&]() {
-    baseline = runner.runProgram(
-        executable, {}, {}, configuration.timeout, configuration.captureMutantOutput, std::nullopt);
+    baseline = runner.runProgram(executable,
+                                 extraArgs,
+                                 {},
+                                 configuration.timeout,
+                                 configuration.captureMutantOutput,
+                                 std::nullopt);
   });
 
   std::vector<std::unique_ptr<MutationResult>> mutationResults;
   std::vector<MutantExecutionTask> tasks;
   tasks.reserve(configuration.parallelization.mutantExecutionWorkers);
   for (int i = 0; i < configuration.parallelization.mutantExecutionWorkers; i++) {
-    tasks.emplace_back(configuration, diagnostics, executable, baseline);
+    tasks.emplace_back(configuration, diagnostics, executable, baseline, extraArgs);
   }
   TaskExecutor<MutantExecutionTask> mutantRunner(
       diagnostics, "Running mutants", mutants, mutationResults, std::move(tasks));

--- a/lib/Parallelization/Tasks/MutantExecutionTask.cpp
+++ b/lib/Parallelization/Tasks/MutantExecutionTask.cpp
@@ -10,9 +10,10 @@ using namespace std::string_literals;
 
 MutantExecutionTask::MutantExecutionTask(const Configuration &configuration,
                                          Diagnostics &diagnostics, const std::string &executable,
-                                         ExecutionResult &baseline)
+                                         ExecutionResult &baseline,
+                                         const std::vector<std::string> &extraArgs)
     : configuration(configuration), diagnostics(diagnostics), executable(executable),
-      baseline(baseline) {}
+      baseline(baseline), extraArgs(extraArgs) {}
 
 void MutantExecutionTask::operator()(iterator begin, iterator end, Out &storage,
                                      progress_counter &counter) {
@@ -22,7 +23,7 @@ void MutantExecutionTask::operator()(iterator begin, iterator end, Out &storage,
     ExecutionResult result;
     if (mutant->isCovered()) {
       result = runner.runProgram(executable,
-                                 {},
+                                 extraArgs,
                                  { mutant->getIdentifier() },
                                  baseline.runningTime * 10,
                                  configuration.captureMutantOutput,

--- a/lib/Toolchain/Linker.cpp
+++ b/lib/Toolchain/Linker.cpp
@@ -57,6 +57,5 @@ std::string Linker::linkObjectFiles(const std::vector<std::string> &objects) {
     diagnostics.error(message.str());
   }
   diagnostics.debug("Link command: "s + command);
-  diagnostics.info("Compiled executable: "s + outputFile);
   return outputFile;
 }

--- a/tests-lit/CMakeLists.txt
+++ b/tests-lit/CMakeLists.txt
@@ -5,6 +5,8 @@ set(CLANG_EXEC ${PATH_TO_LLVM}/bin/clang++)
 set(LIT_EXEC lit)
 set(FILECHECK_EXEC filecheck)
 
+find_package(Python3 COMPONENTS Interpreter)
+
 if(APPLE)
   execute_process(
     COMMAND xcrun -show-sdk-path
@@ -34,12 +36,12 @@ set(LIT_COMMAND
   clang_cc=${clang_cc}
   clang_cxx=${clang_cxx}
   llvm_profdata=${llvm_profdata}
+  python3=${Python3_EXECUTABLE}
   FILECHECK_EXEC=${FILECHECK_EXEC}
   TEST_CXX_FLAGS="${TEST_CXX_FLAGS}"
   ${LIT_EXEC}
   -vv
   ${CMAKE_CURRENT_SOURCE_DIR}/tests
-
   )
 
 add_custom_target(tests-lit

--- a/tests-lit/lit.cfg
+++ b/tests-lit/lit.cfg
@@ -38,6 +38,7 @@ filecheck_exec = os.environ.get('FILECHECK_EXEC', '')
 llvm_path = os.environ.get('PATH_TO_LLVM', '')
 llvm_major_version = os.environ.get('LLVM_VERSION_MAJOR', '')
 test_cxx_flags = os.environ.get('TEST_CXX_FLAGS', '')
+python3 = os.environ.get('python3', '')
 
 assert llvm_path
 assert llvm_major_version
@@ -53,10 +54,12 @@ config.substitutions.append(('%clang_cxx', clang_cxx))
 config.substitutions.append(('%llvm_profdata', llvm_profdata))
 config.substitutions.append(('%CLANG_EXEC', clang_exec))
 config.substitutions.append(('%MULL_EXEC', portable_mull_exec))
+config.substitutions.append(('%mull_cxx', portable_mull_exec))
 config.substitutions.append(('%mull_runner', mull_runner))
 config.substitutions.append(('%FILECHECK_EXEC', filecheck_exec))
 config.substitutions.append(('%LLVM_PATH', llvm_path))
 config.substitutions.append(('%TEST_CXX_FLAGS', test_cxx_flags))
+config.substitutions.append(('%python3', python3))
 
 config.suffixes = ['.cpp', '.c', '.itest']
 

--- a/tests-lit/tests/runner/01/main.c
+++ b/tests-lit/tests/runner/01/main.c
@@ -1,0 +1,67 @@
+extern int printf(const char *, ...);
+extern int strcmp(const char *, const char *);
+
+int test1(int a, int b) {
+  return a + b;
+}
+
+int test2(int a, int b) {
+  return a * b;
+}
+
+int main(int argc, char **argv) {
+  if (argc == 1) {
+    printf("NOT ENOUGH ARGUMENTS\n");
+    return 1;
+  }
+  if (strcmp(argv[1], "first test") == 0) {
+    if (test1(2, 5) == 7) {
+      printf("first test passed\n");
+      return 0;
+    } else {
+      printf("first test failed\n");
+      return 1;
+    }
+  } else if (strcmp(argv[1], "second test") == 0) {
+    if (test2(2, 5) == 10) {
+      printf("second test passed\n");
+      return 0;
+    } else {
+      printf("second test failed\n");
+      return 1;
+    }
+  } else {
+    printf("INCORRECT TEST NAME %s\n", argv[1]);
+    return 1;
+  }
+  return 0;
+}
+
+// clang-format off
+
+// RUN: %clang_cc %s -fembed-bitcode -g -o %s.exe
+
+// RUN: %mull_cxx -linker=%clang_cc -keep-executable -mutate-only -output=%s.mutated.exe -mutators=cxx_add_to_sub -mutators=cxx_mul_to_div %s.exe | %FILECHECK_EXEC %s --dump-input=fail --match-full-lines --check-prefix=CHECK-MUTATE
+// CHECK-MUTATE: [info] Mutate-only mode on:{{.*}}
+// CHECK-MUTATE-NOT: [info] Sanity check run{{.*}}
+// CHECK-MUTATE-NOT: Running mutants
+
+// RUN: %mull_runner %s.mutated.exe -ide-reporter-show-killed -test-program %python3 -- %S/test.py %s.mutated.exe "first test case" | %FILECHECK_EXEC %s --dump-input=fail --match-full-lines --check-prefix=CHECK-TEST1
+// CHECK-TEST1: [info] Killed mutants (1/2):
+// CHECK-TEST1: {{.*}}/main.c:5:12: warning: Killed: Replaced + with - [cxx_add_to_sub]
+// CHECK-TEST1:   return a + b;
+// CHECK-TEST1:            ^
+// CHECK-TEST1: [info] Survived mutants (1/2):
+// CHECK-TEST1: {{.*}}/main.c:9:12: warning: Survived: Replaced * with / [cxx_mul_to_div]
+// CHECK-TEST1:   return a * b;
+// CHECK-TEST1:            ^
+
+// RUN: %mull_runner %s.mutated.exe -ide-reporter-show-killed -test-program %python3 -- %S/test.py %s.mutated.exe "second test case" | %FILECHECK_EXEC %s --dump-input=fail --match-full-lines --check-prefix=CHECK-TEST2
+// CHECK-TEST2: [info] Killed mutants (1/2):
+// CHECK-TEST2: {{.*}}/main.c:9:12: warning: Killed: Replaced * with / [cxx_mul_to_div]
+// CHECK-TEST2:   return a * b;
+// CHECK-TEST2:            ^
+// CHECK-TEST2: [info] Survived mutants (1/2):
+// CHECK-TEST2: {{.*}}/main.c:5:12: warning: Survived: Replaced + with - [cxx_add_to_sub]
+// CHECK-TEST2:   return a + b;
+// CHECK-TEST2:            ^

--- a/tests-lit/tests/runner/01/test.py
+++ b/tests-lit/tests/runner/01/test.py
@@ -1,0 +1,10 @@
+import sys
+import subprocess
+exec = sys.argv[1]
+test_name = sys.argv[2]
+
+if test_name == "first test case":
+    subprocess.run([exec, "first test"], check=True)
+
+if test_name == "second test case":
+    subprocess.run([exec, "second test"], check=True)

--- a/tools/CLIOptions/CLIOptions.h
+++ b/tools/CLIOptions/CLIOptions.h
@@ -11,13 +11,31 @@
 
 // clang-format off
 
+#define RunnerArgs_() \
+list<std::string> RunnerArgs( \
+    Positional, \
+    desc("free form arguments"), \
+    Optional, \
+    value_desc("strings"), \
+    ZeroOrMore, \
+    cat(MullCategory))
+
+#define TestProgram_() \
+opt<std::string> TestProgram( \
+    "test-program", \
+    desc("test program"), \
+    Optional, \
+    init(""), \
+    value_desc("path"), \
+    cat(MullCategory))
+
 #define InputFile_() \
 opt<std::string> InputFile( \
     Positional, \
     desc("<input file>"), \
     Required, \
     value_desc("path"), \
-    cat(MullCategory)) \
+    cat(MullCategory))
 
 #define OutputFile_() \
 opt<std::string> OutputFile( \
@@ -125,7 +143,15 @@ opt<std::string> CoverageInfo( \
 #define DryRunOption_() \
 opt<bool> DryRunOption( \
     "dry-run", \
-    desc("Skips real mutants execution. Disabled by default"), \
+    desc("Skips mutant execution and generation. Disabled by default"), \
+    Optional, \
+    init(false), \
+    cat(MullCategory))
+
+#define MutateOnly_() \
+opt<bool> MutateOnly( \
+    "mutate-only", \
+    desc("Skips mutant execution. Unlike -dry-run generates mutants. Disabled by default"), \
     Optional, \
     init(false), \
     cat(MullCategory))

--- a/tools/mull-cxx/mull-cxx-cli.h
+++ b/tools/mull-cxx/mull-cxx-cli.h
@@ -39,6 +39,7 @@ GitProjectRoot_();
 EnableAST_();
 DisableJunkDetection_();
 IDEReporterShowKilled_();
+MutateOnly_();
 
 void dumpCLIInterface(Diagnostics &diagnostics) {
   // Enumerating CLI options explicitly to control the order and what to show
@@ -50,6 +51,7 @@ void dumpCLIInterface(Diagnostics &diagnostics) {
       &Workers,
       &Timeout,
       &DryRunOption,
+      &MutateOnly,
 
       &ReportName,
       &ReportDirectory,

--- a/tools/mull-cxx/mull-cxx.cpp
+++ b/tools/mull-cxx/mull-cxx.cpp
@@ -88,6 +88,11 @@ int main(int argc, char **argv) {
 
   mull::Configuration configuration;
   configuration.dryRunEnabled = tool::DryRunOption.getValue();
+  if (tool::MutateOnly) {
+    diagnostics.info("Mutate-only mode on: Mull will generate mutants, but won't run them\n");
+    configuration.mutateOnly = true;
+    configuration.skipSanityCheckRun = true;
+  }
 
   configuration.linker = tool::Linker.getValue();
   configuration.linkerFlags = splitFlags(tool::LinkerFlags.getValue());
@@ -277,8 +282,10 @@ int main(int argc, char **argv) {
   mull::Driver driver(diagnostics, configuration, program, toolchain, filters, mutationsFinder);
   auto result = driver.run();
 
-  for (auto &reporter : reporters) {
-    reporter->reportResults(*result);
+  if (!configuration.mutateOnly) {
+    for (auto &reporter : reporters) {
+      reporter->reportResults(*result);
+    }
   }
 
   llvm::llvm_shutdown();

--- a/tools/mull-runner/mull-runner-cli.h
+++ b/tools/mull-runner/mull-runner-cli.h
@@ -21,11 +21,15 @@ ReportName_();
 ReportDirectory_();
 IDEReporterShowKilled_();
 IncludeNotCovered_();
+RunnerArgs_();
+TestProgram_();
 
 void dumpCLIInterface(mull::Diagnostics &diagnostics) {
   // Enumerating CLI options explicitly to control the order and what to show
   Option *reporters = &(Option &)ReportersOption;
   std::vector<Option *> mullOptions({
+      &(Option &)TestProgram,
+
       &Workers,
       &Timeout,
 

--- a/tools/mull-runner/mull-runner.cpp
+++ b/tools/mull-runner/mull-runner.cpp
@@ -83,13 +83,22 @@ int main(int argc, char **argv) {
   std::vector<std::unique_ptr<mull::Reporter>> reporters = reportersOption.reporters(params);
 
   std::string executable = tool::InputFile.getValue();
+  std::string testProgram = executable;
+  if (!tool::TestProgram.empty()) {
+    testProgram = tool::TestProgram.getValue();
+  }
+
+  std::vector<std::string> extraArgs;
+  for (size_t argIndex = 0; argIndex < tool::RunnerArgs.getNumOccurrences(); argIndex++) {
+    extraArgs.push_back(tool::RunnerArgs[argIndex]);
+  }
 
   mull::MutantExtractor mutantExtractor(diagnostics);
   std::vector<std::unique_ptr<mull::Mutant>> mutants = mutantExtractor.extractMutants(executable);
 
   mull::MutantRunner mutantRunner(diagnostics, configuration);
   std::vector<std::unique_ptr<mull::MutationResult>> mutationResults =
-      mutantRunner.runMutants(executable, mutants);
+      mutantRunner.runMutants(testProgram, extraArgs, mutants);
 
   auto result = std::make_unique<mull::Result>(std::move(mutants), std::move(mutationResults));
   for (auto &reporter : reporters) {


### PR DESCRIPTION
This PR concludes the implementation of #778.
What's left is documentation/tutorial, but that would come on the next iteration.

@ligurio, if you want to give it a try, then you can already try the following:


1. Generate mutated version of the program:
```
> mull-cxx -keep-executable \
  -mutate-only \
  -output=mutated-program \
  -mutators=cxx_add_to_sub \
  original-program-with-bitcode
```
2. Run the mutants against the separate test suite:
```
> mull-runner mutated-program  -test-program=python3  -- test-suite.py some "more arguments"
```
or
```
> mull-runner mutated-program  -test-program=test-suite.py  --  some "more arguments"
```

This is a very fresh implementation, so please consider it to be experimental :)
Any feedback is much appreciated!
