### PR TITLE
cxx-frontend: mutations in macros (two examples: add_to_sub and remove_void)

### DIFF
--- a/tests-lit/tests/cxx-frontend/mutations_in_macros/01_macro_add_to_sub/sample.cpp
+++ b/tests-lit/tests/cxx-frontend/mutations_in_macros/01_macro_add_to_sub/sample.cpp
@@ -1,0 +1,36 @@
+extern "C" {
+extern int printf(const char *, ...);
+}
+
+#define SUM(a, b) a + b
+int sum(int a, int b) {
+  return SUM(a, b);
+}
+
+int main() {
+  if (sum(2, 3) == 5) {
+    printf("NORMAL\n");
+    return 0;
+  } else {
+    printf("MUTATED\n");
+    return 1;
+  }
+}
+
+// clang-format off
+
+/**
+RUN: %CLANG_EXEC -Xclang -load -Xclang %mull_frontend_cxx -Xclang -add-plugin -Xclang mull-cxx-frontend -Xclang -plugin-arg-mull-cxx-frontend -Xclang mutators=cxx_add_to_sub %s -o %s.exe | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=FRONTEND
+FRONTEND:Recording mutation point: cxx_add_to_sub:{{.*}}/sample.cpp:5:21 (end: 5:22)
+
+RUN: %s.exe | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
+RUN: (env "cxx_add_to_sub:%s:5:21"=1 %s.exe || true) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
+
+STANDALONE_WITHOUT_MUTATION:NORMAL
+STANDALONE_WITH_MUTATION:MUTATED
+
+RUN: %mull_runner %s.exe -ide-reporter-show-killed | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
+
+MULL_RUNNER:[info] Killed mutants (1/1):
+MULL_RUNNER:{{.*}}sample.cpp:5:21: warning: Killed: Replaced + with - [cxx_add_to_sub]
+*/

--- a/tests-lit/tests/cxx-frontend/mutations_in_macros/02_macro_remove_void_function/sample.cpp
+++ b/tests-lit/tests/cxx-frontend/mutations_in_macros/02_macro_remove_void_function/sample.cpp
@@ -1,0 +1,43 @@
+extern "C" {
+extern int printf(const char *, ...);
+}
+
+void voidSum(int a, int b, int *result) {
+  *result = a + b;
+}
+
+#define VOID_SUM(a, b, result) voidSum(a, b, result)
+
+int sum(int a, int b) {
+  int result = 0;
+  VOID_SUM(a, b, &result);
+  return result;
+}
+
+int main() {
+  if (sum(2, 3) == 5) {
+    printf("NORMAL\n");
+    return 0;
+  } else {
+    printf("MUTATED\n");
+    return 1;
+  }
+}
+
+// clang-format off
+
+/**
+RUN: %CLANG_EXEC -Xclang -load -Xclang %mull_frontend_cxx -Xclang -add-plugin -Xclang mull-cxx-frontend -Xclang -plugin-arg-mull-cxx-frontend -Xclang mutators=cxx_remove_void_call %s -o %s.exe | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=FRONTEND
+FRONTEND:Recording mutation point: cxx_remove_void_call:{{.*}}/sample.cpp:9:32 (end: 9:53)
+
+RUN: %s.exe | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
+RUN: (env "cxx_remove_void_call:%s:9:32"=1 %s.exe || true) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
+
+STANDALONE_WITHOUT_MUTATION:NORMAL
+STANDALONE_WITH_MUTATION:MUTATED
+
+RUN: %mull_runner %s.exe -ide-reporter-show-killed | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
+
+MULL_RUNNER:[info] Killed mutants (1/1):
+MULL_RUNNER:{{.*}}sample.cpp:9:32: warning: Killed: Removed the call to the function [cxx_remove_void_call]
+*/

--- a/tests-lit/tests/cxx-frontend/mutations_in_macros/03_macro_add_to_sub_in_assert/sample.cpp
+++ b/tests-lit/tests/cxx-frontend/mutations_in_macros/03_macro_add_to_sub_in_assert/sample.cpp
@@ -1,0 +1,39 @@
+extern "C" {
+extern int printf(const char *, ...);
+extern void exit(int);
+}
+
+#define ASSERT(expr) \
+    (!(expr)) ? ((void)printf("MUTATED\n", #expr), exit(1)) : (void)0
+
+int test() {
+  ASSERT((2 + 3) == 5);
+  return 0;
+}
+
+int main() {
+  if (test() == 0) {
+    printf("NORMAL\n");
+    return 0;
+  }
+  printf("Should not reach here\n");
+  return 1;
+}
+
+// clang-format off
+
+/**
+RUN: %CLANG_EXEC -Xclang -load -Xclang %mull_frontend_cxx -Xclang -add-plugin -Xclang mull-cxx-frontend -Xclang -plugin-arg-mull-cxx-frontend -Xclang mutators=cxx_add_to_sub %s -o %s.exe | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=FRONTEND
+FRONTEND:Recording mutation point: cxx_add_to_sub:{{.*}}/sample.cpp:10:13 (end: 10:14)
+
+RUN: %s.exe | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
+RUN: (env "cxx_add_to_sub:%s:10:13"=1 %s.exe || true) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
+
+STANDALONE_WITHOUT_MUTATION:NORMAL
+STANDALONE_WITH_MUTATION:MUTATED
+
+RUN: %mull_runner %s.exe -ide-reporter-show-killed | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
+
+MULL_RUNNER:[info] Killed mutants (1/1):
+MULL_RUNNER:{{.*}}sample.cpp:10:13: warning: Killed: Replaced + with - [cxx_add_to_sub]
+*/

--- a/tools/mull-cxx-frontend/src/ASTMutationsSearchVisitor.h
+++ b/tools/mull-cxx-frontend/src/ASTMutationsSearchVisitor.h
@@ -28,6 +28,9 @@ public:
 private:
   bool isValidMutation(mull::MutatorKind mutatorKind);
   void recordMutationPoint(mull::MutatorKind mutatorKind, std::unique_ptr<ASTMutation> mutation,
-                           clang::Stmt *stmt, clang::SourceLocation beginLocation,
+                           clang::Stmt *stmt, clang::SourceLocation mutationLocation,
                            bool locationIsExpression);
+  std::pair<clang::SourceLocation, clang::SourceLocation>
+  getBeginEndMutationLocation(clang::Stmt *stmt, clang::SourceLocation mutationLocation,
+                              bool locationIsExpression);
 };


### PR DESCRIPTION
Depends on #872.