### PR TITLE
tests-lit: fix two regex-based tests

### DIFF
--- a/infrastructure/macos-playbook.yaml
+++ b/infrastructure/macos-playbook.yaml
@@ -43,7 +43,7 @@
       pip:
         name:
           - lit==0.9.0
-          - filecheck==0.0.16
+          - filecheck==0.0.18
           - cloudsmith-cli==0.26.0
         executable: pip3
 

--- a/infrastructure/ubuntu-playbook.yaml
+++ b/infrastructure/ubuntu-playbook.yaml
@@ -44,7 +44,7 @@
       pip:
         name:
           - lit==0.9.0
-          - filecheck==0.0.16
+          - filecheck==0.0.18
           - cloudsmith-cli==0.26.0
         executable: pip3
 

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/03-warning-when-reading-git-diff-from-a-non-git-folder/test.itest
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/03-warning-when-reading-git-diff-from-a-non-git-folder/test.itest
@@ -4,4 +4,4 @@ RUN: cp %S/sample.cpp.modified $TEMPDIR/sample.cpp
 RUN: cd / && %CLANG_EXEC -fembed-bitcode -g -O0 $TEMPDIR/sample.cpp -o $TEMPDIR/sample.cpp.exe
 RUN: cd $TEMPDIR && (unset TERM; %MULL_EXEC -git-diff-ref=master -git-project-root=$TEMPDIR -linker=%clang_cxx -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed $TEMPDIR/sample.cpp.exe 2>&1; test $? = 0) | %FILECHECK_EXEC %s --dump-input=fail --strict-whitespace --match-full-lines
 
-CHECK:[warning] GitDiffReader: cannot get git diff information. Received output: {{.*}}Not a git repository
+CHECK:[warning] GitDiffReader: cannot get git diff information. Received output: {{.*}}Not a git repository{{.*}}

--- a/tests-lit/tests/options/-ide-reporter-show-killed/01_one_killed/sample.cpp
+++ b/tests-lit/tests/options/-ide-reporter-show-killed/01_one_killed/sample.cpp
@@ -20,7 +20,7 @@ RUN: (unset TERM; %MULL_EXEC -linker=%clang_cxx -mutators=cxx_add_to_sub -report
 WITH-OPTION:[info] Running mutants (threads: 1)
 WITH-OPTION:{{^       \[################################\] 1/1\. Finished .*}}
 WITH-OPTION:[info] Killed mutants (1/1):
-WITH-OPTION-NEXT:{{^.*}}sample.cpp:31:18: warning: Killed: Replaced + with -
+WITH-OPTION-NEXT:{{^.*}}sample.cpp:31:18: warning: Killed: Replaced + with - [cxx_add_to_sub]
 WITH-OPTION-NEXT:  int result = a + b;
 WITH-OPTION-NEXT:                 ^
 WITH-OPTION-NEXT:[info] All mutations have been killed

--- a/tests-lit/tests/options/-ide-reporter-show-killed/02_one_survived/sample.cpp
+++ b/tests-lit/tests/options/-ide-reporter-show-killed/02_one_survived/sample.cpp
@@ -13,7 +13,7 @@ RUN: (unset TERM; %MULL_EXEC -linker=%clang_cxx -mutators=cxx_add_to_sub -report
 WITHOUT-OPTION:[info] Running mutants (threads: 1)
 WITHOUT-OPTION:{{^       \[################################\] 1/1\. Finished .*}}
 WITHOUT-OPTION:[info] Survived mutants (1/1):
-WITHOUT-OPTION-NEXT:{{^.*}}sample.cpp:33:18: warning: Survived: Replaced + with -
+WITHOUT-OPTION-NEXT:{{^.*}}sample.cpp:33:18: warning: Survived: Replaced + with - [cxx_add_to_sub]
 WITHOUT-OPTION-NEXT:  int result = a + b;
 WITHOUT-OPTION-NEXT:                 ^
 WITHOUT-OPTION-NEXT:[info] Mutation score: 0%
@@ -23,7 +23,7 @@ RUN: (unset TERM; %MULL_EXEC -linker=%clang_cxx -mutators=cxx_add_to_sub -report
 WITH-OPTION:[info] Running mutants (threads: 1)
 WITH-OPTION:{{^       \[################################\] 1/1\. Finished .*}}
 WITH-OPTION:[info] Survived mutants (1/1):
-WITH-OPTION-NEXT:{{^.*}}sample.cpp:33:18: warning: Survived: Replaced + with -
+WITH-OPTION-NEXT:{{^.*}}sample.cpp:33:18: warning: Survived: Replaced + with - [cxx_add_to_sub]
 WITH-OPTION-NEXT:  int result = a + b;
 WITH-OPTION-NEXT:                 ^
 WITH-OPTION-NEXT:[info] Mutation score: 0%


### PR DESCRIPTION
The new filecheck 0.0.18 contains a fix:

CHECK: regex lines: match full lines when strict mode is enabled #155

Before this fix, it was possible to pass a non-full line with a regex and it would work even though the strict mode flags were provided (--strict-whitespace and --match-full-lines).