### PR TITLE
cxx-frontend: fix the AST factory of getenv()

### DIFF
--- a/tools/mull-cxx-frontend/src/ClangASTMutator.cpp
+++ b/tools/mull-cxx-frontend/src/ClangASTMutator.cpp
@@ -138,12 +138,12 @@ clang::CallExpr *ClangASTMutator::createGetenvCallExpr(std::string identifier) {
                                    identifier,
                                    clang::StringLiteral::StringKind::Ascii,
                                    false,
-                                   factory.getConstantArrayType(context.CharTy, identifier.size()),
+                                   factory.getStringLiteralArrayType(context.CharTy, identifier.size()),
                                    clang::SourceLocation());
 
   clang::ImplicitCastExpr *implicitCastExpr2 =
       clang::ImplicitCastExpr::Create(context,
-                                      context.getPointerType(context.CharTy),
+                                      context.getPointerType(context.getConstType(context.CharTy)),
                                       clang::CastKind::CK_ArrayToPointerDecay,
                                       stringLiteral,
                                       nullptr,


### PR DESCRIPTION
Building against LLVM/Clang source revealed that the getenv() function factory was not using correct types. With this change, consistent results are observed when comparing AST dump of getenv() created by AST and by hand.