### PR TITLE
Set a reasonable lower bound value for the timeout

### DIFF
--- a/lib/Parallelization/Tasks/MutantExecutionTask.cpp
+++ b/lib/Parallelization/Tasks/MutantExecutionTask.cpp
@@ -25,7 +25,7 @@ void MutantExecutionTask::operator()(iterator begin, iterator end, Out &storage,
       result = runner.runProgram(executable,
                                  extraArgs,
                                  { mutant->getIdentifier() },
-                                 baseline.runningTime * 10,
+                                 std::max(30LL, baseline.runningTime * 10),
                                  configuration.captureMutantOutput,
                                  std::nullopt);
     } else {


### PR DESCRIPTION
This important part was lost several months ago here https://github.com/mull-project/mull/commit/8346b8720648576e9355e9b0e8a153e150041d4f#diff-f353c4a77d760052da83fef010d3308cd3d51bcd91ff871cc984048d7f6626e4L37-R27

This is (hopefully) related to #890.