### PR TITLE
Protect getLocForEndOfToken in ThreadSafeASTUnit

### DIFF
--- a/include/mull/JunkDetection/CXX/ASTStorage.h
+++ b/include/mull/JunkDetection/CXX/ASTStorage.h
@@ -24,6 +24,7 @@ public:
   clang::ASTContext &getASTContext();
 
   clang::SourceLocation getLocation(const mull::SourceLocation &sourceLocation);
+  clang::SourceLocation getLocForEndOfToken(const clang::SourceLocation sourceLocationEnd);
   bool isInSystemHeader(clang::SourceLocation &location);
 
   clang::Decl *getDecl(clang::SourceLocation &location);

--- a/lib/JunkDetection/CXX/CXXJunkDetector.cpp
+++ b/lib/JunkDetection/CXX/CXXJunkDetector.cpp
@@ -224,8 +224,6 @@ bool CXXJunkDetector::isJunk(MutationPoint *point) {
   int mutationLocationBeginLine = sourceManager.getExpansionLineNumber(location, nullptr);
   int mutationLocationBeginColumn = sourceManager.getExpansionColumnNumber(location);
 
-  clang::ASTContext &astContext = ast->getASTContext();
-
   /// There are two types of mutated expressions:
   /// 1) Remove-Void, CallExpr example: its mutation location and its getStart() are the same.
   /// 2) Binary Mutation, BinaryOperator example: its mutation location is
@@ -240,8 +238,7 @@ bool CXXJunkDetector::isJunk(MutationPoint *point) {
   /// Clang AST: how to get more precise debug information in certain cases?
   /// http://clang-developers.42468.n3.nabble.com/Clang-AST-how-to-get-more-precise-debug-information-in-certain-cases-td4065195.html
   /// https://stackoverflow.com/questions/11083066/getting-the-source-behind-clangs-ast
-  clang::SourceLocation sourceLocationEndActual = clang::Lexer::getLocForEndOfToken(
-      sourceLocationEnd, 0, sourceManager, astContext.getLangOpts());
+  clang::SourceLocation sourceLocationEndActual = ast->getLocForEndOfToken(sourceLocationEnd);
 
   int endLine = sourceManager.getExpansionLineNumber(sourceLocationEndActual, nullptr);
   int endColumn = sourceManager.getExpansionColumnNumber(sourceLocationEndActual);


### PR DESCRIPTION
getLocForEndOfToken is internally calling getLocation or another not thread safe function. getLocation is known and
already protected for multithreading access. This protects the
getLocForEndOfToken, too.

Fixes https://github.com/mull-project/mull/issues/894