### PR TITLE
Print messages about current mutant in debug mode

### DIFF
--- a/lib/Parallelization/Tasks/MutantExecutionTask.cpp
+++ b/lib/Parallelization/Tasks/MutantExecutionTask.cpp
@@ -3,7 +3,10 @@
 #include "mull/Config/Configuration.h"
 #include "mull/Diagnostics/Diagnostics.h"
 #include "mull/Parallelization/Progress.h"
+#include "mull/SourceLocation.h"
 #include "mull/Toolchain/Runner.h"
+
+#include <sstream>
 
 using namespace mull;
 using namespace std::string_literals;
@@ -18,6 +21,7 @@ MutantExecutionTask::MutantExecutionTask(const Configuration &configuration,
 void MutantExecutionTask::operator()(iterator begin, iterator end, Out &storage,
                                      progress_counter &counter) {
   Runner runner(diagnostics);
+  std::stringstream debugMessage;
   for (auto it = begin; it != end; ++it, counter.increment()) {
     auto &mutant = *it;
     ExecutionResult result;
@@ -32,5 +36,10 @@ void MutantExecutionTask::operator()(iterator begin, iterator end, Out &storage,
       result.status = NotCovered;
     }
     storage.push_back(std::make_unique<MutationResult>(result, mutant.get()));
+    SourceLocation sourceLocation = mutant->getSourceLocation();
+    debugMessage << sourceLocation.filePath << ":";
+    debugMessage << sourceLocation.line << ":" << sourceLocation.column;
+    debugMessage << result.status;
+    diagnostics.debug(debugMessage.str());
   }
 }


### PR DESCRIPTION
Now Mull shows the same output with enable and disabled debug mode on running
mutants. It contains only progress-bar with total and a number of run mutants:

[info] Warm up run (threads: 1)
       [################################] 1/1. Finished in 26296ms
[info] Baseline run (threads: 1)
       [################################] 1/1. Finished in 25931ms
[info] Running mutants (threads: 8)
       [######################----------] 45608/65704

When an total time of mutation testing takes a lot of time it is useful to show
more information about current mutants, like file with mutant and status of
execution.