### PR TITLE
Remove last reference to test-framework

### DIFF
--- a/docs/tutorials/SQLiteReport.rst
+++ b/docs/tutorials/SQLiteReport.rst
@@ -95,8 +95,7 @@ It is also recommended to specify the report name via ``-report-name``, e.g.:
 
 .. code-block::
 
-    mull-cxx -test-framework=GoogleTest \
-      -mutators=cxx_add_to_sub \
+    mull-cxx -mutators=cxx_add_to_sub \
       -compdb-path compile_commands.json \
       -compilation-flags="\
         -isystem /opt/llvm/5.0.0/include/c++/v1 \


### PR DESCRIPTION
There was one reference to the `-test-framework` command line option in the documentation.