### PR TITLE
Clear debugMessage in MutantExecution

### DIFF
--- a/lib/Parallelization/Tasks/MutantExecutionTask.cpp
+++ b/lib/Parallelization/Tasks/MutantExecutionTask.cpp
@@ -41,5 +41,6 @@ void MutantExecutionTask::operator()(iterator begin, iterator end, Out &storage,
     debugMessage << sourceLocation.line << ":" << sourceLocation.column;
     debugMessage << result.status;
     diagnostics.debug(debugMessage.str());
+    debugMessage.str(std::string());
   }
 }


### PR DESCRIPTION
This clears the debugOutput after logging it, so it will no longer concat all the source locations.