### PR TITLE
Fixed order of drain and wait, as proposed in the example of reproc

### DIFF
--- a/lib/Toolchain/Runner.cpp
+++ b/lib/Toolchain/Runner.cpp
@@ -41,6 +41,9 @@ ExecutionResult Runner::runProgram(const std::string &program,
   reproc::options options;
   options.env.extra = reproc::env(env);
   options.redirect.err.type = reproc::redirect::type::pipe;
+  options.stop.first.action = reproc::stop::kill;
+  options.stop.first.timeout = std::chrono::milliseconds(100);
+  options.deadline = std::chrono::milliseconds(timeout);
   if (auto &workingDirectory = optionalWorkingDirectory) {
     options.working_directory = workingDirectory->c_str();
   }

--- a/lib/Toolchain/Runner.cpp
+++ b/lib/Toolchain/Runner.cpp
@@ -68,6 +68,8 @@ ExecutionResult Runner::runProgram(const std::string &program,
   }
 
   int status;
+
+  auto outputs = drainProcess(process, captureOutput);
   std::tie(status, ec) = process.wait(reproc::milliseconds(timeout));
   ExecutionStatus executionStatus = Failed;
   if (ec == std::errc::timed_out) {
@@ -78,8 +80,6 @@ ExecutionResult Runner::runProgram(const std::string &program,
   } else {
     executionStatus = Failed;
   }
-
-  auto outputs = drainProcess(process, captureOutput);
 
   auto elapsed = std::chrono::high_resolution_clock::now() - start;
   ExecutionResult result;


### PR DESCRIPTION
The incorrect order of drain and wait causes an incorrect recognition of failed original test and prolonged timeouts.

See https://github.com/DaanDeMeyer/reproc/blob/main/reproc%2B%2B/examples/drain.cpp#L50