### PR TITLE
detect invalid regex

### DIFF
--- a/include/mull/Filters/FilePathFilter.h
+++ b/include/mull/Filters/FilePathFilter.h
@@ -28,8 +28,14 @@ public:
 private:
   bool shouldSkip(const mull::SourceLocation &location) const;
 
+// The API of llvm::Regex support const match starting from 10.0.0
+#if LLVM_VERSION_MAJOR >= 10
+  std::vector<llvm::Regex> includeFilters;
+  std::vector<llvm::Regex> excludeFilters;
+#else
   mutable std::vector<llvm::Regex> includeFilters;
   mutable std::vector<llvm::Regex> excludeFilters;
+#endif
 
   mutable std::unordered_map<std::string, bool> cache;
   mutable std::mutex cacheMutex;

--- a/include/mull/Filters/FilePathFilter.h
+++ b/include/mull/Filters/FilePathFilter.h
@@ -4,17 +4,17 @@
 #include "mull/Filters/InstructionFilter.h"
 #include "mull/Filters/MutationFilter.h"
 
+#include <llvm/Support/Regex.h>
 #include <mutex>
-#include <regex>
+#include <string>
+#include <utility>
 #include <unordered_map>
 #include <vector>
 
 namespace mull {
 struct SourceLocation;
 
-class FilePathFilter : public MutationFilter,
-                       public FunctionFilter,
-                       public InstructionFilter {
+class FilePathFilter : public MutationFilter, public FunctionFilter, public InstructionFilter {
 public:
   bool shouldSkip(MutationPoint *point) override;
   bool shouldSkip(llvm::Function *function) override;
@@ -22,14 +22,14 @@ public:
   bool shouldSkip(const std::string &sourceFilePath) const;
 
   std::string name() override;
-  void exclude(const std::string &filter);
-  void include(const std::string &filter);
+  std::pair<bool, std::string> exclude(const std::string &filter);
+  std::pair<bool, std::string> include(const std::string &filter);
 
 private:
   bool shouldSkip(const mull::SourceLocation &location) const;
 
-  std::vector<std::regex> includeFilters;
-  std::vector<std::regex> excludeFilters;
+  mutable std::vector<llvm::Regex> includeFilters;
+  mutable std::vector<llvm::Regex> excludeFilters;
 
   mutable std::unordered_map<std::string, bool> cache;
   mutable std::mutex cacheMutex;

--- a/lib/Filters/FilePathFilter.cpp
+++ b/lib/Filters/FilePathFilter.cpp
@@ -69,7 +69,7 @@ std::pair<bool, std::string> FilePathFilter::exclude(const std::string &filter) 
   if (!regex_filter.isValid(error)) {
     return std::make_pair(false, std::move(error));
   }
-  excludeFilters.emplace_back(filter);
+  excludeFilters.emplace_back(regex_filter);
   return std::make_pair(true, std::string());
 }
 
@@ -79,6 +79,6 @@ std::pair<bool, std::string> FilePathFilter::include(const std::string &filter) 
   if (!regex_filter.isValid(error)) {
     return std::make_pair(false, std::move(error));
   }
-  includeFilters.emplace_back(filter);
+  includeFilters.emplace_back(regex_filter);
   return std::make_pair(true, std::string());
 }

--- a/lib/Filters/FilePathFilter.cpp
+++ b/lib/Filters/FilePathFilter.cpp
@@ -36,7 +36,11 @@ bool FilePathFilter::shouldSkip(const std::string &sourceFilePath) const {
     if (!includeFilters.empty()) {
       allow = false;
 
+#if LLVM_VERSION_MAJOR >= 10
+      for (const auto &r : includeFilters) {
+#else
       for (auto &r : includeFilters) {
+#endif
         if (r.match(sourceFilePathCopy)) {
           allow = true;
           break;
@@ -44,7 +48,11 @@ bool FilePathFilter::shouldSkip(const std::string &sourceFilePath) const {
       }
     }
     if (allow) {
+#if LLVM_VERSION_MAJOR >= 10
+      for (const auto &r : excludeFilters) {
+#else
       for (auto &r : excludeFilters) {
+#endif
         if (r.match(sourceFilePathCopy)) {
           allow = false;
           break;
@@ -69,7 +77,7 @@ std::pair<bool, std::string> FilePathFilter::exclude(const std::string &filter) 
   if (!regex_filter.isValid(error)) {
     return std::make_pair(false, std::move(error));
   }
-  excludeFilters.emplace_back(regex_filter);
+  excludeFilters.emplace_back(std::move(regex_filter));
   return std::make_pair(true, std::string());
 }
 
@@ -79,6 +87,6 @@ std::pair<bool, std::string> FilePathFilter::include(const std::string &filter) 
   if (!regex_filter.isValid(error)) {
     return std::make_pair(false, std::move(error));
   }
-  includeFilters.emplace_back(regex_filter);
+  includeFilters.emplace_back(std::move(regex_filter));
   return std::make_pair(true, std::string());
 }

--- a/tests-lit/tests/xclude-regex/invalid_regex/sample.cpp
+++ b/tests-lit/tests/xclude-regex/invalid_regex/sample.cpp
@@ -1,0 +1,24 @@
+int equal(int a, int b) {
+  return a == b;
+}
+
+int main() {
+  return equal(2, 2) != 1;
+}
+
+// clang-format off
+/**
+
+RUN: cd %S
+RUN: mkdir -p %S/Output/sandbox
+RUN: cp %S/main.cpp %S/Output/sandbox/main.cpp
+RUN: cd %S/Output/sandbox
+
+/// We cd to the the test directory and compile using relative paths.
+RUN: cd %S; %clang_cxx %sysroot -fembed-bitcode -g -O0 Output/sandbox/main.cpp -o Output/main.cpp.exe
+
+RUN: cd %S/Output && echo $PATH; (unset TERM; %mull_cxx -mutators=cxx_eq_to_ne -linker-flags="%sysroot" --linker=%clang_cxx -debug main.cpp.exe --reporters IDE --include-path=*cpp --exclude-path=Output/.***; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+
+CHECK:[warning] Invalid regex for include{{.*}}
+CHECK:[warning] Invalid regex for exclue{{.*}}
+*/

--- a/tests-lit/tests/xclude-regex/invalid_regex/sample.cpp
+++ b/tests-lit/tests/xclude-regex/invalid_regex/sample.cpp
@@ -11,14 +11,14 @@ int main() {
 
 RUN: cd %S
 RUN: mkdir -p %S/Output/sandbox
-RUN: cp %S/main.cpp %S/Output/sandbox/main.cpp
+RUN: cp %S/sample.cpp %S/Output/sandbox/sample.cpp
 RUN: cd %S/Output/sandbox
 
 /// We cd to the the test directory and compile using relative paths.
-RUN: cd %S; %clang_cxx %sysroot -fembed-bitcode -g -O0 Output/sandbox/main.cpp -o Output/main.cpp.exe
+RUN: cd %S; %clang_cxx %sysroot -fembed-bitcode -g -O0 Output/sandbox/sample.cpp -o Output/sample.cpp.exe
 
-RUN: cd %S/Output && echo $PATH; (unset TERM; %mull_cxx -mutators=cxx_eq_to_ne -linker-flags="%sysroot" --linker=%clang_cxx -debug main.cpp.exe --reporters IDE --include-path=*cpp --exclude-path=Output/.***; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output && echo $PATH; (unset TERM; %mull_cxx -mutators=cxx_eq_to_ne -linker-flags="%sysroot" --linker=%clang_cxx -debug sample.cpp.exe --reporters IDE --include-path=*cpp --exclude-path=Output/.***; test $? == 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
-CHECK:[warning] Invalid regex for include{{.*}}
-CHECK:[warning] Invalid regex for exclue{{.*}}
+CHECK:[warning] Invalid regex for exclude-path:{{.*}}
+CHECK:[warning] Invalid regex for include-path:{{.*}}
 */

--- a/tests-lit/tests/xclude-regex/valid_regex/sample.cpp
+++ b/tests-lit/tests/xclude-regex/valid_regex/sample.cpp
@@ -1,0 +1,23 @@
+int equal(int a, int b) {
+  return a == b;
+}
+
+int main() {
+  return equal(2, 2) != 1;
+}
+
+// clang-format off
+/**
+
+RUN: cd %S
+RUN: mkdir -p %S/Output/sandbox
+RUN: cp %S/main.cpp %S/Output/sandbox/main.cpp
+RUN: cd %S/Output/sandbox
+
+/// We cd to the the test directory and compile using relative paths.
+RUN: cd %S; %clang_cxx %sysroot -fembed-bitcode -g -O0 Output/sandbox/main.cpp -o Output/main.cpp.exe
+
+RUN: cd %S/Output && echo $PATH; (unset TERM; %mull_cxx -mutators=cxx_eq_to_ne -linker-flags="%sysroot" --linker=%clang_cxx -debug main.cpp.exe --reporters IDE --include-path=.*cpp --exclude-path=Output/.*; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+
+CHECK-NOT:[warning] Invalid regex{{.*}}
+*/

--- a/tests-lit/tests/xclude-regex/valid_regex/sample.cpp
+++ b/tests-lit/tests/xclude-regex/valid_regex/sample.cpp
@@ -11,13 +11,13 @@ int main() {
 
 RUN: cd %S
 RUN: mkdir -p %S/Output/sandbox
-RUN: cp %S/main.cpp %S/Output/sandbox/main.cpp
+RUN: cp %S/sample.cpp %S/Output/sandbox/sample.cpp
 RUN: cd %S/Output/sandbox
 
 /// We cd to the the test directory and compile using relative paths.
-RUN: cd %S; %clang_cxx %sysroot -fembed-bitcode -g -O0 Output/sandbox/main.cpp -o Output/main.cpp.exe
+RUN: cd %S; %clang_cxx %sysroot -fembed-bitcode -g -O0 Output/sandbox/sample.cpp -o Output/sample.cpp.exe
 
-RUN: cd %S/Output && echo $PATH; (unset TERM; %mull_cxx -mutators=cxx_eq_to_ne -linker-flags="%sysroot" --linker=%clang_cxx -debug main.cpp.exe --reporters IDE --include-path=.*cpp --exclude-path=Output/.*; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output && echo $PATH; (unset TERM; %mull_cxx -mutators=cxx_eq_to_ne -linker-flags="%sysroot" --linker=%clang_cxx -debug sample.cpp.exe --reporters IDE --include-path=.*cpp --exclude-path=Output/.*; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK-NOT:[warning] Invalid regex{{.*}}
 */

--- a/tests/Mutations-E2E/CXX/Arithmetic/Mutation_Arithmetic_Add_Test.cpp
+++ b/tests/Mutations-E2E/CXX/Arithmetic/Mutation_Arithmetic_Add_Test.cpp
@@ -8,6 +8,8 @@
 
 #include <gtest/gtest.h>
 
+#include <regex>
+
 using namespace mull;
 using namespace mull_test;
 using namespace llvm;

--- a/tests/Mutations-E2E/CXX/Arithmetic/Mutation_Arithmetic_UnaryMinusToNoop_Test.cpp
+++ b/tests/Mutations-E2E/CXX/Arithmetic/Mutation_Arithmetic_UnaryMinusToNoop_Test.cpp
@@ -8,6 +8,8 @@
 
 #include <gtest/gtest.h>
 
+#include <regex>
+
 using namespace mull;
 using namespace mull_test;
 using namespace llvm;

--- a/tests/Mutations-E2E/CXX/ConstAssignment/Mutation_ConstAssignment_AssignConst.cpp
+++ b/tests/Mutations-E2E/CXX/ConstAssignment/Mutation_ConstAssignment_AssignConst.cpp
@@ -7,6 +7,7 @@
 #include <clang/Frontend/ASTUnit.h>
 #include <clang/Tooling/Tooling.h>
 #include <llvm/IR/Module.h>
+#include <regex>
 
 #include "Helpers/MutationTestBed.h"
 

--- a/tests/Mutations-E2E/CXX/ConstAssignment/Mutation_ConstAssignment_InitConst.cpp
+++ b/tests/Mutations-E2E/CXX/ConstAssignment/Mutation_ConstAssignment_InitConst.cpp
@@ -13,6 +13,8 @@
 
 #include <gtest/gtest.h>
 
+#include <regex>
+
 using namespace mull;
 using namespace mull::cxx;
 using namespace mull_test;

--- a/tests/Mutations-E2E/CXX/RemoveNegationTest.cpp
+++ b/tests/Mutations-E2E/CXX/RemoveNegationTest.cpp
@@ -7,6 +7,7 @@
 #include "Helpers/MutationTestBed.h"
 
 #include <gtest/gtest.h>
+#include <regex>
 
 using namespace mull;
 using namespace mull_test;

--- a/tests/Mutations-E2E/Scalar/01_Mutation_Scalar_ReturnValue_Test.cpp
+++ b/tests/Mutations-E2E/Scalar/01_Mutation_Scalar_ReturnValue_Test.cpp
@@ -12,6 +12,8 @@
 
 #include <gtest/gtest.h>
 
+#include <regex>
+
 using namespace mull;
 using namespace mull_test;
 using namespace llvm;

--- a/tests/Mutations-E2E/Scalar/02_Mutation_Scalar_BinaryOperand_Test.cpp
+++ b/tests/Mutations-E2E/Scalar/02_Mutation_Scalar_BinaryOperand_Test.cpp
@@ -12,6 +12,8 @@
 
 #include <gtest/gtest.h>
 
+#include <regex>
+
 using namespace mull;
 using namespace mull_test;
 using namespace llvm;

--- a/tools/mull-cxx/mull-cxx.cpp
+++ b/tools/mull-cxx/mull-cxx.cpp
@@ -221,7 +221,7 @@ int main(int argc, char **argv) {
     auto added = filePathFilter->exclude(regex);
     if (!added.first){
       std::stringstream warningMessage;
-      warningMessage << "Invalid regex for path exlusion: '" << regex << "' has been ignored. Error: " << added.second;
+      warningMessage << "Invalid regex for exclude-path: '" << regex << "' has been ignored. Error: " << added.second;
       diagnostics.warning(warningMessage.str());
     }
   }
@@ -229,7 +229,7 @@ int main(int argc, char **argv) {
     auto added = filePathFilter->include(regex);
     if (!added.first){
       std::stringstream warningMessage;
-      warningMessage << "Invalid regex for path inclusion '" << regex << "' has been ignored. Error: " << added.second;
+      warningMessage << "Invalid regex for include-path: '" << regex << "' has been ignored. Error: " << added.second;
       diagnostics.warning(warningMessage.str());
     }
   }

--- a/tools/mull-cxx/mull-cxx.cpp
+++ b/tools/mull-cxx/mull-cxx.cpp
@@ -218,10 +218,20 @@ int main(int argc, char **argv) {
   filters.functionFilters.push_back(filePathFilter);
 
   for (const auto &regex : tool::ExcludePaths) {
-    filePathFilter->exclude(regex);
+    auto added = filePathFilter->exclude(regex);
+    if (!added.first){
+      std::stringstream warningMessage;
+      warningMessage << "Invalid regex for path exlusion: '" << regex << "' has been ignored. Error: " << added.second;
+      diagnostics.warning(warningMessage.str());
+    }
   }
   for (const auto &regex : tool::IncludePaths) {
-    filePathFilter->include(regex);
+    auto added = filePathFilter->include(regex);
+    if (!added.first){
+      std::stringstream warningMessage;
+      warningMessage << "Invalid regex for path inclusion '" << regex << "' has been ignored. Error: " << added.second;
+      diagnostics.warning(warningMessage.str());
+    }
   }
 
   if (!tool::GitDiffRef.getValue().empty()) {


### PR DESCRIPTION
As this is only possible by catching the exception the flag
-fno-exception has been removed


Fixes: https://github.com/mull-project/mull/issues/845