### PR TITLE
Do not lower bitcode into machine code by default

### DIFF
--- a/docs/command-line/generated/mull-cxx-cli-options.rst
+++ b/docs/command-line/generated/mull-cxx-cli-options.rst
@@ -8,6 +8,8 @@
 
 --mutate-only		Skips mutant execution. Unlike -dry-run generates mutants. Disabled by default
 
+--lower-bitcode		Lower bitcode into machine code for linking. Disabled by default
+
 --report-name filename		Filename for the report (only for supported reporters). Defaults to <timestamp>.<extension>
 
 --report-dir directory		Where to store report (defaults to '.')

--- a/include/mull/Config/Configuration.h
+++ b/include/mull/Config/Configuration.h
@@ -20,6 +20,7 @@ struct Configuration {
   bool keepObjectFiles;
   bool keepExecutable;
   bool mutateOnly;
+  bool lowerBitcode;
 
   int timeout;
   unsigned linkerTimeout;

--- a/lib/Config/Configuration.cpp
+++ b/lib/Config/Configuration.cpp
@@ -18,8 +18,8 @@ unsigned MullDefaultLinkerTimeoutMilliseconds = 30000;
 Configuration::Configuration()
     : debugEnabled(false), dryRunEnabled(false), captureTestOutput(true), captureMutantOutput(true),
       skipSanityCheckRun(false), includeNotCovered(false), keepObjectFiles(false),
-      keepExecutable(false), mutateOnly(false), timeout(MullDefaultTimeoutMilliseconds),
-      linkerTimeout(MullDefaultLinkerTimeoutMilliseconds), diagnostics(IDEDiagnosticsKind::None),
-      parallelization(singleThreadParallelization()) {}
+      keepExecutable(false), mutateOnly(false), lowerBitcode(false),
+      timeout(MullDefaultTimeoutMilliseconds), linkerTimeout(MullDefaultLinkerTimeoutMilliseconds),
+      diagnostics(IDEDiagnosticsKind::None), parallelization(singleThreadParallelization()) {}
 
 } // namespace mull

--- a/tools/CLIOptions/CLIOptions.h
+++ b/tools/CLIOptions/CLIOptions.h
@@ -7,9 +7,9 @@
 #include <mull/Reporters/Reporter.h>
 #include <mull/Toolchain/Toolchain.h>
 #include <sstream>
+#include <string>
 #include <unordered_map>
 #include <vector>
-#include <string>
 
 // clang-format off
 
@@ -163,6 +163,14 @@ opt<bool> DryRunOption( \
 opt<bool> MutateOnly( \
     "mutate-only", \
     desc("Skips mutant execution. Unlike -dry-run generates mutants. Disabled by default"), \
+    Optional, \
+    init(false), \
+    cat(MullCategory))
+
+#define LowerBitcode_() \
+opt<bool> LowerBitcode( \
+    "lower-bitcode", \
+    desc("Lower bitcode into machine code for linking. Disabled by default"), \
     Optional, \
     init(false), \
     cat(MullCategory))

--- a/tools/mull-cxx/mull-cxx-cli.h
+++ b/tools/mull-cxx/mull-cxx-cli.h
@@ -40,6 +40,7 @@ GitProjectRoot_();
 DisableJunkDetection_();
 IDEReporterShowKilled_();
 MutateOnly_();
+LowerBitcode_();
 
 void dumpCLIInterface(Diagnostics &diagnostics) {
   // Enumerating CLI options explicitly to control the order and what to show
@@ -52,6 +53,7 @@ void dumpCLIInterface(Diagnostics &diagnostics) {
       &Timeout,
       &DryRunOption,
       &MutateOnly,
+      &LowerBitcode,
 
       &ReportName,
       &ReportDirectory,

--- a/tools/mull-cxx/mull-cxx.cpp
+++ b/tools/mull-cxx/mull-cxx.cpp
@@ -94,6 +94,7 @@ int main(int argc, char **argv) {
 
   mull::Configuration configuration;
   configuration.dryRunEnabled = tool::DryRunOption.getValue();
+  configuration.lowerBitcode = tool::LowerBitcode.getValue();
   if (tool::MutateOnly) {
     diagnostics.info("Mutate-only mode on: Mull will generate mutants, but won't run them\n");
     configuration.mutateOnly = true;


### PR DESCRIPTION
By lowering bitcode we do not respect the relocation model and various other target options.
Related: https://github.com/mull-project/mull/issues/903#issuecomment-972882621