### PR TITLE
Introduce IR frontend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ add_subdirectory(vendor)
 set (MULL_DEFINITIONS ${LLVM_DEFINITIONS})
 set (THIRD_PARTY_INCLUDE_DIRS
   ${LLVM_INCLUDE_DIRS}
+  ${CLANG_INCLUDE_DIRS}
   ${CMAKE_CURRENT_LIST_DIR}/vendor/LibEBC/lib/include
   ${CMAKE_CURRENT_LIST_DIR}/vendor/libirm/include
   ${CMAKE_SOURCE_DIR}/vendor

--- a/include/mull/Bitcode.h
+++ b/include/mull/Bitcode.h
@@ -17,8 +17,8 @@ class Diagnostics;
 
 class Bitcode {
 public:
-  explicit Bitcode(std::unique_ptr<llvm::LLVMContext> context,
-                   std::unique_ptr<llvm::Module> module);
+  explicit Bitcode(llvm::Module *unownedModule);
+  Bitcode(std::unique_ptr<llvm::LLVMContext> context, std::unique_ptr<llvm::Module> module);
 
   llvm::Module *getModule();
   llvm::Module *getModule() const;
@@ -32,6 +32,7 @@ public:
 private:
   std::unique_ptr<llvm::LLVMContext> context;
   std::unique_ptr<llvm::Module> module;
+  llvm::Module *unownedModule;
   std::string uniqueIdentifier;
 
   std::map<llvm::Function *, std::vector<MutationPoint *>> mutationPoints;

--- a/include/mull/Config/Configuration.h
+++ b/include/mull/Config/Configuration.h
@@ -23,13 +23,14 @@ struct Configuration {
   bool keepExecutable;
   bool mutateOnly;
   bool lowerBitcode;
+  bool junkDetectionDisabled;
 
   unsigned timeout;
   unsigned linkerTimeout;
 
   IDEDiagnosticsKind diagnostics;
 
-  std::vector<std::string> bitcodePaths;
+  std::vector<std::string> bitcodePaths; // TODO: Drop this one
   std::vector<std::string> mutators;
 
   std::string executable;
@@ -39,7 +40,16 @@ struct Configuration {
   std::string linker;
   std::vector<std::string> linkerFlags;
 
+  std::string compilationDatabasePath;
+  std::vector<std::string> compilerFlags;
+
+  std::vector<std::string> includePaths;
+  std::vector<std::string> excludePaths;
+
   ParallelizationConfig parallelization;
+
+  std::string gitDiffRef;
+  std::string gitProjectRoot;
 
   Configuration();
 

--- a/include/mull/Driver.h
+++ b/include/mull/Driver.h
@@ -68,4 +68,6 @@ private:
   std::vector<FunctionUnderTest> getFunctionsUnderTest();
 };
 
+void mutateBitcode(llvm::Module &module);
+
 } // namespace mull

--- a/include/mull/MutationsFinder.h
+++ b/include/mull/MutationsFinder.h
@@ -11,13 +11,13 @@ namespace mull {
 
 struct Configuration;
 class Program;
-class ReachableFunction;
 class Diagnostics;
+class Bitcode;
 
 class MutationsFinder {
 public:
   MutationsFinder(std::vector<std::unique_ptr<Mutator>> mutators, const Configuration &config);
-  std::vector<MutationPoint *> getMutationPoints(Diagnostics &diagnostics, const Program &program,
+  std::vector<MutationPoint *> getMutationPoints(Diagnostics &diagnostics,
                                                  std::vector<FunctionUnderTest> &functions);
 
 private:

--- a/lib/Bitcode.cpp
+++ b/lib/Bitcode.cpp
@@ -13,17 +13,27 @@ using namespace mull;
 using namespace llvm;
 using namespace std;
 
+Bitcode::Bitcode(llvm::Module *unownedModule)
+    : context(nullptr), module(nullptr), unownedModule(unownedModule),
+      uniqueIdentifier(llvm::sys::path::stem(this->unownedModule->getModuleIdentifier()).str()) {}
+
 Bitcode::Bitcode(std::unique_ptr<llvm::LLVMContext> context, std::unique_ptr<llvm::Module> module)
-    : context(std::move(context)), module(std::move(module)),
+    : context(std::move(context)), module(std::move(module)), unownedModule(nullptr),
       uniqueIdentifier(llvm::sys::path::stem(this->module->getModuleIdentifier()).str()) {}
 
 llvm::Module *Bitcode::getModule() {
-  assert(module);
+  assert(module || unownedModule);
+  if (unownedModule) {
+    return unownedModule;
+  }
   return module.get();
 }
 
 llvm::Module *Bitcode::getModule() const {
-  assert(module);
+  assert(module || unownedModule);
+  if (unownedModule) {
+    return unownedModule;
+  }
   return module.get();
 }
 

--- a/lib/Config/Configuration.cpp
+++ b/lib/Config/Configuration.cpp
@@ -18,7 +18,7 @@ unsigned MullDefaultLinkerTimeoutMilliseconds = 30000;
 Configuration::Configuration()
     : debugEnabled(false), dryRunEnabled(false), captureTestOutput(true), captureMutantOutput(true),
       skipSanityCheckRun(false), includeNotCovered(false), keepObjectFiles(false),
-      keepExecutable(false), mutateOnly(false), lowerBitcode(false),
+      keepExecutable(false), mutateOnly(false), lowerBitcode(false), junkDetectionDisabled(false),
       timeout(MullDefaultTimeoutMilliseconds), linkerTimeout(MullDefaultLinkerTimeoutMilliseconds),
       diagnostics(IDEDiagnosticsKind::None), parallelization(singleThreadParallelization()) {}
 

--- a/lib/Config/ConfigurationParser.cpp
+++ b/lib/Config/ConfigurationParser.cpp
@@ -47,10 +47,20 @@ template <> struct llvm::yaml::MappingTraits<Configuration> {
     io.mapOptional("linker", config.linker);
     io.mapOptional("linkerFlags", config.linkerFlags);
     io.mapOptional("parallelization", config.parallelization);
+    io.mapOptional("compilationDatabasePath", config.compilationDatabasePath);
+    io.mapOptional("compilerFlags", config.compilerFlags);
+    io.mapOptional("junkDetectionDisabled", config.junkDetectionDisabled);
+    io.mapOptional("gitDiffRef", config.gitDiffRef);
+    io.mapOptional("gitProjectRoot", config.gitProjectRoot);
+    io.mapOptional("includePaths", config.includePaths);
+    io.mapOptional("excludePaths", config.excludePaths);
   }
 };
 
 std::string Configuration::findConfig(Diagnostics &diagnostics) {
+  if (getenv("MULL_CONFIG") != nullptr) {
+    return getenv("MULL_CONFIG");
+  }
   llvm::SmallString<PATH_MAX> cwd;
   std::error_code ec = llvm::sys::fs::current_path(cwd);
   if (ec) {

--- a/lib/Driver.cpp
+++ b/lib/Driver.cpp
@@ -1,14 +1,22 @@
 #include "mull/Driver.h"
 
+#include "mull/BitcodeMetadataReader.h"
 #include "mull/Config/Configuration.h"
 #include "mull/Diagnostics/Diagnostics.h"
+#include "mull/Filters/FilePathFilter.h"
 #include "mull/Filters/Filters.h"
 #include "mull/Filters/FunctionFilter.h"
+#include "mull/Filters/GitDiffFilter.h"
+#include "mull/Filters/JunkMutationFilter.h"
+#include "mull/Filters/NoDebugInfoFilter.h"
 #include "mull/FunctionUnderTest.h"
+#include "mull/JunkDetection/CXX/ASTStorage.h"
+#include "mull/JunkDetection/CXX/CXXJunkDetector.h"
 #include "mull/Mutant.h"
 #include "mull/MutantRunner.h"
 #include "mull/MutationResult.h"
 #include "mull/MutationsFinder.h"
+#include "mull/Mutators/MutatorsFactory.h"
 #include "mull/Parallelization/Parallelization.h"
 #include "mull/Program/Program.h"
 #include "mull/Result.h"
@@ -100,7 +108,7 @@ std::vector<MutationPoint *> Driver::findMutationPoints() {
   selectInstructions(filteredFunctions);
 
   std::vector<MutationPoint *> mutationPoints =
-      mutationsFinder.getMutationPoints(diagnostics, program, filteredFunctions);
+      mutationsFinder.getMutationPoints(diagnostics, filteredFunctions);
 
   return mutationPoints;
 }
@@ -317,7 +325,10 @@ std::vector<FunctionUnderTest> Driver::getFunctionsUnderTest() {
       /// to avoid collisions
       /// TODO: check case when filename:functionName is not enough to resolve collisions
       /// TODO: pick a proper data structure
-      std::unordered_map<std::string, std::unordered_map<std::string, std::vector<llvm::coverage::CountedRegion>>> scopedFunctions;
+      std::unordered_map<
+          std::string,
+          std::unordered_map<std::string, std::vector<llvm::coverage::CountedRegion>>>
+          scopedFunctions;
       std::unordered_map<std::string, std::vector<llvm::coverage::CountedRegion>> unscopedFunctions;
       for (auto &it : coverage->getCoveredFunctions()) {
         if (!it.ExecutionCount) {
@@ -349,7 +360,7 @@ std::vector<FunctionUnderTest> Driver::getFunctionsUnderTest() {
             std::string scope = llvm::sys::path::filename(filepath).str();
             if (scopedFunctions[scope].count(name)) {
               covered = true;
-            std::swap(linecoverage, scopedFunctions[scope][name]);
+              std::swap(linecoverage, scopedFunctions[scope][name]);
             }
           }
           if (covered) {
@@ -372,4 +383,238 @@ std::vector<FunctionUnderTest> Driver::getFunctionsUnderTest() {
   });
 
   return functionsUnderTest;
+}
+
+void mull::mutateBitcode(llvm::Module &module) {
+  /// Setup
+
+  Diagnostics diagnostics;
+  std::string configPath = Configuration::findConfig(diagnostics);
+  Configuration configuration;
+  if (configPath.empty()) {
+    diagnostics.warning("Config not found. Using some defaults.");
+  } else {
+    diagnostics.info("Using configuration "s + configPath);
+    configuration = Configuration::loadFromDisk(diagnostics, configPath);
+  }
+
+  if (configuration.debugEnabled) {
+    diagnostics.enableDebugMode();
+  }
+
+  std::vector<std::unique_ptr<mull::Filter>> filterStorage;
+  mull::Filters filters;
+
+  auto noDebugInfoFilter = new mull::NoDebugInfoFilter;
+  auto filePathFilter = new mull::FilePathFilter;
+
+  for (const auto &regex : configuration.excludePaths) {
+    auto added = filePathFilter->exclude(regex);
+    if (!added.first) {
+      std::stringstream warningMessage;
+      warningMessage << "Invalid regex for exclude-path: '" << regex
+                     << "' has been ignored. Error: " << added.second;
+      diagnostics.warning(warningMessage.str());
+    }
+  }
+  for (const auto &regex : configuration.includePaths) {
+    auto added = filePathFilter->include(regex);
+    if (!added.first) {
+      std::stringstream warningMessage;
+      warningMessage << "Invalid regex for include-path: '" << regex
+                     << "' has been ignored. Error: " << added.second;
+      diagnostics.warning(warningMessage.str());
+    }
+  }
+
+  filterStorage.emplace_back(noDebugInfoFilter);
+  filterStorage.emplace_back(filePathFilter);
+
+  filters.mutationFilters.push_back(noDebugInfoFilter);
+  filters.functionFilters.push_back(noDebugInfoFilter);
+  filters.instructionFilters.push_back(noDebugInfoFilter);
+
+  filters.mutationFilters.push_back(filePathFilter);
+  filters.functionFilters.push_back(filePathFilter);
+
+  std::string cxxCompilationFlags;
+  for (auto &flag : configuration.compilerFlags) {
+    cxxCompilationFlags += flag + ' ';
+  }
+  mull::BitcodeMetadataReader bitcodeCompilationDatabaseLoader;
+  std::unordered_map<std::string, std::string> bitcodeCompilationFlags =
+      bitcodeCompilationDatabaseLoader.getCompilationDatabase(module);
+  if (!bitcodeCompilationFlags.empty()) {
+    diagnostics.info(std::string("Found compilation flags in the input bitcode"));
+  }
+
+  mull::ASTStorage astStorage(diagnostics,
+                              configuration.compilationDatabasePath,
+                              cxxCompilationFlags,
+                              bitcodeCompilationFlags);
+
+  mull::CXXJunkDetector junkDetector(diagnostics, astStorage);
+  if (!configuration.junkDetectionDisabled) {
+    auto *junkFilter = new mull::JunkMutationFilter(junkDetector);
+    filters.mutationFilters.push_back(junkFilter);
+    filterStorage.emplace_back(junkFilter);
+  }
+
+  if (!configuration.gitDiffRef.empty()) {
+    if (configuration.gitProjectRoot.empty()) {
+      std::stringstream debugMessage;
+      debugMessage
+          << "-git-diff-ref option has been provided but the path to the Git project root has not "
+             "been specified via -git-project-root. The incremental testing will be disabled.";
+      diagnostics.warning(debugMessage.str());
+    } else if (!llvm::sys::fs::is_directory(configuration.gitProjectRoot)) {
+      std::stringstream debugMessage;
+      debugMessage << "directory provided by -git-project-root does not exist, ";
+      debugMessage << "the incremental testing will be disabled: ";
+      debugMessage << configuration.gitProjectRoot;
+      diagnostics.warning(debugMessage.str());
+    } else {
+      llvm::SmallString<256> tmpGitProjectRoot;
+      std::string gitProjectRoot = configuration.gitProjectRoot;
+      if (!llvm::sys::fs::real_path(gitProjectRoot, tmpGitProjectRoot)) {
+        gitProjectRoot = tmpGitProjectRoot.str();
+
+        diagnostics.info("Incremental testing using Git Diff is enabled.\n"s + "- Git ref: " +
+                         configuration.gitDiffRef + "\n" + "- Git project root: " + gitProjectRoot);
+        mull::GitDiffFilter *gitDiffFilter = mull::GitDiffFilter::createFromGitDiff(
+            diagnostics, gitProjectRoot, configuration.gitDiffRef);
+
+        if (gitDiffFilter) {
+          filterStorage.emplace_back(gitDiffFilter);
+          filters.instructionFilters.push_back(gitDiffFilter);
+        }
+      } else {
+        diagnostics.warning("could not expand -git-project-root to an absolute path: "s +
+                            gitProjectRoot);
+      }
+    }
+  }
+
+  SingleTaskExecutor singleTask(diagnostics);
+
+  /// Actual Work
+
+  Bitcode bitcode(&module);
+  std::vector<FunctionUnderTest> functionsUnderTest;
+  singleTask.execute("Gathering functions under test", [&]() {
+    std::unique_ptr<llvm::coverage::CoverageMapping> coverage =
+        loadCoverage(configuration, diagnostics);
+    if (coverage) {
+      /// Some of the function records contain just name, the others are prefixed with the filename
+      /// to avoid collisions
+      /// TODO: check case when filename:functionName is not enough to resolve collisions
+      /// TODO: pick a proper data structure
+      std::unordered_map<
+          std::string,
+          std::unordered_map<std::string, std::vector<llvm::coverage::CountedRegion>>>
+          scopedFunctions;
+      std::unordered_map<std::string, std::vector<llvm::coverage::CountedRegion>> unscopedFunctions;
+      for (auto &it : coverage->getCoveredFunctions()) {
+        if (!it.ExecutionCount) {
+          continue;
+        }
+        std::string scope;
+        std::string name = it.Name;
+        size_t idx = name.find(':');
+        if (idx != std::string::npos) {
+          scope = name.substr(0, idx);
+          name = name.substr(idx + 1);
+        }
+        if (scope.empty()) {
+          unscopedFunctions[name] = it.CountedRegions;
+        } else {
+          scopedFunctions[scope][name] = it.CountedRegions;
+        }
+      }
+
+      for (llvm::Function &function : module) {
+        bool covered = false;
+        std::vector<llvm::coverage::CountedRegion> linecoverage = {};
+        std::string name = function.getName().str();
+        if (unscopedFunctions.count(name)) {
+          covered = true;
+          std::swap(linecoverage, unscopedFunctions[name]);
+        } else {
+          std::string filepath = SourceLocation::locationFromFunction(&function).unitFilePath;
+          std::string scope = llvm::sys::path::filename(filepath).str();
+          if (scopedFunctions[scope].count(name)) {
+            covered = true;
+            std::swap(linecoverage, scopedFunctions[scope][name]);
+          }
+        }
+        if (covered) {
+          functionsUnderTest.emplace_back(&function, &bitcode, true, linecoverage);
+        } else if (configuration.includeNotCovered) {
+          functionsUnderTest.emplace_back(&function, &bitcode);
+        }
+      }
+    } else {
+      if (configuration.includeNotCovered) {
+        diagnostics.warning("-include-not-covered is enabled, but there is no coverage info!");
+      }
+      for (llvm::Function &function : module) {
+        functionsUnderTest.emplace_back(&function, &bitcode, true);
+      }
+    }
+  });
+
+  MutatorsFactory mutatorsFactory(diagnostics);
+  MutationsFinder mutationsFinder(mutatorsFactory.mutators(configuration.mutators), configuration);
+
+  std::vector<InstructionSelectionTask> instructionSelectionTasks;
+  instructionSelectionTasks.reserve(configuration.parallelization.workers);
+  for (int i = 0; i < configuration.parallelization.workers; i++) {
+    instructionSelectionTasks.emplace_back(filters.instructionFilters);
+  }
+
+  std::vector<int> Nothing;
+  TaskExecutor<InstructionSelectionTask> selectionRunner(diagnostics,
+                                                         "Instruction selection",
+                                                         functionsUnderTest,
+                                                         Nothing,
+                                                         std::move(instructionSelectionTasks));
+  selectionRunner.execute();
+
+  std::vector<MutationPoint *> mutationPoints =
+      mutationsFinder.getMutationPoints(diagnostics, functionsUnderTest);
+  std::vector<MutationPoint *> mutations = std::move(mutationPoints);
+
+  for (auto filter : filters.mutationFilters) {
+    std::vector<MutationFilterTask> tasks;
+    tasks.reserve(configuration.parallelization.workers);
+    for (int i = 0; i < configuration.parallelization.workers; i++) {
+      tasks.emplace_back(*filter);
+    }
+
+    std::string label = std::string("Applying filter: ") + filter->name();
+    std::vector<MutationPoint *> tmp;
+    TaskExecutor<MutationFilterTask> filterRunner(
+        diagnostics, label, mutations, tmp, std::move(tasks));
+    filterRunner.execute();
+    mutations = std::move(tmp);
+  }
+
+  singleTask.execute("Prepare mutations", [&]() {
+    for (auto point : mutations) {
+      point->getBitcode()->addMutation(point);
+    }
+  });
+
+  singleTask.execute("Cloning functions for mutation",
+                     [&]() { CloneMutatedFunctionsTask::cloneFunctions(bitcode); });
+
+  singleTask.execute("Removing original functions",
+                     [&]() { DeleteOriginalFunctionsTask::deleteFunctions(bitcode); });
+
+  singleTask.execute("Redirect mutated functions",
+                     [&]() { InsertMutationTrampolinesTask::insertTrampolines(bitcode); });
+
+  TaskExecutor<ApplyMutationTask> applyMutations(
+      diagnostics, "Applying mutations", mutations, Nothing, { ApplyMutationTask() });
+  applyMutations.execute();
 }

--- a/lib/JunkDetection/CXX/ASTStorage.cpp
+++ b/lib/JunkDetection/CXX/ASTStorage.cpp
@@ -103,9 +103,10 @@ clang::SourceLocation ThreadSafeASTUnit::getLocation(const mull::SourceLocation 
   return location;
 }
 
-clang::SourceLocation ThreadSafeASTUnit::getLocForEndOfToken(const clang::SourceLocation sourceLocationEnd) {
-  /// clang::Lexer::getLocForEndOfToken internally calls getLocation, which is known for not beeing thread safe.
-  /// therefore we need to protect it within the ThreadSafeASTUnit
+clang::SourceLocation
+ThreadSafeASTUnit::getLocForEndOfToken(const clang::SourceLocation sourceLocationEnd) {
+  /// clang::Lexer::getLocForEndOfToken internally calls getLocation, which is known for not beeing
+  /// thread safe. therefore we need to protect it within the ThreadSafeASTUnit
   std::lock_guard<std::mutex> lock(mutex);
   clang::SourceManager &sourceManager = ast->getSourceManager();
   /// Clang AST: how to get more precise debug information in certain cases?

--- a/lib/Mutant.cpp
+++ b/lib/Mutant.cpp
@@ -8,8 +8,8 @@ using namespace mull;
 Mutant::Mutant(std::string identifier, std::string mutatorIdentifier, SourceLocation sourceLocation,
                SourceLocation endLocation, bool covered)
     : identifier(std::move(identifier)), mutatorIdentifier(std::move(mutatorIdentifier)),
-      sourceLocation(std::move(sourceLocation)), endLocation(endLocation), covered(covered),
-      mutatorKind(MutatorKind::InvalidKind) {}
+      sourceLocation(std::move(sourceLocation)), endLocation(std::move(endLocation)),
+      covered(covered), mutatorKind(MutatorKind::InvalidKind) {}
 
 const std::string &Mutant::getIdentifier() const {
   return identifier;

--- a/lib/MutationsFinder.cpp
+++ b/lib/MutationsFinder.cpp
@@ -13,7 +13,7 @@ MutationsFinder::MutationsFinder(std::vector<std::unique_ptr<Mutator>> mutators,
     : mutators(std::move(mutators)), config(config) {}
 
 std::vector<MutationPoint *>
-MutationsFinder::getMutationPoints(Diagnostics &diagnostics, const Program &program,
+MutationsFinder::getMutationPoints(Diagnostics &diagnostics,
                                    std::vector<FunctionUnderTest> &functions) {
   std::vector<SearchMutationPointsTask> tasks;
   tasks.reserve(config.parallelization.workers);

--- a/tests-lit/CMakeLists.txt
+++ b/tests-lit/CMakeLists.txt
@@ -24,6 +24,7 @@ set(LIT_COMMAND
   mull_cxx=$<TARGET_FILE:mull-cxx-${LLVM_VERSION_MAJOR}>
   mull_runner=$<TARGET_FILE:mull-runner-${LLVM_VERSION_MAJOR}>
   mull_frontend_cxx=$<TARGET_FILE:mull-cxx-frontend-${LLVM_VERSION_MAJOR}>
+  mull_ir_frontend=$<TARGET_FILE:mull-cxx-ir-frontend-${LLVM_VERSION_MAJOR}>
   clang_cc=${LIT_CLANG}
   clang_cxx=${LIT_CLANGXX}
   sysroot=${sysroot}

--- a/tests-lit/lit.cfg
+++ b/tests-lit/lit.cfg
@@ -30,6 +30,7 @@ llvm_profdata = os.environ.get('llvm_profdata', '')
 mull_cxx = os.environ.get('mull_cxx', '')
 mull_runner = os.environ.get('mull_runner', '')
 mull_frontend_cxx = os.environ.get('mull_frontend_cxx', '')
+mull_ir_frontend = os.environ.get('mull_ir_frontend', '')
 filecheck = os.environ.get('filecheck', '')
 llvm_major_version = os.environ.get('LLVM_VERSION_MAJOR', '')
 test_cxx_flags = os.environ.get('TEST_CXX_FLAGS', '')
@@ -48,20 +49,29 @@ config.substitutions.append(('%llvm_profdata', llvm_profdata))
 config.substitutions.append(('%mull_cxx', mull_cxx))
 config.substitutions.append(('%mull_runner', mull_runner))
 config.substitutions.append(('%mull_frontend_cxx', mull_frontend_cxx))
+config.substitutions.append(('%mull_ir_frontend', mull_ir_frontend))
 config.substitutions.append(('%filecheck', filecheck))
 config.substitutions.append(('%TEST_CXX_FLAGS', test_cxx_flags))
 config.substitutions.append(('%python3', python3))
 
 config.suffixes = ['.cpp', '.c', '.itest']
 
-if int(llvm_major_version) >= 8:
-  config.available_features.add('LLVM_8_OR_HIGHER')
-
 if int(llvm_major_version) <= 10:
   config.available_features.add('LLVM_10_OR_LOWER')
+
+if int(llvm_major_version) >= 11:
+  config.available_features.add('LLVM_11_OR_HIGHER')
 
 if platform.system() == 'Darwin':
   config.available_features.add('MACOS')
 else:
   config.available_features.add('LINUX')
+
+if int(llvm_major_version) > 11:
+  config.substitutions.append(('%pass_mull_ir_frontend', "-fexperimental-new-pass-manager -fpass-plugin=" + mull_ir_frontend))
+elif int(llvm_major_version) >= 9:
+  # LLVM 9 and 10 doesn't include the pass if no optimizations enabled
+  config.substitutions.append(('%pass_mull_ir_frontend', "-O1 -fexperimental-new-pass-manager -fpass-plugin=" + mull_ir_frontend))
+else:
+  config.substitutions.append(('%pass_mull_ir_frontend', "-Xclang -load -Xclang " + mull_ir_frontend))
 

--- a/tests-lit/tests/coverage/01/main.c
+++ b/tests-lit/tests/coverage/01/main.c
@@ -13,14 +13,18 @@ int main() {
 // RUN: env LLVM_PROFILE_FILE=%s.profraw %s.exe
 // RUN: %llvm_profdata merge %s.profraw -o %s.profdata
 
+// RUN: cd / && %clang_cc %sysroot %s %pass_mull_ir_frontend -g -fprofile-instr-generate -fcoverage-mapping -o %s-ir.exe
 // RUN: unset TERM; %mull_cxx -keep-executable -output=%s.mutated.exe -linker=%clang_cc -linker-flags="%sysroot -fprofile-instr-generate" -mutators=cxx_add_to_sub %s.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-NO-COVERAGE
 // RUN: unset TERM; %mull_runner %s.mutated.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-NO-COVERAGE
+// RUN: unset TERM; %mull_runner %s-ir.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-NO-COVERAGE
 // CHECK-NO-COVERAGE:[info] Survived mutants (1/1):
 // CHECK-NO-COVERAGE:{{^.*}}main.c:2:5: warning: Survived: Replaced + with - [cxx_add_to_sub]
 // CHECK-NO-COVERAGE:[info] Mutation score: 0%
 
+// RUN: cd %S && env MULL_CONFIG=%S/mull.cov.yml %clang_cc %sysroot %s %pass_mull_ir_frontend -g -fprofile-instr-generate -fcoverage-mapping -o %s-ir-cov.exe
 // RUN: unset TERM; %mull_cxx -keep-executable -output=%s.mutated.cov.exe -linker=%clang_cc -coverage-info=%s.profdata -linker-flags="%sysroot -fprofile-instr-generate" -mutators=cxx_add_to_sub %s.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-COVERAGE
 // LLVM 9 and below seems to lose the executable bit when copying the file, adding it here explicitly
 // RUN: chmod +x %s.mutated.cov.exe
 // RUN: unset TERM; %mull_runner %s.mutated.cov.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-COVERAGE
+// RUN: unset TERM; %mull_runner %s-ir-cov.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-COVERAGE
 // CHECK-COVERAGE:[info] No mutants found. Mutation score: infinitely high

--- a/tests-lit/tests/coverage/01/mull.cov.yml
+++ b/tests-lit/tests/coverage/01/mull.cov.yml
@@ -1,0 +1,4 @@
+mutators:
+  - cxx_add_to_sub
+coverageInfo: ./main.c.profdata
+executable: ./main.c.exe

--- a/tests-lit/tests/coverage/01/mull.yml
+++ b/tests-lit/tests/coverage/01/mull.yml
@@ -1,0 +1,2 @@
+mutators:
+  - cxx_add_to_sub

--- a/tests-lit/tests/coverage/02/main.c
+++ b/tests-lit/tests/coverage/02/main.c
@@ -13,8 +13,10 @@ int main() {
 // RUN: env LLVM_PROFILE_FILE=%s.profraw %s.exe
 // RUN: %llvm_profdata merge %s.profraw -o %s.profdata
 
+// RUN: cd %S && %clang_cc %sysroot %s %pass_mull_ir_frontend -g -fprofile-instr-generate -fcoverage-mapping -o %s-ir.exe
 // RUN: unset TERM; %mull_cxx -keep-executable -output=%s.mutated.exe -linker=%clang_cc -coverage-info=%s.profdata -ide-reporter-show-killed -include-not-covered -linker-flags="%sysroot -fprofile-instr-generate" -mutators=cxx_add_to_sub %s.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 // RUN: unset TERM; %mull_runner -ide-reporter-show-killed -include-not-covered %s.mutated.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+// RUN: unset TERM; %mull_runner -ide-reporter-show-killed -include-not-covered %s-ir.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 // CHECK:[info] Not Covered mutants (1/1):
 // CHECK:{{^.*}}main.c:2:5: warning: Not Covered: Replaced + with - [cxx_add_to_sub]
 // CHECK:[info] Mutation score: 0%

--- a/tests-lit/tests/coverage/02/mull.yml
+++ b/tests-lit/tests/coverage/02/mull.yml
@@ -1,0 +1,5 @@
+mutators:
+  - cxx_add_to_sub
+coverageInfo: ./main.c.profdata
+executable: ./main.c.exe
+includeNotCovered: true

--- a/tests-lit/tests/coverage/partial-covered-functions/main.c
+++ b/tests-lit/tests/coverage/partial-covered-functions/main.c
@@ -28,8 +28,10 @@ int main(){
 // RUN: env LLVM_PROFILE_FILE=%s.profraw %s.exe
 // RUN: %llvm_profdata merge %s.profraw -o %s.profdata
 
+// RUN: cd %S && env MULL_CONFIG=%S/mull.yml %clang_cc %sysroot %s %pass_mull_ir_frontend -g -fprofile-instr-generate -fcoverage-mapping -o %s-ir-no-cov.exe
 // RUN: unset TERM; %mull_cxx -keep-executable -output=%s.mutated.exe -linker=%clang_cc -linker-flags="%sysroot -fprofile-instr-generate" -mutators=cxx_add_to_sub %s.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-NO-COVERAGE
 // RUN: unset TERM; %mull_runner %s.mutated.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-NO-COVERAGE
+// RUN: unset TERM; %mull_runner %s-ir-no-cov.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-NO-COVERAGE
 // CHECK-NO-COVERAGE:[info] Survived mutants (4/4):
 // CHECK-NO-COVERAGE:{{^.*}}main.c:5:16: warning: Survived: Replaced + with - [cxx_add_to_sub]
 // CHECK-NO-COVERAGE:{{^.*}}main.c:10:11: warning: Survived: Replaced + with - [cxx_add_to_sub]
@@ -37,10 +39,12 @@ int main(){
 // CHECK-NO-COVERAGE:{{^.*}}main.c:14:25: warning: Survived: Replaced + with - [cxx_add_to_sub]
 // CHECK-NO-COVERAGE:[info] Mutation score: 0%
 
+// RUN: cd %S && env MULL_CONFIG=%S/mull.cov.yml %clang_cc %sysroot %s %pass_mull_ir_frontend -g -fprofile-instr-generate -fcoverage-mapping -o %s-ir-cov.exe
 // RUN: unset TERM; %mull_cxx -keep-executable -output=%s.mutated.cov.exe -linker=%clang_cc -coverage-info=%s.profdata -linker-flags="%sysroot -fprofile-instr-generate" -mutators=cxx_add_to_sub %s.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-COVERAGE
 // LLVM 9 and below seems to lose the executable bit when copying the file, adding it here explicitly
 // RUN: chmod +x %s.mutated.cov.exe
 // RUN: unset TERM; %mull_runner %s.mutated.cov.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-COVERAGE
+// RUN: unset TERM; %mull_runner %s-ir-cov.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-COVERAGE
 // CHECK-COVERAGE:[info] Survived mutants (2/4):
 // CHECK-COVERAGE:{{^.*}}main.c:10:11: warning: Survived: Replaced + with - [cxx_add_to_sub]
 // CHECK-COVERAGE:{{^.*}}main.c:14:21: warning: Survived: Replaced + with - [cxx_add_to_sub]

--- a/tests-lit/tests/coverage/partial-covered-functions/mull.cov.yml
+++ b/tests-lit/tests/coverage/partial-covered-functions/mull.cov.yml
@@ -1,0 +1,4 @@
+mutators:
+  - cxx_add_to_sub
+coverageInfo: ./main.c.profdata
+executable: ./main.c.exe

--- a/tests-lit/tests/coverage/partial-covered-functions/mull.yml
+++ b/tests-lit/tests/coverage/partial-covered-functions/mull.yml
@@ -1,0 +1,2 @@
+mutators:
+  - cxx_add_to_sub

--- a/tests-lit/tests/cxx-frontend/00-sandbox/sample.cpp
+++ b/tests-lit/tests/cxx-frontend/00-sandbox/sample.cpp
@@ -20,15 +20,19 @@ int main() {
 
 /**
 RUN: %clang_cxx %sysroot -fplugin=%mull_frontend_cxx -S -emit-llvm %s
-RUN: %clang_cxx %sysroot -fplugin=%mull_frontend_cxx %s -o %s.exe
+RUN: %clang_cxx %sysroot -fplugin=%mull_frontend_cxx %s -o %s-ast.exe
+RUN: %clang_cxx %sysroot -g %pass_mull_ir_frontend %s -o %s-ir.exe
 
-RUN: %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
-RUN: (env "cxx_add_to_sub:%s:6:12"=1 %s.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
+RUN: %s-ast.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
+RUN: (env "cxx_add_to_sub:%s:6:12"=1 %s-ast.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
+RUN: %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
+RUN: (env "cxx_add_to_sub:%s:6:12"=1 %s-ir.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
 
 STANDALONE_WITHOUT_MUTATION:NORMAL
 STANDALONE_WITH_MUTATION:MUTATED
 
-RUN: %mull_runner %s.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
+RUN: %mull_runner %s-ast.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
+RUN: %mull_runner %s-ir.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
 
 MULL_RUNNER:[info] Killed mutants (1/1):
 MULL_RUNNER:{{.*}}sample.cpp:6:12: warning: Killed: Replaced + with - [cxx_add_to_sub]

--- a/tests-lit/tests/cxx-frontend/binary_operator/01-return-expr/sample.cpp
+++ b/tests-lit/tests/cxx-frontend/binary_operator/01-return-expr/sample.cpp
@@ -19,15 +19,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: %clang_cxx %sysroot -fplugin=%mull_frontend_cxx %s -o %s.exe
+RUN: %clang_cxx %sysroot -fplugin=%mull_frontend_cxx %s -o %s-ast.exe
+RUN: %clang_cxx -g %sysroot %pass_mull_ir_frontend %s -o %s-ir.exe
 
-RUN: %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
-RUN: (env "cxx_add_to_sub:%s:6:12"=1 %s.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
+RUN: %s-ast.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
+RUN: (env "cxx_add_to_sub:%s:6:12"=1 %s-ast.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
+
+RUN: %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
+RUN: (env "cxx_add_to_sub:%s:6:12"=1 %s-ir.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
 
 STANDALONE_WITHOUT_MUTATION:NORMAL
 STANDALONE_WITH_MUTATION:MUTATED
 
-RUN: %mull_runner %s.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
+RUN: %mull_runner %s-ast.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
+RUN: %mull_runner %s-ir.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
 
 MULL_RUNNER:[info] Killed mutants (1/1):
 MULL_RUNNER:{{.*}}sample.cpp:6:12: warning: Killed: Replaced + with - [cxx_add_to_sub]

--- a/tests-lit/tests/cxx-frontend/binary_operator/02-paren-expr/sample.cpp
+++ b/tests-lit/tests/cxx-frontend/binary_operator/02-paren-expr/sample.cpp
@@ -19,15 +19,19 @@ int main() {
 // clang-format off
 
 /**
-RUN: %clang_cxx %sysroot -fplugin=%mull_frontend_cxx %s -o %s.exe
+RUN: %clang_cxx %sysroot -fplugin=%mull_frontend_cxx %s -o %s-ast.exe
+RUN: %clang_cxx %sysroot -g %pass_mull_ir_frontend %s -o %s-ir.exe
 
-RUN: %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
-RUN: (env "cxx_add_to_sub:%s:6:13"=1 %s.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
+RUN: %s-ast.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
+RUN: (env "cxx_add_to_sub:%s:6:13"=1 %s-ast.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
+RUN: %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
+RUN: (env "cxx_add_to_sub:%s:6:13"=1 %s-ir.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
 
 STANDALONE_WITHOUT_MUTATION:NORMAL
 STANDALONE_WITH_MUTATION:MUTATED
 
-RUN: %mull_runner %s.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
+RUN: %mull_runner %s-ast.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
+RUN: %mull_runner %s-ir.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
 
 MULL_RUNNER:[info] Killed mutants (1/1):
 MULL_RUNNER:{{.*}}sample.cpp:6:13: warning: Killed: Replaced + with - [cxx_add_to_sub]

--- a/tests-lit/tests/cxx-frontend/binary_operator/03-implicit-cast-expr/sample.cpp
+++ b/tests-lit/tests/cxx-frontend/binary_operator/03-implicit-cast-expr/sample.cpp
@@ -23,15 +23,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: %clang_cxx %sysroot -fplugin=%mull_frontend_cxx %s -o %s.exe
+RUN: %clang_cxx %sysroot -fplugin=%mull_frontend_cxx %s -o %s-ast.exe
+RUN: %clang_cxx %sysroot -g %pass_mull_ir_frontend %s -o %s-ir.exe
 
-RUN: %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
-RUN: (env "cxx_add_to_sub:%s:6:9"=1 %s.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
+RUN: %s-ast.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
+RUN: (env "cxx_add_to_sub:%s:6:9"=1 %s-ast.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
+
+RUN: %s-ast.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
+RUN: (env "cxx_add_to_sub:%s:6:9"=1 %s-ast.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
 
 STANDALONE_WITHOUT_MUTATION:NORMAL
 STANDALONE_WITH_MUTATION:MUTATED
 
-RUN: %mull_runner %s.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
+RUN: %mull_runner %s-ast.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
+RUN: %mull_runner %s-ir.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
 
 MULL_RUNNER:[info] Killed mutants (1/1):
 MULL_RUNNER:{{.*}}sample.cpp:6:9: warning: Killed: Replaced + with - [cxx_add_to_sub]

--- a/tests-lit/tests/cxx-frontend/binary_operator/05-var-decl/sample.cpp
+++ b/tests-lit/tests/cxx-frontend/binary_operator/05-var-decl/sample.cpp
@@ -20,15 +20,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: %clang_cxx %sysroot %sysroot -fplugin=%mull_frontend_cxx %s -o %s.exe
+RUN: %clang_cxx %sysroot -fplugin=%mull_frontend_cxx %s -o %s-ast.exe
+RUN: %clang_cxx %sysroot -g %pass_mull_ir_frontend %s -o %s-ir.exe
 
-RUN: %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
-RUN: (env "cxx_add_to_sub:%s:6:13"=1 %s.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
+RUN: %s-ast.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
+RUN: (env "cxx_add_to_sub:%s:6:13"=1 %s-ast.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
+
+RUN: %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
+RUN: (env "cxx_add_to_sub:%s:6:13"=1 %s-ir.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
 
 STANDALONE_WITHOUT_MUTATION:NORMAL
 STANDALONE_WITH_MUTATION:MUTATED
 
-RUN: %mull_runner %s.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
+RUN: %mull_runner %s-ast.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
+RUN: %mull_runner %s-ir.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
 
 MULL_RUNNER:[info] Killed mutants (1/1):
 MULL_RUNNER:{{.*}}sample.cpp:6:13: warning: Killed: Replaced + with - [cxx_add_to_sub]

--- a/tests-lit/tests/cxx-frontend/binary_operator/20-parent-is-binary-operator-lhs/sample.cpp
+++ b/tests-lit/tests/cxx-frontend/binary_operator/20-parent-is-binary-operator-lhs/sample.cpp
@@ -24,15 +24,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: %clang_cxx %sysroot -fplugin=%mull_frontend_cxx %s -o %s.exe
+RUN: %clang_cxx %sysroot -fplugin=%mull_frontend_cxx %s -o %s-ast.exe
+RUN: %clang_cxx %sysroot -g %pass_mull_ir_frontend %s -o %s-ir.exe
 
-RUN: %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
-RUN: (env "cxx_add_to_sub:%s:6:33"=1 %s.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
+RUN: %s-ast.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
+RUN: (env "cxx_add_to_sub:%s:6:33"=1 %s-ast.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
+
+RUN: %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
+RUN: (env "cxx_add_to_sub:%s:6:33"=1 %s-ir.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
 
 STANDALONE_WITHOUT_MUTATION:NORMAL
 STANDALONE_WITH_MUTATION:MUTATED
 
-RUN: %mull_runner %s.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
+RUN: %mull_runner %s-ast.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
+RUN: %mull_runner %s-ir.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
 
 MULL_RUNNER:[info] Killed mutants (1/1):
 MULL_RUNNER:{{.*}}sample.cpp:6:33: warning: Killed: Replaced + with - [cxx_add_to_sub]

--- a/tests-lit/tests/cxx-frontend/binary_operator/21-parent-is-binary-operator-rhs/sample.cpp
+++ b/tests-lit/tests/cxx-frontend/binary_operator/21-parent-is-binary-operator-rhs/sample.cpp
@@ -1,9 +1,9 @@
 extern "C" {
 extern int printf(const char *, ...);
 }
-
+int x = 1;
 int sum_times() {
-  return (1 * (1 + 1));
+  return (x * (x + x));
 }
 
 int main() {
@@ -19,15 +19,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: %clang_cxx %sysroot -fplugin=%mull_frontend_cxx %s -o %s.exe
+RUN: %clang_cxx %sysroot -fplugin=%mull_frontend_cxx %s -o %s-ast.exe
+RUN: %clang_cxx %sysroot -g %pass_mull_ir_frontend %s -o %s-ir.exe
 
-RUN: %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
-RUN: (env "cxx_add_to_sub:%s:6:18"=1 %s.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
+RUN: %s-ast.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
+RUN: (env "cxx_add_to_sub:%s:6:18"=1 %s-ast.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
+
+RUN: %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
+RUN: (env "cxx_add_to_sub:%s:6:18"=1 %s-ir.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
 
 STANDALONE_WITHOUT_MUTATION:NORMAL
 STANDALONE_WITH_MUTATION:MUTATED
 
-RUN: %mull_runner %s.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
+RUN: %mull_runner %s-ast.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
+RUN: %mull_runner %s-ir.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
 
 MULL_RUNNER:[info] Killed mutants (1/1):
 MULL_RUNNER:{{.*}}sample.cpp:6:18: warning: Killed: Replaced + with - [cxx_add_to_sub]

--- a/tests-lit/tests/cxx-frontend/debug_information/cxx_add_to_sub/sample.cpp
+++ b/tests-lit/tests/cxx-frontend/debug_information/cxx_add_to_sub/sample.cpp
@@ -19,16 +19,22 @@ int main() {
 // clang-format off
 
 /**
-RUN: %clang_cxx %sysroot -fplugin=%mull_frontend_cxx %s -o %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=FRONTEND
+RUN: %clang_cxx %sysroot -fplugin=%mull_frontend_cxx %s -o %s-ast.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=FRONTEND
 FRONTEND:Recording mutation point: cxx_add_to_sub:{{.*}}/sample.cpp:6:12 (end: 6:13)
 
-RUN: %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
-RUN: (env "cxx_add_to_sub:%s:6:12"=1 %s.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
+RUN: %clang_cxx %sysroot -g %pass_mull_ir_frontend %s -o %s-ir.exe
+
+RUN: %s-ast.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
+RUN: (env "cxx_add_to_sub:%s:6:12"=1 %s-ast.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
+
+RUN: %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
+RUN: (env "cxx_add_to_sub:%s:6:12"=1 %s-ir.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
 
 STANDALONE_WITHOUT_MUTATION:NORMAL
 STANDALONE_WITH_MUTATION:MUTATED
 
-RUN: %mull_runner %s.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
+RUN: %mull_runner %s-ast.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
+RUN: %mull_runner %s-ir.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
 
 MULL_RUNNER:[info] Killed mutants (1/1):
 MULL_RUNNER:{{.*}}sample.cpp:6:12: warning: Killed: Replaced + with - [cxx_add_to_sub]

--- a/tests-lit/tests/cxx-frontend/debug_information/cxx_remove_negation/sample.cpp
+++ b/tests-lit/tests/cxx-frontend/debug_information/cxx_remove_negation/sample.cpp
@@ -19,16 +19,21 @@ int main() {
 // clang-format off
 
 /**
-RUN: %clang_cxx %sysroot -fplugin=%mull_frontend_cxx %s -o %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=FRONTEND
+RUN: %clang_cxx %sysroot -g %pass_mull_ir_frontend %s -o %s-ir.exe
+RUN: %clang_cxx %sysroot -fplugin=%mull_frontend_cxx %s -o %s-ast.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=FRONTEND
 FRONTEND:Recording mutation point: cxx_remove_negation:{{.*}}/sample.cpp:6:10 (end: 6:11)
 
-RUN: %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
-RUN: (env "cxx_remove_negation:%s:6:10"=1 %s.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
+RUN: %s-ast.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
+RUN: (env "cxx_remove_negation:%s:6:10"=1 %s-ast.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
+
+RUN: %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITHOUT_MUTATION
+RUN: (env "cxx_remove_negation:%s:6:10"=1 %s-ir.exe || true) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=STANDALONE_WITH_MUTATION
 
 STANDALONE_WITHOUT_MUTATION:NORMAL
 STANDALONE_WITH_MUTATION:MUTATED
 
-RUN: %mull_runner %s.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
+RUN: %mull_runner %s-ast.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
+RUN: %mull_runner %s-ir.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=MULL_RUNNER
 
 MULL_RUNNER:[info] Killed mutants (1/1):
 MULL_RUNNER:{{.*}}sample.cpp:6:10: warning: Killed: Replaced !a with a [cxx_remove_negation]

--- a/tests-lit/tests/deduplication/01/main.cpp
+++ b/tests-lit/tests/deduplication/01/main.cpp
@@ -13,11 +13,16 @@ int main() {
 }
 
 // clang-format off
-
-// RUN: cd / && %clang_cxx %sysroot %s -fembed-bitcode -g -o %s.exe
+// Runs infinitely on LLVM 10 or lower
+// REQUIRES: LLVM_11_OR_HIGHER
+// RUN: %clang_cxx %sysroot %pass_mull_ir_frontend %s -g -o %s-ir.exe
+// RUN: cd / && %clang_cxx %sysroot %s -fembed-bitcode -g -o %s-ebc.exe
 // RUN: cd %CURRENT_DIR
 
-// RUN: unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_add_to_sub -ide-reporter-show-killed %s.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+// RUN: unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_add_to_sub -ide-reporter-show-killed %s-ebc.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+// RUN: unset TERM; %mull_cxx -mutate-only -output %s-mutated.exe -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_add_to_sub -ide-reporter-show-killed %s-ebc.exe 2>&1
+// RUN: unset TERM; %mull_runner -ide-reporter-show-killed %s-mutated.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+// RUN: unset TERM; %mull_runner -ide-reporter-show-killed %s-ir.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 // CHECK:[info] Killed mutants (1/1):
 // CHECK:{{.*}}main.cpp:2:15: warning: Killed: Replaced + with - [cxx_add_to_sub]
 // CHECK:  return arg1 + arg2;

--- a/tests-lit/tests/deduplication/01/mull.yml
+++ b/tests-lit/tests/deduplication/01/mull.yml
@@ -1,0 +1,2 @@
+mutators:
+  - cxx_add_to_sub

--- a/tests-lit/tests/github-reporter/equality/main.cpp
+++ b/tests-lit/tests/github-reporter/equality/main.cpp
@@ -16,9 +16,11 @@ RUN: cp %S/main.cpp %S/Output/sandbox/main.cpp
 RUN: cd %S/Output/sandbox
 
 /// We cd to the the test directory and compile using relative paths.
-RUN: cd %S; %clang_cxx %sysroot -fembed-bitcode -g -O0 Output/sandbox/main.cpp -o Output/main.cpp.exe
+RUN: cd %S; %clang_cxx %sysroot -fembed-bitcode -g -O0 Output/sandbox/main.cpp -o Output/main.cpp-ebc.exe
+RUN: cd %S; %clang_cxx %sysroot -g -O0 %pass_mull_ir_frontend Output/sandbox/main.cpp -o Output/main.cpp-ir.exe
 
-RUN: cd %S/Output && echo $PATH; (unset TERM; %mull_cxx -mutators=cxx_eq_to_ne -linker-flags="%sysroot" --linker=%clang_cxx -debug main.cpp.exe --report-name test --reporters GithubAnnotations --reporters IDE; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output && echo $PATH; (unset TERM; %mull_cxx -mutators=cxx_eq_to_ne -linker-flags="%sysroot" --linker=%clang_cxx -debug main.cpp-ebc.exe --report-name test --reporters GithubAnnotations --reporters IDE; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output && echo $PATH; (unset TERM; %mull_runner main.cpp-ir.exe --report-name test --reporters GithubAnnotations --reporters IDE; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Github Annotations:
 CHECK:{{::}}warning file={{.*}}/main.cpp,line=2,col=12,endLine=2,endColumn=14::[cxx_eq_to_ne] Replaced == with !=

--- a/tests-lit/tests/github-reporter/equality/mull.yml
+++ b/tests-lit/tests/github-reporter/equality/mull.yml
@@ -1,0 +1,2 @@
+mutators:
+  - cxx_eq_to_ne

--- a/tests-lit/tests/github-reporter/shift/main.cpp
+++ b/tests-lit/tests/github-reporter/shift/main.cpp
@@ -16,9 +16,11 @@ RUN: cp %S/main.cpp %S/Output/sandbox/main.cpp
 RUN: cd %S/Output/sandbox
 
 /// We cd to the the test directory and compile using relative paths.
-RUN: cd %S; %clang_cxx %sysroot -fembed-bitcode -g -O0 Output/sandbox/main.cpp -o Output/main.cpp.exe
+RUN: cd %S; %clang_cxx %sysroot -fembed-bitcode -g -O0 Output/sandbox/main.cpp -o Output/main.cpp-ebc.exe
+RUN: cd %S; %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g Output/sandbox/main.cpp -o Output/main.cpp-ir.exe
 
-RUN: cd %S/Output && echo $PATH; (unset TERM; %mull_cxx -mutators=cxx_bitwise -linker-flags="%sysroot" --linker=%clang_cxx -debug main.cpp.exe --report-name test --reporters GithubAnnotations --reporters IDE; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output && echo $PATH; (unset TERM; %mull_cxx -mutators=cxx_bitwise -linker-flags="%sysroot" --linker=%clang_cxx -debug main.cpp-ebc.exe --report-name test --reporters GithubAnnotations --reporters IDE; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output && echo $PATH; (unset TERM; %mull_runner main.cpp-ir.exe --report-name test --reporters GithubAnnotations --reporters IDE; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Github Annotations:
 CHECK:{{::}}warning file={{.*}}/main.cpp,line=2,col=12,endLine=2,endColumn=14::[cxx_lshift_to_rshift] Replaced << with >>

--- a/tests-lit/tests/github-reporter/shift/mull.yml
+++ b/tests-lit/tests/github-reporter/shift/mull.yml
@@ -1,0 +1,2 @@
+mutators:
+  - cxx_bitwise

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/01-reading-git-diff-and-filtering/mull.yml
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/01-reading-git-diff-and-filtering/mull.yml
@@ -1,0 +1,6 @@
+gitDiffRef: master
+gitProjectRoot: ./Output/sandbox
+mutators:
+  - cxx_ge_to_lt
+  - cxx_ge_to_gt
+debugEnabled: true

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/01-reading-git-diff-and-filtering/test.itest
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/01-reading-git-diff-and-filtering/test.itest
@@ -6,17 +6,20 @@ RUN: git init .
 RUN: git add sample.cpp
 RUN: git -c user.name='Mull' -c user.email=alex@lowlevelbits.org commit -m "Impersonation is evil."
 RUN: cp %S/sample.cpp.modified %S/Output/sandbox/sample.cpp
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g -O0 %S/Output/sandbox/sample.cpp -o %S/Output/sample.cpp.exe
-RUN: cd %S/Output/sandbox && (unset TERM; %mull_cxx -debug -git-diff-ref=master -git-project-root=%S/Output/sandbox -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed %S/Output/sample.cpp.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g -O0 %S/Output/sandbox/sample.cpp -o %S/Output/sample.cpp-ebc.exe
+RUN: cd %S && %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g %S/Output/sandbox/sample.cpp -o %S/Output/sample.cpp-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines  --check-prefix=CHECK_MUTATE
+RUN: cd %S/Output/sandbox && (unset TERM; %mull_cxx -debug -git-diff-ref=master -git-project-root=%S/Output/sandbox -linker=%clang_cxx -mutate-only -output=%S/Output/sample.cpp.mutated.exe -linker-flags="%sysroot" -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed %S/Output/sample.cpp-ebc.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK_MUTATE
+RUN: cd %S/Output/sandbox && (unset TERM; %mull_runner %S/Output/sample.cpp-ir.exe -ide-reporter-show-killed 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output/sandbox && (unset TERM; %mull_runner %S/Output/sample.cpp.mutated.exe -ide-reporter-show-killed 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
-CHECK:[info] Incremental testing using Git Diff is enabled.
-CHECK:- Git ref: master
-CHECK:- Git project root: {{.*}}/Output/sandbox
+CHECK_MUTATE:[info] Incremental testing using Git Diff is enabled.
+CHECK_MUTATE:- Git ref: master
+CHECK_MUTATE:- Git project root: {{.*}}/Output/sandbox
 
-CHECK:[debug] GitDiffFilter: whitelisting instruction: {{.*}}/sample.cpp:4:7
-CHECK:[debug] GitDiffFilter: whitelisting instruction: {{.*}}/sample.cpp:4:11
-CHECK:[debug] GitDiffFilter: skipping instruction: {{.*}}/sample.cpp:7:7
-CHECK:[debug] GitDiffFilter: skipping instruction: {{.*}}/sample.cpp:7:11
+CHECK_MUTATE:[debug] GitDiffFilter: whitelisting instruction: {{.*}}/sample.cpp:4:7
+CHECK_MUTATE:[debug] GitDiffFilter: whitelisting instruction: {{.*}}/sample.cpp:4:11
+CHECK_MUTATE:[debug] GitDiffFilter: skipping instruction: {{.*}}/sample.cpp:7:7
+CHECK_MUTATE:[debug] GitDiffFilter: skipping instruction: {{.*}}/sample.cpp:7:11
 
 CHECK:[info] Killed mutants (2/2):
 CHECK:{{^.*}}sample.cpp:4:11: warning: Killed: Replaced >= with > [cxx_ge_to_gt]{{$}}

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/02-reading-git-diff-and-not-filtering/mull.yml
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/02-reading-git-diff-and-not-filtering/mull.yml
@@ -1,0 +1,6 @@
+gitDiffRef: master
+gitProjectRoot: ./Output/sandbox
+mutators:
+  - cxx_ge_to_lt
+  - cxx_ge_to_gt
+debugEnabled: true

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/02-reading-git-diff-and-not-filtering/test.itest
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/02-reading-git-diff-and-not-filtering/test.itest
@@ -8,11 +8,16 @@ RUN: git -c user.name='Mull' -c user.email=alex@lowlevelbits.org commit -m "Impe
 RUN: cp %S/sample.cpp.modified %S/Output/sandbox/sample.cpp
 RUN: cd / && %clang_cxx %sysroot -S -emit-llvm -g -O0 %S/Output/sandbox/sample.cpp -o %S/Output/sample.cpp.ll
 RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g -O0 %S/Output/sandbox/sample.cpp -o %S/Output/sample.cpp.exe
-RUN: cd %S/Output/sandbox && (unset TERM; %mull_cxx -debug -git-diff-ref=master -git-project-root=%S/Output/sandbox -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed %S/Output/sample.cpp.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S && %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g %S/Output/sandbox/sample.cpp -o %S/Output/sample.cpp-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK_MUTATE
+RUN: cd %S/Output/sandbox && (unset TERM; %mull_cxx -mutate-only -keep-executable -output=%S/Output/sample.cpp.mutated.exe -debug -git-diff-ref=master -git-project-root=%S/Output/sandbox -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed %S/Output/sample.cpp.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK_MUTATE
+RUN: chmod +x %S/Output/sample.cpp.mutated.exe
 
-CHECK:[debug] GitDiffFilter: skipping instruction: {{.*}}/sample.cpp:4:7
-CHECK:[debug] GitDiffFilter: skipping instruction: {{.*}}/sample.cpp:4:11
-CHECK:[debug] GitDiffFilter: skipping instruction: {{.*}}/sample.cpp:7:7
-CHECK:[debug] GitDiffFilter: skipping instruction: {{.*}}/sample.cpp:7:11
+RUN: cd %S/Output/sandbox && (unset TERM; %mull_runner -ide-reporter-show-killed %S/Output/sample.cpp.mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output/sandbox && (unset TERM; %mull_runner -ide-reporter-show-killed %S/Output/sample.cpp-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+
+CHECK_MUTATE:[debug] GitDiffFilter: skipping instruction: {{.*}}/sample.cpp:4:7
+CHECK_MUTATE:[debug] GitDiffFilter: skipping instruction: {{.*}}/sample.cpp:4:11
+CHECK_MUTATE:[debug] GitDiffFilter: skipping instruction: {{.*}}/sample.cpp:7:7
+CHECK_MUTATE:[debug] GitDiffFilter: skipping instruction: {{.*}}/sample.cpp:7:11
 
 CHECK:[info] No mutants found. Mutation score: infinitely high

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/03-reading-git-diff-and-filtering-compiled-from-nonroot/mull.yml
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/03-reading-git-diff-and-filtering-compiled-from-nonroot/mull.yml
@@ -1,0 +1,6 @@
+gitDiffRef: master
+gitProjectRoot: ./Output/sandbox
+mutators:
+  - cxx_ge_to_lt
+  - cxx_ge_to_gt
+debugEnabled: true

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/03-reading-git-diff-and-filtering-compiled-from-nonroot/test.itest
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/03-reading-git-diff-and-filtering-compiled-from-nonroot/test.itest
@@ -9,11 +9,16 @@ RUN: cp %S/sample.cpp.modified %S/Output/sandbox/sample.cpp
 
 /// We cd to the the test directory and compile using relative paths.
 RUN: cd %S; %clang_cxx %sysroot -fembed-bitcode -g -O0 Output/sandbox/sample.cpp -o Output/sample.cpp.exe
+RUN: cd %S; %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g Output/sandbox/sample.cpp -o Output/sample.cpp-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK_MUTATE
 
-RUN: cd %S/Output/sandbox && (unset TERM; %mull_cxx -debug -git-diff-ref=master -git-project-root=%S/Output/sandbox -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed %S/Output/sample.cpp.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output/sandbox && (unset TERM; %mull_cxx -mutate-only -output=%S/Output/sample.cpp.mutated.exe -debug -git-diff-ref=master -git-project-root=%S/Output/sandbox -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed %S/Output/sample.cpp.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK_MUTATE
 
-CHECK:[debug] GitDiffFilter: whitelisting instruction: {{.*}}/sample.cpp:4:7
-CHECK:[debug] GitDiffFilter: whitelisting instruction: {{.*}}/sample.cpp:4:11
+RUN: cd %S/Output/sandbox && (unset TERM; %mull_runner %S/Output/sample.cpp.mutated.exe -ide-reporter-show-killed %S/Output/sample.cpp.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output/sandbox && (unset TERM; %mull_runner %S/Output/sample.cpp-ir.exe -ide-reporter-show-killed %S/Output/sample.cpp.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+
+CHECK_MUTATE:[debug] GitDiffFilter: whitelisting instruction: {{.*}}/sample.cpp:4:7
+CHECK_MUTATE:[debug] GitDiffFilter: whitelisting instruction: {{.*}}/sample.cpp:4:11
+
 CHECK:[info] Killed mutants (2/2):
 CHECK:{{^.*}}sample.cpp:4:11: warning: Killed: Replaced >= with > [cxx_ge_to_gt]{{$}}
 CHECK:{{^.*}}sample.cpp:4:11: warning: Killed: Replaced >= with < [cxx_ge_to_lt]{{$}}

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/04-reading-git-diff-and-filtering-from-header-file/mull.yml
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/04-reading-git-diff-and-filtering-from-header-file/mull.yml
@@ -1,0 +1,6 @@
+gitDiffRef: master
+gitProjectRoot: ./Output/sandbox
+mutators:
+  - cxx_ge_to_lt
+  - cxx_ge_to_gt
+debugEnabled: true

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/04-reading-git-diff-and-filtering-from-header-file/test.itest
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/04-reading-git-diff-and-filtering-from-header-file/test.itest
@@ -8,10 +8,15 @@ RUN: git add -A
 RUN: git -c user.name='Mull' -c user.email=alex@lowlevelbits.org commit -m "Impersonation is evil."
 RUN: cp %S/valid_age.h.modified %S/Output/sandbox/valid_age.h
 RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g -O0 %S/Output/sandbox/sample.cpp -o %S/Output/sample.cpp.exe
-RUN: cd %S/Output/sandbox && (unset TERM; %mull_cxx -debug -git-diff-ref=master -git-project-root=%S/Output/sandbox -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed %S/Output/sample.cpp.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S && %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g %S/Output/sandbox/sample.cpp -o %S/Output/sample.cpp-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK_MUTATE
+RUN: cd %S/Output/sandbox && (unset TERM; %mull_cxx -mutate-only -output=%S/Output/sample.cpp.mutated.exe -debug -git-diff-ref=master -git-project-root=%S/Output/sandbox -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed %S/Output/sample.cpp.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK_MUTATE
 
-CHECK:[debug] GitDiffFilter: whitelisting instruction: {{.*}}/valid_age.h:4:7
-CHECK:[debug] GitDiffFilter: whitelisting instruction: {{.*}}/valid_age.h:4:11
+RUN: cd %S/Output/sandbox && (unset TERM; %mull_runner %S/Output/sample.cpp.mutated.exe -ide-reporter-show-killed 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output/sandbox && (unset TERM; %mull_runner %S/Output/sample.cpp-ir.exe -ide-reporter-show-killed 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+
+CHECK_MUTATE:[debug] GitDiffFilter: whitelisting instruction: {{.*}}/valid_age.h:4:7
+CHECK_MUTATE:[debug] GitDiffFilter: whitelisting instruction: {{.*}}/valid_age.h:4:11
+
 CHECK:[info] Killed mutants (2/2):
 CHECK:{{^.*}}valid_age.h:4:11: warning: Killed: Replaced >= with > [cxx_ge_to_gt]{{$}}
 CHECK:  if (age >= 21) { // This comment line creates a diff!

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/05-reading-empty-git-diff-skipping-everything/mull.yml
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/05-reading-empty-git-diff-skipping-everything/mull.yml
@@ -1,0 +1,6 @@
+gitDiffRef: master
+gitProjectRoot: ./Output/sandbox
+mutators:
+  - cxx_ge_to_lt
+  - cxx_ge_to_gt
+debugEnabled: true

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/05-reading-empty-git-diff-skipping-everything/test.itest
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/05-reading-empty-git-diff-skipping-everything/test.itest
@@ -6,9 +6,14 @@ RUN: git init .
 RUN: git add sample.cpp
 RUN: git -c user.name='Mull' -c user.email=alex@lowlevelbits.org commit -m "Impersonation is evil."
 RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g -O0 %S/Output/sandbox/sample.cpp -o %S/Output/sample.cpp.exe
-RUN: cd %S/Output/sandbox && (unset TERM; %mull_cxx -debug -git-diff-ref=master -git-project-root=%S/Output/sandbox -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed %S/Output/sample.cpp.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S && %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g %S/Output/sandbox/sample.cpp -o %S/Output/sample.cpp-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK_MUTATE
+RUN: cd %S/Output/sandbox && (unset TERM; %mull_cxx -mutate-only -keep-executable -output=%S/Output/sample.cpp.mutated.exe -debug -git-diff-ref=master -git-project-root=%S/Output/sandbox -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed %S/Output/sample.cpp.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK_MUTATE
+RUN: chmod +x %S/Output/sample.cpp.mutated.exe
 
-CHECK:[debug] GitDiffFilter: git diff is empty. Skipping instruction: {{.*}}/sample.cpp:4:7
-CHECK:[debug] GitDiffFilter: git diff is empty. Skipping instruction: {{.*}}/sample.cpp:4:11
+RUN: cd %S/Output/sandbox && (unset TERM; %mull_runner -ide-reporter-show-killed %S/Output/sample.cpp.mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output/sandbox && (unset TERM; %mull_runner -ide-reporter-show-killed %S/Output/sample.cpp-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+
+CHECK_MUTATE:[debug] GitDiffFilter: git diff is empty. Skipping instruction: {{.*}}/sample.cpp:4:7
+CHECK_MUTATE:[debug] GitDiffFilter: git diff is empty. Skipping instruction: {{.*}}/sample.cpp:4:11
 
 CHECK:[info] No mutants found. Mutation score: infinitely high

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/06-reading-git-diff-and-filtering-expands-to-full-path/mull.yml
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/06-reading-git-diff-and-filtering-expands-to-full-path/mull.yml
@@ -1,0 +1,6 @@
+gitDiffRef: master
+gitProjectRoot: .
+mutators:
+  - cxx_ge_to_lt
+  - cxx_ge_to_gt
+debugEnabled: true

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/06-reading-git-diff-and-filtering-expands-to-full-path/test.itest
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/06-reading-git-diff-and-filtering-expands-to-full-path/test.itest
@@ -7,18 +7,22 @@ RUN: git add sample.cpp
 RUN: git -c user.name='Mull' -c user.email=alex@lowlevelbits.org commit -m "Impersonation is evil."
 RUN: cp %S/sample.cpp.modified %S/Output/sandbox/sample.cpp
 RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g -O0 %S/Output/sandbox/sample.cpp -o %S/Output/sample.cpp.exe
+RUN: cd %S/Output/sandbox && %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g %S/Output/sandbox/sample.cpp -o %S/Output/sample.cpp-ir.exe  | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK_MUTATE
 
 /// The important part relevant to this test is -git-project-root=. (relative path is passed)
-RUN: cd %S/Output/sandbox && (unset TERM; %mull_cxx -debug -git-diff-ref=master -git-project-root=. -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed %S/Output/sample.cpp.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output/sandbox && (unset TERM; %mull_cxx -debug -mutate-only -output=%S/Output/sample.cpp.mutated.exe -git-diff-ref=master -git-project-root=. -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed %S/Output/sample.cpp.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK_MUTATE
 
-CHECK:[info] Incremental testing using Git Diff is enabled.
-CHECK:- Git ref: master
-CHECK:- Git project root: {{.*}}/Output/sandbox
+RUN: (unset TERM; %mull_runner -ide-reporter-show-killed %S/Output/sample.cpp.mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -ide-reporter-show-killed %S/Output/sample.cpp-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
-CHECK:[debug] GitDiffFilter: whitelisting instruction: {{.*}}/sample.cpp:4:7
-CHECK:[debug] GitDiffFilter: whitelisting instruction: {{.*}}/sample.cpp:4:11
-CHECK:[debug] GitDiffFilter: skipping instruction: {{.*}}/sample.cpp:7:7
-CHECK:[debug] GitDiffFilter: skipping instruction: {{.*}}/sample.cpp:7:11
+CHECK_MUTATE:[info] Incremental testing using Git Diff is enabled.
+CHECK_MUTATE:- Git ref: master
+CHECK_MUTATE:- Git project root: {{.*}}/Output/sandbox
+
+CHECK_MUTATE:[debug] GitDiffFilter: whitelisting instruction: {{.*}}/sample.cpp:4:7
+CHECK_MUTATE:[debug] GitDiffFilter: whitelisting instruction: {{.*}}/sample.cpp:4:11
+CHECK_MUTATE:[debug] GitDiffFilter: skipping instruction: {{.*}}/sample.cpp:7:7
+CHECK_MUTATE:[debug] GitDiffFilter: skipping instruction: {{.*}}/sample.cpp:7:11
 
 CHECK:[info] Killed mutants (2/2):
 CHECK:{{^.*}}sample.cpp:4:11: warning: Killed: Replaced >= with > [cxx_ge_to_gt]{{$}}

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/01-warning-when-git-diff-but-without-git-project-root/mull.yml
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/01-warning-when-git-diff-but-without-git-project-root/mull.yml
@@ -1,0 +1,5 @@
+gitDiffRef: master
+mutators:
+  - cxx_ge_to_lt
+  - cxx_ge_to_gt
+debugEnabled: true

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/01-warning-when-git-diff-but-without-git-project-root/test.itest
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/01-warning-when-git-diff-but-without-git-project-root/test.itest
@@ -2,7 +2,7 @@ RUN: cd %S
 RUN: TEMPDIR=$(mktemp -d)
 RUN: cp %S/sample.cpp.modified $TEMPDIR/sample.cpp
 RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g -O0 $TEMPDIR/sample.cpp -o $TEMPDIR/sample.cpp.exe
-RUN: cd $TEMPDIR && (unset TERM; %mull_cxx -workers=1 -debug -git-diff-ref=master -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed $TEMPDIR/sample.cpp.exe 2>&1; test $? = 0)
 RUN: cd $TEMPDIR && (unset TERM; %mull_cxx -workers=1 -debug -git-diff-ref=master -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed $TEMPDIR/sample.cpp.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S && %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g $TEMPDIR/sample.cpp -o $TEMPDIR/sample.cpp-ir.exe  | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[warning] -git-diff-ref option has been provided but the path to the Git project root has not been specified via -git-project-root. The incremental testing will be disabled.

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/02-warning-when-git-project-root-does-not-exist/mull.yml
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/02-warning-when-git-project-root-does-not-exist/mull.yml
@@ -1,0 +1,6 @@
+gitDiffRef: master
+gitProjectRoot: /tmp/does-not-exist
+mutators:
+  - cxx_ge_to_lt
+  - cxx_ge_to_gt
+debugEnabled: true

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/02-warning-when-git-project-root-does-not-exist/test.itest
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/02-warning-when-git-project-root-does-not-exist/test.itest
@@ -3,5 +3,6 @@ RUN: TEMPDIR=$(mktemp -d)
 RUN: cp %S/sample.cpp.modified $TEMPDIR/sample.cpp
 RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g -O0 $TEMPDIR/sample.cpp -o $TEMPDIR/sample.cpp.exe
 RUN: cd $TEMPDIR && (unset TERM; %mull_cxx -debug -git-diff-ref=master -git-project-root=/tmp/does-not-exist -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed $TEMPDIR/sample.cpp.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S && %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g $TEMPDIR/sample.cpp -o $TEMPDIR/sample.cpp.exe  | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[warning] directory provided by -git-project-root does not exist, the incremental testing will be disabled: /tmp/does-not-exist

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/03-warning-when-reading-git-diff-from-a-non-git-folder/mull.yml
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/03-warning-when-reading-git-diff-from-a-non-git-folder/mull.yml
@@ -1,0 +1,6 @@
+gitDiffRef: master
+gitProjectRoot: /tmp/not-git-dir
+mutators:
+  - cxx_ge_to_lt
+  - cxx_ge_to_gt
+debugEnabled: true

--- a/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/03-warning-when-reading-git-diff-from-a-non-git-folder/test.itest
+++ b/tests-lit/tests/incremental-testing-using-git-diff/git-diff-filtering-of-llvm-ir-functions/_preconditions/03-warning-when-reading-git-diff-from-a-non-git-folder/test.itest
@@ -1,7 +1,7 @@
-RUN: cd %S
-RUN: TEMPDIR=$(mktemp -d)
+RUN: TEMPDIR=/tmp/not-git-dir
+RUN: mkdir -p $TEMPDIR
 RUN: cp %S/sample.cpp.modified $TEMPDIR/sample.cpp
 RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g -O0 $TEMPDIR/sample.cpp -o $TEMPDIR/sample.cpp.exe
 RUN: cd $TEMPDIR && (unset TERM; %mull_cxx -git-diff-ref=master -git-project-root=$TEMPDIR -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed $TEMPDIR/sample.cpp.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-
+RUN: cd %S && %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g $TEMPDIR/sample.cpp -o $TEMPDIR/sample.cpp.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK:[warning] GitDiffReader: cannot get git diff information. Received output: {{.*}}Not a git repository{{.*}}

--- a/tests-lit/tests/junk_detection/00_error_compilation_flags_database_does_not_match_real_flags/mull.no_flag.yml
+++ b/tests-lit/tests/junk_detection/00_error_compilation_flags_database_does_not_match_real_flags/mull.no_flag.yml
@@ -1,0 +1,4 @@
+mutators:
+  - cxx_remove_void_call
+  - cxx_add_to_sub
+compilationDatabasePath: compile_commands.no_flag.json

--- a/tests-lit/tests/junk_detection/00_error_compilation_flags_database_does_not_match_real_flags/mull.no_junk.yml
+++ b/tests-lit/tests/junk_detection/00_error_compilation_flags_database_does_not_match_real_flags/mull.no_junk.yml
@@ -1,0 +1,4 @@
+mutators:
+  - cxx_remove_void_call
+  - cxx_add_to_sub
+junkDetectionDisabled: true

--- a/tests-lit/tests/junk_detection/00_error_compilation_flags_database_does_not_match_real_flags/mull.with_flag.yml
+++ b/tests-lit/tests/junk_detection/00_error_compilation_flags_database_does_not_match_real_flags/mull.with_flag.yml
@@ -1,0 +1,4 @@
+mutators:
+  - cxx_remove_void_call
+  - cxx_add_to_sub
+compilationDatabasePath: compile_commands.with_flag.json

--- a/tests-lit/tests/junk_detection/00_error_compilation_flags_database_does_not_match_real_flags/sample.cpp
+++ b/tests-lit/tests/junk_detection/00_error_compilation_flags_database_does_not_match_real_flags/sample.cpp
@@ -16,23 +16,35 @@ int main() {
 RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g -O0 -DFLAG=1 %s -o %s.exe
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.no_flag.json.template > %S/compile_commands.no_flag.json
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.with_flag.json.template > %S/compile_commands.with_flag.json
+
 RUN: cd %CURRENT_DIR
+RUN: cd / && env MULL_CONFIG=%S/mull.no_junk.yml %clang_cxx -O0 %sysroot %pass_mull_ir_frontend -g -DFLAG=1 %s -o %s-ir-no-junk.exe
 RUN: %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -disable-junk-detection -mutators=cxx_remove_void_call -mutators=cxx_add_to_sub -reporters=IDE %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
-RUN: %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_remove_void_call -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.no_flag.json %s.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-NO-FLAG
-RUN: %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_remove_void_call -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.with_flag.json %s.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAG
+RUN: %mull_runner -reporters=IDE %s-ir-no-junk.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
+
+RUN: cd %S && env MULL_CONFIG=%S/mull.no_flag.yml %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g -DFLAG=1 %s -o %s-ir-no-flag.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-NO-FLAG-MUTATE
+RUN: %mull_cxx -linker=%clang_cxx -mutate-only -output=%s-no-flag.exe -linker-flags="%sysroot" -mutators=cxx_remove_void_call -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.no_flag.json %s.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-NO-FLAG-MUTATE
+RUN: %mull_runner %s-no-flag.exe -reporters=IDE -ide-reporter-show-killed 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-NO-FLAG
+RUN: %mull_runner %s-ir-no-flag.exe -reporters=IDE -ide-reporter-show-killed 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-NO-FLAG
+
+RUN: cd %S && env MULL_CONFIG=%S/mull.with_flag.yml %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g -DFLAG=1 %s -o %s-ir-with-flag.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAG-MUTATE
+RUN: %mull_cxx -mutate-only -output=%s-with-flag.exe -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_remove_void_call -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.with_flag.json %s.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAG-MUTATE
+RUN: %mull_runner %s-with-flag.exe -reporters=IDE -ide-reporter-show-killed 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAG
+RUN: %mull_runner %s-ir-with-flag.exe -reporters=IDE -ide-reporter-show-killed 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAG
+
 
 WITHOUT-JUNK-DETECTION:{{^.*}}sample.cpp:5:13: warning: Survived: Removed the call to the function [cxx_remove_void_call]{{$}}
 
-WITH-JUNK-DETECTION-NO-FLAG:{{^.*}}sample.cpp:2:2: error: "FLAG is not defined"
-WITH-JUNK-DETECTION-NO-FLAG:#error "FLAG is not defined"
-WITH-JUNK-DETECTION-NO-FLAG: ^
-WITH-JUNK-DETECTION-NO-FLAG:[warning] Cannot parse file: '{{.*}}sample.cpp':
-WITH-JUNK-DETECTION-NO-FLAG:mull-cxx {{.*}}sample.cpp{{$}}
-WITH-JUNK-DETECTION-NO-FLAG:Make sure that the flags provided to Mull are the same flags that are used for normal compilation.
-TODO: It is interesting why there is no junk even if we have the error above.
+WITH-JUNK-DETECTION-NO-FLAG-MUTATE:{{^.*}}sample.cpp:2:2: error: "FLAG is not defined"
+WITH-JUNK-DETECTION-NO-FLAG-MUTATE:#error "FLAG is not defined"
+WITH-JUNK-DETECTION-NO-FLAG-MUTATE: ^
+WITH-JUNK-DETECTION-NO-FLAG-MUTATE:[warning] Cannot parse file: '{{.*}}sample.cpp':
+WITH-JUNK-DETECTION-NO-FLAG-MUTATE:mull-cxx {{.*}}sample.cpp{{$}}
+WITH-JUNK-DETECTION-NO-FLAG-MUTATE:Make sure that the flags provided to Mull are the same flags that are used for normal compilation.
+ TODO: It is interesting why there is no junk even if we have the error above.
 WITH-JUNK-DETECTION-NO-FLAG:[info] Killed mutants (1/1):
 
-WITH-JUNK-DETECTION-WITH-FLAG-NOT:#error "FLAG is not defined"
-WITH-JUNK-DETECTION-WITH-FLAG-NOT:{{^.*[Ee]rror.*$}}
+WITH-JUNK-DETECTION-WITH-FLAG-MUTATE-NOT:#error "FLAG is not defined"
+WITH-JUNK-DETECTION-WITH-FLAG-MUTATE-NOT:{{^.*Error.*$}}
 WITH-JUNK-DETECTION-WITH-FLAG:[info] Killed mutants (1/1):
 **/

--- a/tests-lit/tests/junk_detection/01_junk_detection/mull.no_junk.yml
+++ b/tests-lit/tests/junk_detection/01_junk_detection/mull.no_junk.yml
@@ -1,0 +1,4 @@
+mutators:
+  - cxx_add_to_sub
+  - cxx_remove_void_call
+junkDetectionDisabled: true

--- a/tests-lit/tests/junk_detection/01_junk_detection/mull.yml
+++ b/tests-lit/tests/junk_detection/01_junk_detection/mull.yml
@@ -1,0 +1,4 @@
+mutators:
+  - cxx_add_to_sub
+  - cxx_remove_void_call
+compilationDatabasePath: compile_commands.json

--- a/tests-lit/tests/junk_detection/01_junk_detection/sample.cpp
+++ b/tests-lit/tests/junk_detection/01_junk_detection/sample.cpp
@@ -12,8 +12,13 @@ int main() {
 RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g -O0 %s -o %s.exe
 RUN: sed -e "s:%PWD:%s:g" %S/compile_commands.json.template > %S/compile_commands.json
 RUN: cd %CURRENT_DIR
+RUN: env MULL_CONFIG=%S/mull.no_junk.yml %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g %s -o %s-ir-no-junk.exe
 RUN: %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -workers=1 -disable-junk-detection -mutators=cxx_add_to_sub -mutators=cxx_remove_void_call -reporters=IDE %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
+RUN: %mull_runner -workers=1 -reporters=IDE %s-ir-no-junk.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
+
+RUN: env MULL_CONFIG=%S/mull.yml %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g %s -o %s-ir.exe
 RUN: %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -workers=1 -mutators=cxx_add_to_sub -mutators=cxx_remove_void_call -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION
+RUN: %mull_runner -workers=1 -reporters=IDE -ide-reporter-show-killed %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION
 
 WITHOUT-JUNK-DETECTION:{{^.*}}[info] Running mutants (threads: 1){{$}}
 WITHOUT-JUNK-DETECTION:{{^.*}}sample.cpp:1:13: warning: Survived: Removed the call to the function [cxx_remove_void_call]{{$}}

--- a/tests-lit/tests/junk_detection/02_junk_detection_using_extra_flags/mull.no_flag.yml
+++ b/tests-lit/tests/junk_detection/02_junk_detection_using_extra_flags/mull.no_flag.yml
@@ -1,0 +1,5 @@
+mutators:
+  - cxx_add_to_sub
+  - cxx_remove_void_call
+compilerFlags:
+  - -DWRONG_FLAG=1

--- a/tests-lit/tests/junk_detection/02_junk_detection_using_extra_flags/mull.no_junk.yml
+++ b/tests-lit/tests/junk_detection/02_junk_detection_using_extra_flags/mull.no_junk.yml
@@ -1,0 +1,4 @@
+mutators:
+  - cxx_add_to_sub
+  - cxx_remove_void_call
+junkDetectionDisabled: true

--- a/tests-lit/tests/junk_detection/02_junk_detection_using_extra_flags/mull.with_flag.yml
+++ b/tests-lit/tests/junk_detection/02_junk_detection_using_extra_flags/mull.with_flag.yml
@@ -1,0 +1,5 @@
+mutators:
+  - cxx_add_to_sub
+  - cxx_remove_void_call
+compilerFlags:
+  - -DFLAG=1

--- a/tests-lit/tests/junk_detection/02_junk_detection_using_extra_flags/sample.cpp
+++ b/tests-lit/tests/junk_detection/02_junk_detection_using_extra_flags/sample.cpp
@@ -15,22 +15,32 @@ int main() {
 /**
 RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g -O0 -DFLAG=1 %s -o %s.exe
 RUN: cd %CURRENT_DIR
+RUN: cd / && env MULL_CONFIG=%S/mull.no_junk.yml %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g -DFLAG=1 %s -o %s-ir-no-junk.exe
+RUN: %mull_runner -reporters=IDE %s-ir-no-junk.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
 RUN: %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -disable-junk-detection -mutators=cxx_add_to_sub -mutators=cxx_remove_void_call -reporters=IDE %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
-RUN: %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_add_to_sub -mutators=cxx_remove_void_call -reporters=IDE -ide-reporter-show-killed -compilation-flags '-DWRONG_FLAG=1' %s.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-NO-FLAG
-RUN: %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_add_to_sub -mutators=cxx_remove_void_call -reporters=IDE -ide-reporter-show-killed -compilation-flags '-DFLAG=1' %s.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAG
 
 WITHOUT-JUNK-DETECTION:{{^.*}}sample.cpp:5:13: warning: Survived: Removed the call to the function [cxx_remove_void_call]{{$}}
 
-WITH-JUNK-DETECTION-NO-FLAG:{{^.*}}sample.cpp:2:2: error: "FLAG is not defined"
-WITH-JUNK-DETECTION-NO-FLAG:#error "FLAG is not defined"
-WITH-JUNK-DETECTION-NO-FLAG: ^
-WITH-JUNK-DETECTION-NO-FLAG:[warning] Cannot parse file: '{{.*}}sample.cpp':
-WITH-JUNK-DETECTION-NO-FLAG:mull-cxx {{.*}}sample.cpp{{$}}
-WITH-JUNK-DETECTION-NO-FLAG:Make sure that the flags provided to Mull are the same flags that are used for normal compilation.
+RUN: cd / && env MULL_CONFIG=%S/mull.no_flag.yml %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g -DFLAG=1 %s -o %s-ir-no-flag.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-NO-FLAG-MUTATE
+RUN: %mull_cxx -mutate-only -output=%s-no-flag.exe -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_add_to_sub -mutators=cxx_remove_void_call -reporters=IDE -ide-reporter-show-killed -compilation-flags '-DWRONG_FLAG=1' %s.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-NO-FLAG-MUTATE
+RUN: %mull_runner -ide-reporter-show-killed %s-no-flag.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-NO-FLAG
+RUN: %mull_runner -ide-reporter-show-killed %s-ir-no-flag.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-NO-FLAG
+
+WITH-JUNK-DETECTION-NO-FLAG-MUTATE:{{^.*}}sample.cpp:2:2: error: "FLAG is not defined"
+WITH-JUNK-DETECTION-NO-FLAG-MUTATE:#error "FLAG is not defined"
+WITH-JUNK-DETECTION-NO-FLAG-MUTATE: ^
+WITH-JUNK-DETECTION-NO-FLAG-MUTATE:[warning] Cannot parse file: '{{.*}}sample.cpp':
+WITH-JUNK-DETECTION-NO-FLAG-MUTATE:mull-cxx {{.*}}sample.cpp{{$}}
+WITH-JUNK-DETECTION-NO-FLAG-MUTATE:Make sure that the flags provided to Mull are the same flags that are used for normal compilation.
 TODO: It is interesting why there is no junk even if we have the error above.
 WITH-JUNK-DETECTION-NO-FLAG:[info] Killed mutants (1/1):
 
-WITH-JUNK-DETECTION-WITH-FLAG-NOT:#error "FLAG is not defined"
-WITH-JUNK-DETECTION-WITH-FLAG-NOT:{{^.*[Ee]rror.*$}}
+RUN: cd / && env MULL_CONFIG=%S/mull.with_flag.yml %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g -DFLAG=1 %s -o %s-ir-with-flag.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAG-MUTATE
+RUN: %mull_cxx -mutate-only -output=%s-with-flag.exe -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_add_to_sub -mutators=cxx_remove_void_call -reporters=IDE -ide-reporter-show-killed -compilation-flags '-DFLAG=1' %s.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAG-MUTATE
+RUN: %mull_runner -reporters=IDE -ide-reporter-show-killed %s-with-flag.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAG
+RUN: %mull_runner -reporters=IDE -ide-reporter-show-killed %s-ir-with-flag.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAG
+
+WITH-JUNK-DETECTION-WITH-FLAG-MUTATE-NOT:#error "FLAG is not defined"
+WITH-JUNK-DETECTION-WITH-FLAG-MUTATE-NOT:{{^.*[Ee]rror.*$}}
 WITH-JUNK-DETECTION-WITH-FLAG:[info] Killed mutants (1/1):
 **/

--- a/tests-lit/tests/junk_detection/03_junk_detection_merging_comp_db_and_extra_flags/mull.no_junk.yml
+++ b/tests-lit/tests/junk_detection/03_junk_detection_merging_comp_db_and_extra_flags/mull.no_junk.yml
@@ -1,0 +1,4 @@
+mutators:
+  - cxx_add_to_sub
+  - cxx_remove_void_call
+junkDetectionDisabled: true

--- a/tests-lit/tests/junk_detection/03_junk_detection_merging_comp_db_and_extra_flags/mull.yml
+++ b/tests-lit/tests/junk_detection/03_junk_detection_merging_comp_db_and_extra_flags/mull.yml
@@ -1,0 +1,6 @@
+mutators:
+  - cxx_add_to_sub
+  - cxx_remove_void_call
+compilationDatabasePath: compile_commands.json
+compilaerFlags:
+  - -DFLAG_VIA_EXTRA_FLAGS=1

--- a/tests-lit/tests/junk_detection/03_junk_detection_merging_comp_db_and_extra_flags/sample.cpp
+++ b/tests-lit/tests/junk_detection/03_junk_detection_merging_comp_db_and_extra_flags/sample.cpp
@@ -20,11 +20,19 @@ int main() {
 RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g -O0 -DFLAG_VIA_COMP_DB=1 -DFLAG_VIA_EXTRA_FLAGS=1 %s -o %s.exe
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
 RUN: cd %CURRENT_DIR
-RUN: %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -disable-junk-detection -mutators=cxx_add_to_sub -mutators=cxx_remove_void_call -reporters=IDE %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
-RUN: %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_add_to_sub -mutators=cxx_remove_void_call -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json -compilation-flags '-DFLAG_VIA_EXTRA_FLAGS=1' %s.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAGS
+
+RUN: cd / && env MULL_CONFIG=%S/mull.no_junk.yml %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g -DFLAG_VIA_COMP_DB=1 -DFLAG_VIA_EXTRA_FLAGS=1 %s -o %s-ir-no-junk.exe
+RUN: %mull_cxx -mutate-only -output=%s-no-junk.exe -linker=%clang_cxx -linker-flags="%sysroot" -disable-junk-detection -mutators=cxx_add_to_sub -mutators=cxx_remove_void_call -reporters=IDE %s.exe
+RUN: %mull_runner %s-no-junk.exe -reporters=IDE | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
+RUN: %mull_runner %s-ir-no-junk.exe -reporters=IDE | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
 
 WITHOUT-JUNK-DETECTION:{{^.*}}sample.cpp:9:13: warning: Survived: Removed the call to the function [cxx_remove_void_call]{{$}}
 
-WITH-JUNK-DETECTION-WITH-FLAGS-NOT:{{^.*[Ee]rror.*$}}
+RUN: cd %S && env MULL_CONFIG=%S/mull.yml %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g -DFLAG_VIA_COMP_DB=1 -DFLAG_VIA_EXTRA_FLAGS=1 %s -o %s-ir-with-flags.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAGS-MUTATE
+RUN: %mull_cxx -mutate-only -output=%s-with-flags.exe -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_add_to_sub -mutators=cxx_remove_void_call -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json -compilation-flags '-DFLAG_VIA_EXTRA_FLAGS=1' %s.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAGS-MUTATE
+RUN: %mull_runner %s-with-flags.exe -reporters=IDE -ide-reporter-show-killed 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAGS
+RUN: %mull_runner %s-ir-with-flags.exe -reporters=IDE -ide-reporter-show-killed 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAGS
+
+WITH-JUNK-DETECTION-WITH-FLAGS-MUTATE-NOT:{{^.*[Ee]rror.*$}}
 WITH-JUNK-DETECTION-WITH-FLAGS:[info] Killed mutants (1/1):
 **/

--- a/tests-lit/tests/junk_detection/04_junk_detection_using_bitcode_compilation_flags_via_record_command_line_flag/mull.no_junk.yml
+++ b/tests-lit/tests/junk_detection/04_junk_detection_using_bitcode_compilation_flags_via_record_command_line_flag/mull.no_junk.yml
@@ -1,0 +1,4 @@
+mutators:
+  - cxx_add_to_sub
+  - cxx_remove_void_call
+junkDetectionDisabled: true

--- a/tests-lit/tests/junk_detection/04_junk_detection_using_bitcode_compilation_flags_via_record_command_line_flag/mull.yml
+++ b/tests-lit/tests/junk_detection/04_junk_detection_using_bitcode_compilation_flags_via_record_command_line_flag/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_add_to_sub
+  - cxx_remove_void_call

--- a/tests-lit/tests/junk_detection/04_junk_detection_using_bitcode_compilation_flags_via_record_command_line_flag/sample.cpp
+++ b/tests-lit/tests/junk_detection/04_junk_detection_using_bitcode_compilation_flags_via_record_command_line_flag/sample.cpp
@@ -13,17 +13,23 @@ int main() {
 // clang-format off
 
 /**
-REQUIRES: LLVM_8_OR_HIGHER
 RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g -DFLAG=1 %s -o %s.exe
 RUN: cd %CURRENT_DIR
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -disable-junk-detection -mutators=cxx_add_to_sub -mutators=cxx_remove_void_call -reporters=IDE -ide-reporter-show-killed %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-RECORD-COMMAND-LINE
-WITHOUT-RECORD-COMMAND-LINE-NOT:Found compilation flags in the input bitcode
+
+RUN: cd / && env MULL_CONFIG=%S/mull.no_junk.yml %clang_cxx %sysroot %pass_mull_ir_frontend -g -DFLAG=1 %s -o %s-ir-no-junk.exe
+RUN: (unset TERM; %mull_cxx -mutate-only -output=%s-no-junk.exe -linker=%clang_cxx -linker-flags="%sysroot" -disable-junk-detection -mutators=cxx_add_to_sub -mutators=cxx_remove_void_call -reporters=IDE -ide-reporter-show-killed %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-RECORD-COMMAND-LINE-MUTATE
+RUN: (unset TERM; %mull_runner -reporters=IDE -ide-reporter-show-killed %s-no-junk.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-RECORD-COMMAND-LINE
+RUN: (unset TERM; %mull_runner -reporters=IDE -ide-reporter-show-killed %s-ir-no-junk.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-RECORD-COMMAND-LINE
+WITHOUT-RECORD-COMMAND-LINE-MUTATE-NOT:Found compilation flags in the input bitcode
 WITHOUT-RECORD-COMMAND-LINE:{{^.*}}sample.cpp:5:13: warning: Survived: Removed the call to the function [cxx_remove_void_call]{{$}}
 
+
 RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g -DFLAG=1 -grecord-command-line %s -o %s.exe
-RUN: cd %CURRENT_DIR
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_add_to_sub -mutators=cxx_remove_void_call -reporters=IDE -ide-reporter-show-killed %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-RECORD-COMMAND-LINE
-WITH-RECORD-COMMAND-LINE:[info] Found compilation flags in the input bitcode
-WITH-RECORD-COMMAND-LINE-NOT:{{^.*[Ee]rror.*$}}
+RUN: cd / && env MULL_CONFIG=%S/mull.yml %clang_cxx %sysroot %pass_mull_ir_frontend -g -DFLAG=1 -grecord-command-line %s -o %s-ir-record-cli.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-RECORD-COMMAND-LINE-MUTATE
+RUN: (unset TERM; %mull_cxx -mutate-only -output=%s-record-cli.exe -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_add_to_sub -mutators=cxx_remove_void_call -reporters=IDE -ide-reporter-show-killed %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-RECORD-COMMAND-LINE-MUTATE
+RUN: (unset TERM; %mull_runner -reporters=IDE -ide-reporter-show-killed %s-record-cli.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-RECORD-COMMAND-LINE
+RUN: (unset TERM; %mull_runner -reporters=IDE -ide-reporter-show-killed %s-ir-record-cli.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-RECORD-COMMAND-LINE
+WITH-RECORD-COMMAND-LINE-MUTATE:[info] Found compilation flags in the input bitcode
+WITH-RECORD-COMMAND-LINE-MUTATE-NOT:{{^.*[Ee]rror.*$}}
 WITH-RECORD-COMMAND-LINE:[info] Killed mutants (1/1):
 **/

--- a/tests-lit/tests/mutation_testing_elements/01_mutation_testing_elements_report/sample.cpp
+++ b/tests-lit/tests/mutation_testing_elements/01_mutation_testing_elements_report/sample.cpp
@@ -14,13 +14,17 @@ int main() {
 // clang-format off
 
 /**
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe
 RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
 RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_remove_void_call -reporters=IDE -reporters=Elements --report-dir=%S/Output --report-name=sample -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -reporters=Elements --report-dir=%S/Output --report-name=sample-ir -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 RUN: [[ -f %S/Output/sample.json ]]
+RUN: [[ -f %S/Output/sample-ir.json ]]
 RUN: cat %S/Output/sample.json | filecheck %s --check-prefix=CHECK-JSON
-CHECK-JSON: "config": {"Build Date": "{{.*}}", "CommandLine": "{{.*}}", {{.*}}, "URL": "https://github.com/mull-project/mull"}{{.*}} "mutants": [{"id": "cxx_remove_void_call", "location": {"end": {"column": 26, "line": 6}, "start": {"column": 3, "line": 6}}, "mutatorName": "Removed the call to the function", "replacement": "", "status": "Killed"}]{{.*}} "framework": {"brandingInformation": {"homepageUrl": "https://github.com/mull-project/mull"}, "name": "Mull", "version": "{{.*}}, LLVM {{.*}}"}
+RUN: cat %S/Output/sample-ir.json | filecheck %s --check-prefix=CHECK-JSON
+CHECK-JSON: "config": {"Build Date": "{{.*}}", {{.*}} "URL": "https://github.com/mull-project/mull"}{{.*}} "mutants": [{"id": "cxx_remove_void_call", "location": {"end": {"column": 26, "line": 6}, "start": {"column": 3, "line": 6}}, "mutatorName": "Removed the call to the function", "replacement": "", "status": "Killed"}]{{.*}} "framework": {"brandingInformation": {"homepageUrl": "https://github.com/mull-project/mull"}, "name": "Mull", "version": "{{.*}}, LLVM {{.*}}"}
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:6:3: warning: Killed: Removed the call to the function [cxx_remove_void_call]

--- a/tests-lit/tests/mutation_testing_elements/mull.yml
+++ b/tests-lit/tests/mutation_testing_elements/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_remove_void_call
+compilationDatabasePath: compile_commands.json

--- a/tests-lit/tests/mutations/assignment/cxx_assign_const/01/main.c
+++ b/tests-lit/tests/mutations/assignment/cxx_assign_const/01/main.c
@@ -9,10 +9,12 @@ int main() {
 
 // clang-format off
 
-// RUN: cd / && %clang_cc %sysroot -fembed-bitcode -g -O0 %s -o %s.exe
+// RUN: %clang_cc %sysroot -O0 %pass_mull_ir_frontend -g %s -o %s-ir.exe
+// RUN: cd / && %clang_cc %sysroot -fembed-bitcode -g -O0 %s -o %s-ebc.exe
 // RUN: cd %CURRENT_DIR
-// RUN: unset TERM; %mull_cxx -linker=%clang_cc -linker-flags="%sysroot" -disable-junk-detection -keep-executable -output=%s.mutated.exe -mutators=cxx_assign_const -ide-reporter-show-killed -reporters=IDE %s.exe | %filecheck %s --dump-input=fail
+// RUN: unset TERM; %mull_cxx -linker=%clang_cc -linker-flags="%sysroot" -disable-junk-detection -keep-executable -output=%s.mutated.exe -mutators=cxx_assign_const -ide-reporter-show-killed -reporters=IDE %s-ebc.exe | %filecheck %s --dump-input=fail
 // RUN: unset TERM; %mull_runner -ide-reporter-show-killed -reporters=IDE %s.mutated.exe | %filecheck %s --dump-input=fail
+// RUN: unset TERM; %mull_runner -ide-reporter-show-killed -reporters=IDE %s-ir.exe | %filecheck %s --dump-input=fail
 // CHECK:[info] Killed mutants (1/1):
 // CHECK:{{.*}}main.c:2:7: warning: Killed: Replaced 'a = b' with 'a = 42' [cxx_assign_const]
 // CHECK:  int b = a + 100;

--- a/tests-lit/tests/mutations/assignment/cxx_assign_const/01/mull.yml
+++ b/tests-lit/tests/mutations/assignment/cxx_assign_const/01/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_assign_const
+junkDetectionDisabled: true

--- a/tests-lit/tests/mutations/comparison/cxx_lt_to_ge/01/main.c
+++ b/tests-lit/tests/mutations/comparison/cxx_lt_to_ge/01/main.c
@@ -19,10 +19,12 @@ int main() {
 
 // clang-format off
 
+// RUN: %clang_cc %sysroot -O0 %pass_mull_ir_frontend -g %s -o %s-ir.exe
 // RUN: cd / && %clang_cc %sysroot -fembed-bitcode -g -O0 %s -o %s.exe
 // RUN: cd %CURRENT_DIR
 // RUN: unset TERM; %mull_cxx -keep-executable -output=%s.mutated.exe -linker=%clang_cc -linker-flags="%sysroot" -mutators=cxx_lt_to_ge -ide-reporter-show-killed -reporters=IDE %s.exe | %filecheck %s --dump-input=fail
 // RUN: unset TERM; %mull_runner -ide-reporter-show-killed -reporters=IDE %s.mutated.exe | %filecheck %s --dump-input=fail
+// RUN: unset TERM; %mull_runner -ide-reporter-show-killed -reporters=IDE %s-ir.exe | %filecheck %s --dump-input=fail
 // CHECK:[info] Killed mutants (1/1):
 // CHECK:{{.*}}main.c:2:9: warning: Killed: Replaced < with >= [cxx_lt_to_ge]
 // CHECK:  if (a < b) {

--- a/tests-lit/tests/mutations/comparison/cxx_lt_to_ge/01/mull.yml
+++ b/tests-lit/tests/mutations/comparison/cxx_lt_to_ge/01/mull.yml
@@ -1,0 +1,2 @@
+mutators:
+  - cxx_lt_to_ge

--- a/tests-lit/tests/mutations/logical/and_or_combined/01/main.c
+++ b/tests-lit/tests/mutations/logical/and_or_combined/01/main.c
@@ -85,10 +85,12 @@ int main() {
 
 // clang-format off
 
+// RUN: %clang_cc %sysroot -O0 %pass_mull_ir_frontend -g %s -o %s-ir.exe
 // RUN: cd / && %clang_cc %sysroot -fembed-bitcode -g -O0 %s -o %s.exe
 // RUN: cd %CURRENT_DIR
 // RUN: unset TERM; %mull_cxx -keep-executable -output=%s.mutated.exe -linker=%clang_cc -linker-flags="%sysroot" -mutators=cxx_logical_or_to_and -mutators=cxx_logical_and_to_or -ide-reporter-show-killed -reporters=IDE %s.exe | %filecheck %s --dump-input=fail
 // RUN: unset TERM; %mull_runner -ide-reporter-show-killed -reporters=IDE %s.mutated.exe | %filecheck %s --dump-input=fail
+// RUN: unset TERM; %mull_runner -ide-reporter-show-killed -reporters=IDE %s-ir.exe | %filecheck %s --dump-input=fail
 // CHECK:[info] Killed mutants (4/8):
 // CHECK:{{.*}}main.c:6:23: warning: Killed: Replaced || with && [cxx_logical_or_to_and]
 // CHECK:  if (a < b && (b < c || a < c)) {

--- a/tests-lit/tests/mutations/logical/and_or_combined/01/mull.yml
+++ b/tests-lit/tests/mutations/logical/and_or_combined/01/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_logical_or_to_and
+  - cxx_logical_and_to_or

--- a/tests-lit/tests/mutations/logical/cxx_logical_and_to_or/01/main.c
+++ b/tests-lit/tests/mutations/logical/cxx_logical_and_to_or/01/main.c
@@ -91,10 +91,12 @@ int main() {
 
 // clang-format off
 
+// RUN: %clang_cc %sysroot -O0 %pass_mull_ir_frontend -g %s -o %s-ir.exe
 // RUN: cd / && %clang_cc %sysroot -fembed-bitcode -g -O0 %s -o %s.exe
 // RUN: cd %CURRENT_DIR
 // RUN: unset TERM; %mull_cxx -keep-executable -output=%s.mutated.exe -linker=%clang_cc -linker-flags="%sysroot" -mutators=cxx_logical_and_to_or -ide-reporter-show-killed -reporters=IDE %s.exe | %filecheck %s --dump-input=fail
 // RUN: unset TERM; %mull_runner -ide-reporter-show-killed -reporters=IDE %s.mutated.exe | %filecheck %s --dump-input=fail
+// RUN: unset TERM; %mull_runner -ide-reporter-show-killed -reporters=IDE %s-ir.exe | %filecheck %s --dump-input=fail
 // CHECK:[info] Killed mutants (2/5):
 // CHECK:{{.*}}main.c:8:13: warning: Killed: Replaced && with || [cxx_logical_and_to_or]
 // CHECK:  if (a < b && b < c) {

--- a/tests-lit/tests/mutations/logical/cxx_logical_and_to_or/01/mull.yml
+++ b/tests-lit/tests/mutations/logical/cxx_logical_and_to_or/01/mull.yml
@@ -1,0 +1,2 @@
+mutators:
+  - cxx_logical_and_to_or

--- a/tests-lit/tests/mutations/logical/cxx_logical_and_to_or/02/main.cpp
+++ b/tests-lit/tests/mutations/logical/cxx_logical_and_to_or/02/main.cpp
@@ -77,10 +77,12 @@ int main() {
 
 // clang-format off
 
+// RUN: %clang_cxx %sysroot %TEST_CXX_FLAGS -O0 %pass_mull_ir_frontend -g %s -o %s-ir.exe
 // RUN: cd / && %clang_cxx %sysroot %TEST_CXX_FLAGS -fembed-bitcode -g -O0 %s -o %s.exe
 // RUN: cd %CURRENT_DIR
 // RUN: unset TERM; %mull_cxx -keep-executable -output=%s.mutated.exe -linker=%clang_cxx -linker-flags="%sysroot -lc++" -disable-junk-detection -mutators=cxx_logical_and_to_or -ide-reporter-show-killed -reporters=IDE %s.exe | %filecheck %s --dump-input=fail
 // RUN: unset TERM; %mull_runner -ide-reporter-show-killed -reporters=IDE %s.mutated.exe | %filecheck %s --dump-input=fail
+// RUN: unset TERM; %mull_runner -ide-reporter-show-killed -reporters=IDE %s-ir.exe | %filecheck %s --dump-input=fail
 // CHECK:[info] Killed mutants (3/3):
 // CHECK:{{.*}}main.cpp:11:51: warning: Killed: Replaced && with || [cxx_logical_and_to_or]
 // CHECK:  if ((string1.find("STR1") != std::string::npos) &&

--- a/tests-lit/tests/mutations/logical/cxx_logical_and_to_or/02/mull.yml
+++ b/tests-lit/tests/mutations/logical/cxx_logical_and_to_or/02/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_logical_and_to_or
+junkDetectionDisabled: true

--- a/tests-lit/tests/mutations/logical/cxx_logical_or_to_and/01/main.c
+++ b/tests-lit/tests/mutations/logical/cxx_logical_or_to_and/01/main.c
@@ -91,10 +91,12 @@ int main() {
 
 // clang-format off
 
+// RUN: %clang_cc %sysroot -O0 %pass_mull_ir_frontend -g %s -o %s-ir.exe
 // RUN: cd / && %clang_cc %sysroot -fembed-bitcode -g -O0 %s -o %s.exe
 // RUN: cd %CURRENT_DIR
 // RUN: unset TERM; %mull_cxx -keep-executable -output=%s.mutated.exe -linker=%clang_cc -linker-flags="%sysroot" -mutators=cxx_logical_or_to_and -ide-reporter-show-killed -reporters=IDE %s.exe | %filecheck %s --dump-input=fail
 // RUN: unset TERM; %mull_runner -ide-reporter-show-killed -reporters=IDE %s.mutated.exe | %filecheck %s --dump-input=fail
+// RUN: unset TERM; %mull_runner -ide-reporter-show-killed -reporters=IDE %s-ir.exe | %filecheck %s --dump-input=fail
 // CHECK:[info] Killed mutants (2/5):
 // CHECK:{{.*}}8:13: warning: Killed: Replaced || with && [cxx_logical_or_to_and]
 // CHECK:  if (a < b || b < c) {

--- a/tests-lit/tests/mutations/logical/cxx_logical_or_to_and/01/mull.yml
+++ b/tests-lit/tests/mutations/logical/cxx_logical_or_to_and/01/mull.yml
@@ -1,0 +1,2 @@
+mutators:
+  - cxx_logical_or_to_and

--- a/tests-lit/tests/mutations/logical/cxx_logical_or_to_and/02/main.cpp
+++ b/tests-lit/tests/mutations/logical/cxx_logical_or_to_and/02/main.cpp
@@ -79,10 +79,12 @@ int main() {
 
 // clang-format off
 
+// RUN: %clang_cxx %sysroot %TEST_CXX_FLAGS -O0 %pass_mull_ir_frontend -g %s -o %s-ir.exe
 // RUN: cd / && %clang_cxx %sysroot %TEST_CXX_FLAGS -fembed-bitcode -g -O0 %s -o %s.exe
 // RUN: cd %CURRENT_DIR
 // RUN: unset TERM; %mull_cxx -keep-executable -output=%s.mutated.exe -linker=%clang_cxx -linker-flags="%sysroot -lc++" -disable-junk-detection -mutators=cxx_logical_or_to_and -ide-reporter-show-killed -reporters=IDE %s.exe | %filecheck %s --dump-input=fail
 // RUN: unset TERM; %mull_runner -ide-reporter-show-killed -reporters=IDE %s.mutated.exe | %filecheck %s --dump-input=fail
+// RUN: unset TERM; %mull_runner -ide-reporter-show-killed -reporters=IDE %s-ir.exe | %filecheck %s --dump-input=fail
 // CHECK:[info] Killed mutants (3/3):
 // CHECK:{{.*}}main.cpp:11:51: warning: Killed: Replaced || with && [cxx_logical_or_to_and]
 // CHECK:  if ((string1.find("STR1") != std::string::npos) || (string2.find("STR1") != std::string::npos)) {

--- a/tests-lit/tests/mutations/logical/cxx_logical_or_to_and/02/mull.yml
+++ b/tests-lit/tests/mutations/logical/cxx_logical_or_to_and/02/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_logical_or_to_and
+junkDetectionDisabled: true

--- a/tests-lit/tests/mutations/logical/cxx_remove_negation/main.cpp
+++ b/tests-lit/tests/mutations/logical/cxx_remove_negation/main.cpp
@@ -14,10 +14,12 @@ int main() {
 // clang-format off
 
 /**
+RUN: %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g %s -o %s-ir.exe
 RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g -O0 %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: unset TERM; %mull_cxx -keep-executable -output=%s.mutated.exe -linker=%clang_cxx -linker-flags="%sysroot" -workers=1 -mutators=cxx_remove_negation --ide-reporter-show-killed -reporters=IDE %s.exe | %filecheck %s --dump-input=fail
 RUN: unset TERM; %mull_runner -workers=1 --ide-reporter-show-killed -reporters=IDE %s.mutated.exe | %filecheck %s --dump-input=fail
+RUN: unset TERM; %mull_runner -workers=1 --ide-reporter-show-killed -reporters=IDE %s-ir.exe | %filecheck %s --dump-input=fail
 CHECK:[info] Running mutants (threads: 1)
 CHECK:{{^       \[################################\] 2/2\. Finished .*}}
 CHECK:[info] Killed mutants (1/2):

--- a/tests-lit/tests/mutations/logical/cxx_remove_negation/mull.yml
+++ b/tests-lit/tests/mutations/logical/cxx_remove_negation/mull.yml
@@ -1,0 +1,2 @@
+mutators:
+  - cxx_remove_negation

--- a/tests-lit/tests/mutations/math/cxx_add_to_sub/01_no_mutations/sample.cpp
+++ b/tests-lit/tests/mutations/math/cxx_add_to_sub/01_no_mutations/sample.cpp
@@ -1,9 +1,11 @@
 // clang-format off
 
 /**
+RUN: %clang_cxx %sysroot %pass_mull_ir_frontend -g -O0 %s -o %s-ir.exe
 RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g -O0 %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_add_to_sub -compdb-path %S/compile_commands.json -compilation-flags="" -reporters=Elements -report-dir=%S -report-name=01_no_mutations %s.exe | %filecheck %s --dump-input=fail
+RUN: %mull_runner -reporters=Elements -report-dir=%S -report-name=01_no_mutations %s-ir.exe | %filecheck %s --dump-input=fail
 CHECK:[info] No mutants found. Mutation score: infinitely high
 **/
 

--- a/tests-lit/tests/mutations/math/cxx_add_to_sub/02_basic/sample.cpp
+++ b/tests-lit/tests/mutations/math/cxx_add_to_sub/02_basic/sample.cpp
@@ -1,9 +1,11 @@
 // clang-format off
 
 /**
+RUN: %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g %s -o %s-ir.exe
 RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g -O0 %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_add_to_sub -reporters=IDE %s.exe | %filecheck %s --dump-input=fail
+RUN: unset TERM; %mull_runner -reporters=IDE %s-ir.exe | %filecheck %s --dump-input=fail
 CHECK:[info] Running mutants (threads: 1)
 CHECK:{{^       \[################################\] 1/1\. Finished .*}}
 CHECK:[info] All mutations have been killed

--- a/tests-lit/tests/mutations/math/cxx_add_to_sub/03_no_ret/sample.cpp
+++ b/tests-lit/tests/mutations/math/cxx_add_to_sub/03_no_ret/sample.cpp
@@ -10,8 +10,10 @@ int main() {
 }
 
 /**
+RUN: %clang_cxx %sysroot %pass_mull_ir_frontend -g -O0 %s -o %s-ir.exe
 RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g -O0 %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_add_to_sub -reporters=IDE %s.exe | %filecheck %s --dump-input=fail
+RUN: unset TERM; %mull_runner -reporters=IDE %s-ir.exe | %filecheck %s --dump-input=fail
 CHECK-NOT:[error]
 **/

--- a/tests-lit/tests/mutations/math/cxx_add_to_sub/04_count_letters/count_letter.c
+++ b/tests-lit/tests/mutations/math/cxx_add_to_sub/04_count_letters/count_letter.c
@@ -26,9 +26,11 @@ int main() {
 
 // clang-format off
 
+// RUN: %clang_cc %sysroot -O0 %pass_mull_ir_frontend -g %s -o %s-ir.exe
 // RUN: cd / && %clang_cc %sysroot -fembed-bitcode -g -O0 %s -o %s.exe
 // RUN: cd %CURRENT_DIR
 // RUN: unset TERM; %mull_cxx -linker=%clang_cc -linker-flags="%sysroot" -mutators=cxx_add_to_sub -ide-reporter-show-killed -reporters=IDE %s.exe | %filecheck %s --dump-input=fail
+// RUN: unset TERM; %mull_runner -ide-reporter-show-killed -reporters=IDE %s-ir.exe | %filecheck %s --dump-input=fail
 // CHECK:[info] Killed mutants (1/1):
 // CHECK:{{.*}}count_letter.c:8:19: warning: Killed: Replaced + with - [cxx_add_to_sub]
 // CHECK:    count = count + 1;

--- a/tests-lit/tests/mutations/math/cxx_add_to_sub/mull.yml
+++ b/tests-lit/tests/mutations/math/cxx_add_to_sub/mull.yml
@@ -1,0 +1,2 @@
+mutators:
+  - cxx_add_to_sub

--- a/tests-lit/tests/mutations/math/cxx_div_to_mul/01/main.c
+++ b/tests-lit/tests/mutations/math/cxx_div_to_mul/01/main.c
@@ -15,9 +15,11 @@ int main() {
 
 // clang-format off
 
+// RUN: %clang_cc %sysroot -O0 %pass_mull_ir_frontend -g %s -o %s-ir.exe
 // RUN: cd / && %clang_cc %sysroot -fembed-bitcode -g -O0 %s -o %s.exe
 // RUN: cd %CURRENT_DIR
 // RUN: unset TERM; %mull_cxx -linker=%clang_cc -linker-flags="%sysroot" -mutators=cxx_div_to_mul -ide-reporter-show-killed -reporters=IDE %s.exe | %filecheck %s --dump-input=fail
+// RUN: unset TERM; %mull_runner -ide-reporter-show-killed -reporters=IDE %s-ir.exe | %filecheck %s --dump-input=fail
 // CHECK:[info] Killed mutants (1/1):
 // CHECK:{{.*}}main.c:2:12: warning: Killed: Replaced / with * [cxx_div_to_mul]
 // CHECK:  return a / b;

--- a/tests-lit/tests/mutations/math/cxx_div_to_mul/mull.yml
+++ b/tests-lit/tests/mutations/math/cxx_div_to_mul/mull.yml
@@ -1,0 +1,2 @@
+mutators:
+  - cxx_div_to_mul

--- a/tests-lit/tests/mutations/math/cxx_mul_to_div/01/main.c
+++ b/tests-lit/tests/mutations/math/cxx_mul_to_div/01/main.c
@@ -15,9 +15,11 @@ int main() {
 
 // clang-format off
 
+// RUN: %clang_cc %sysroot -O0 %pass_mull_ir_frontend -g %s -o %s-ir.exe
 // RUN: cd / && %clang_cc %sysroot -fembed-bitcode -g -O0 %s -o %s.exe
 // RUN: cd %CURRENT_DIR
 // RUN: unset TERM; %mull_cxx -linker=%clang_cc -linker-flags="%sysroot" -mutators=cxx_mul_to_div -ide-reporter-show-killed -reporters=IDE %s.exe | %filecheck %s --dump-input=fail
+// RUN: unset TERM; %mull_runner -ide-reporter-show-killed -reporters=IDE %s-ir.exe | %filecheck %s --dump-input=fail
 // CHECK:[info] Killed mutants (1/1):
 // CHECK:{{.*}}main.c:2:12: warning: Killed: Replaced * with / [cxx_mul_to_div]
 // CHECK:  return a * b;

--- a/tests-lit/tests/mutations/math/cxx_mul_to_div/mull.yml
+++ b/tests-lit/tests/mutations/math/cxx_mul_to_div/mull.yml
@@ -1,0 +1,2 @@
+mutators:
+  - cxx_mul_to_div

--- a/tests-lit/tests/mutations/math/cxx_sub_to_add/01/main.c
+++ b/tests-lit/tests/mutations/math/cxx_sub_to_add/01/main.c
@@ -15,9 +15,11 @@ int main() {
 
 // clang-format off
 
+// RUN: %clang_cc %sysroot -O0 %pass_mull_ir_frontend -g %s -o %s-ir.exe
 // RUN: cd / && %clang_cc %sysroot -fembed-bitcode -g -O0 %s -o %s.exe
 // RUN: cd %CURRENT_DIR
 // RUN: unset TERM; %mull_cxx -linker=%clang_cc -linker-flags="%sysroot" -mutators=cxx_sub_to_add -ide-reporter-show-killed -reporters=IDE %s.exe | %filecheck %s --dump-input=fail
+// RUN: unset TERM; %mull_runner -ide-reporter-show-killed -reporters=IDE %s-ir.exe | %filecheck %s --dump-input=fail
 // CHECK:[info] Killed mutants (1/1):
 // CHECK:{{.*}}main.c:2:12: warning: Killed: Replaced - with + [cxx_sub_to_add]
 // CHECK:  return a - b;

--- a/tests-lit/tests/mutations/math/cxx_sub_to_add/mull.yml
+++ b/tests-lit/tests/mutations/math/cxx_sub_to_add/mull.yml
@@ -1,0 +1,2 @@
+mutators:
+  - cxx_sub_to_add

--- a/tests-lit/tests/mutations/misc/remove_void_function_mutator/01/main.c
+++ b/tests-lit/tests/mutations/misc/remove_void_function_mutator/01/main.c
@@ -18,9 +18,11 @@ int main() {
 
 // clang-format off
 
+// RUN: %clang_cc %sysroot -O0 %pass_mull_ir_frontend -g %s -o %s-ir.exe
 // RUN: cd / && %clang_cc %sysroot -fembed-bitcode -g -O0 %s -o %s.exe
 // RUN: cd %CURRENT_DIR
 // RUN: unset TERM; %mull_cxx -linker=%clang_cc -linker-flags="%sysroot" -mutators=cxx_remove_void_call -ide-reporter-show-killed -reporters=IDE %s.exe | %filecheck %s --dump-input=fail
+// RUN: unset TERM; %mull_runner -ide-reporter-show-killed -reporters=IDE %s-ir.exe | %filecheck %s --dump-input=fail
 // CHECK:[info] Killed mutants (1/1):
 // CHECK:{{.*}}8:3: warning: Killed: Removed the call to the function [cxx_remove_void_call]
 // CHECK:  void_function();

--- a/tests-lit/tests/mutations/misc/remove_void_function_mutator/01/mull.yml
+++ b/tests-lit/tests/mutations/misc/remove_void_function_mutator/01/mull.yml
@@ -1,0 +1,2 @@
+mutators:
+  - cxx_remove_void_call

--- a/tests-lit/tests/patch-reporter/equality/main.cpp
+++ b/tests-lit/tests/patch-reporter/equality/main.cpp
@@ -16,11 +16,13 @@ RUN: cd %S/Output/sandbox
 
 /// We cd to the the test directory and compile using relative paths.
 RUN: cd %S; %clang_cxx %sysroot -fembed-bitcode -g -O0 Output/sandbox/main.cpp -o Output/main.cpp.exe
+RUN: cd %S; %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g Output/sandbox/main.cpp -o Output/main.cpp-ir.exe
 
-RUN: cd %S/Output && echo $PATH; (unset TERM; %mull_cxx -mutators=cxx_eq_to_ne -linker-flags="%sysroot" --linker=%clang_cxx -debug main.cpp.exe --report-name test --reporters Patches --reporters IDE; test $? = 0; ls -R %S/Output/test-patches; cat %S/Output/test-patches/killed-Output_sandbox_main_cpp-cxx_eq_to_ne-L2-C12.patch) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output; (unset TERM; %mull_cxx -mutators=cxx_eq_to_ne -linker-flags="%sysroot" --linker=%clang_cxx -debug ./main.cpp.exe --report-name test --reporters Patches --reporters IDE; test $? = 0; ls -R %S/Output/test-patches; cat %S/Output/test-patches/`ls %S/Output/test-patches/`) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RU: cd %S/Output; (unset TERM; %mull_runner ./main.cpp-ir.exe -debug --report-name test-ir --reporters Patches --reporters IDE; test $? = 0; ls -R %S/Output/test-ir-patches; cat %S/Output/test-ir-patches/`ls %S/Output/test-ir-patches/`) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[debug] Writing Patchfile: {{.*}}
-CHECK:[info] Patchfiles can be found at './test-patches'
+CHECK:[info] Patchfiles can be found at './test{{.*}}-patches'
 CHECK:{{.*}}main_cpp{{.*}}
 CHECK:--- a{{.*}}/Output/sandbox/main.cpp 0
 CHECK:+{{\s+}}return a != b;

--- a/tests-lit/tests/patch-reporter/equality/mull.yml
+++ b/tests-lit/tests/patch-reporter/equality/mull.yml
@@ -1,0 +1,2 @@
+mutators:
+  - cxx_eq_to_ne

--- a/tests-lit/tests/patch-reporter/git_dir_relative/main.cpp
+++ b/tests-lit/tests/patch-reporter/git_dir_relative/main.cpp
@@ -16,11 +16,13 @@ RUN: cd %S/Output/sandbox
 
 /// We cd to the the test directory and compile using relative paths.
 RUN: cd %S; %clang_cxx %sysroot -fembed-bitcode -g -O0 Output/sandbox/main.cpp -o Output/main.cpp.exe
+RUN: cd %S; %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g Output/sandbox/main.cpp -o Output/main.cpp-ir.exe
 
-RUN: cd %S/Output && echo $PATH; (unset TERM; %mull_cxx -mutators=cxx_eq_to_ne -linker-flags="%sysroot" --git-project-root %S --linker=%clang_cxx -debug main.cpp.exe --report-name test --reporters Patches --reporters IDE; test $? = 0; ls -R %S/Output/test-patches; cat %S/Output/test-patches/killed-Output_sandbox_main_cpp-cxx_eq_to_ne-L2-C12.patch) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output; (unset TERM; %mull_cxx -mutators=cxx_eq_to_ne -linker-flags="%sysroot" -report-patch-base %S --linker=%clang_cxx -debug main.cpp.exe --report-name test --reporters Patches --reporters IDE; test $? = 0; ls -R %S/Output/test-patches; cat %S/Output/test-patches/killed-Output_sandbox_main_cpp-cxx_eq_to_ne-L2-C12.patch) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output; (unset TERM; %mull_runner -report-patch-base %S -debug ./main.cpp-ir.exe --report-name test-ir --reporters Patches --reporters IDE; test $? = 0; ls -R %S/Output/test-ir-patches; cat %S/Output/test-ir-patches/`ls %S/Output/test-ir-patches`) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[debug] Writing Patchfile: {{.*}}
-CHECK:[info] Patchfiles can be found at './test-patches'
+CHECK:[info] Patchfiles can be found at './test{{.*}}-patches'
 CHECK:{{.*}}main_cpp{{.*}}
 CHECK:--- a/Output/sandbox/main.cpp 0
 CHECK:+{{\s+}}return a != b;

--- a/tests-lit/tests/patch-reporter/git_dir_relative/mull.yml
+++ b/tests-lit/tests/patch-reporter/git_dir_relative/mull.yml
@@ -1,0 +1,2 @@
+mutators:
+  - cxx_eq_to_ne

--- a/tests-lit/tests/patch-reporter/multiline_patch/main.cpp
+++ b/tests-lit/tests/patch-reporter/multiline_patch/main.cpp
@@ -25,11 +25,13 @@ RUN: cd %S/Output/sandbox
 
 /// We cd to the the test directory and compile using relative paths.
 RUN: cd %S; %clang_cxx %sysroot -fembed-bitcode -g -O0 Output/sandbox/main.cpp -o Output/main.cpp.exe
+RUN: cd %S; %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g Output/sandbox/main.cpp -o Output/main.cpp-ir.exe
 
-RUN: cd %S/Output && echo $PATH; (unset TERM; %mull_cxx -mutators=cxx_remove_void_call -linker-flags="%sysroot" --linker=%clang_cxx -debug main.cpp.exe --report-name test --reporters Patches --reporters IDE; test $? = 0; ls -R %S/Output/test-patches; cat %S/Output/test-patches/survived-Output_sandbox_main_cpp-cxx_remove_void_call-L7-C3.patch; cat %S/Output/test-patches/survived-Output_sandbox_main_cpp-cxx_remove_void_call-L9-C3.patch) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output; (unset TERM; %mull_cxx -mutators=cxx_remove_void_call -linker-flags="%sysroot" --linker=%clang_cxx -debug main.cpp.exe --report-name test --reporters Patches --reporters IDE; test $? = 0; ls -R %S/Output/test-patches; cd %S/Output/test-patches; cat `ls`) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output; (unset TERM; %mull_runner -debug ./main.cpp-ir.exe --report-name test-ir --reporters Patches --reporters IDE; test $? = 0; ls -R %S/Output/test-ir-patches; cd %S/Output/test-ir-patches; cat `ls`) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[debug] Writing Patchfile: {{.*}}
-CHECK:[info] Patchfiles can be found at './test-patches'
+CHECK:[info] Patchfiles can be found at './test{{.*}}-patches'
 CHECK:{{.*}}main_cpp-cxx_remove_void{{.*}}
 CHECK:--- a{{.*}}/Output/sandbox/main.cpp 0
 CHECK:-{{\s+}}false);

--- a/tests-lit/tests/patch-reporter/multiline_patch/mull.yml
+++ b/tests-lit/tests/patch-reporter/multiline_patch/mull.yml
@@ -1,0 +1,2 @@
+mutators:
+  - cxx_remove_void_call

--- a/tests-lit/tests/patch-reporter/remove_void_call/main.cpp
+++ b/tests-lit/tests/patch-reporter/remove_void_call/main.cpp
@@ -23,11 +23,13 @@ RUN: cd %S/Output/sandbox
 
 /// We cd to the the test directory and compile using relative paths.
 RUN: cd %S; %clang_cxx %sysroot -fembed-bitcode -g -O0 Output/sandbox/main.cpp -o Output/main.cpp.exe
+RUN: cd %S; %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g Output/sandbox/main.cpp -o Output/main.cpp-ir.exe
 
-RUN: cd %S/Output && echo $PATH; (unset TERM; %mull_cxx -mutators=cxx_calls -linker-flags="%sysroot" --linker=%clang_cxx -debug main.cpp.exe --report-name test --reporters Patches --reporters IDE; test $? = 0; ls -R %S/Output/test-patches; cat %S/Output/test-patches/killed-Output_sandbox_main_cpp-cxx_remove_void_call-L7-C3.patch; cat %S/Output/test-patches/killed-Output_sandbox_main_cpp-cxx_replace_scalar_call-L12-C3.patch) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output; (unset TERM; %mull_cxx -mutators=cxx_calls -linker-flags="%sysroot" --linker=%clang_cxx -debug main.cpp.exe --report-name test --reporters Patches --reporters IDE; test $? = 0; ls -R %S/Output/test-patches; cd %S/Output/test-patches; cat `ls`) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output; (unset TERM; %mull_runner -debug ./main.cpp-ir.exe --report-name test-ir --reporters Patches --reporters IDE; test $? = 0; ls -R %S/Output/test-ir-patches; cd %S/Output/test-ir-patches; cat `ls`) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[debug] Writing Patchfile: {{.*}}
-CHECK:[info] Patchfiles can be found at './test-patches'
+CHECK:[info] Patchfiles can be found at './test{{.*}}-patches'
 CHECK:{{.*}}main_cpp-cxx_remove_void{{.*}}
 CHECK:{{.*}}main_cpp-cxx_replace_scalar{{.*}}
 CHECK:--- a{{.*}}/Output/sandbox/main.cpp 0

--- a/tests-lit/tests/patch-reporter/remove_void_call/mull.yml
+++ b/tests-lit/tests/patch-reporter/remove_void_call/mull.yml
@@ -1,0 +1,2 @@
+mutators:
+  - cxx_calls

--- a/tests-lit/tests/patch-reporter/reporter_path_base/main.cpp
+++ b/tests-lit/tests/patch-reporter/reporter_path_base/main.cpp
@@ -16,11 +16,13 @@ RUN: cd %S/Output/sandbox
 
 /// We cd to the the test directory and compile using relative paths.
 RUN: cd %S; %clang_cxx %sysroot -fembed-bitcode -g -O0 Output/sandbox/main.cpp -o Output/main.cpp.exe
+RUN: cd %S; %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g Output/sandbox/main.cpp -o Output/main.cpp-ir.exe
 
-RUN: cd %S/Output && echo $PATH; (unset TERM; %mull_cxx -mutators=cxx_eq_to_ne -linker-flags="%sysroot" --git-project-root %S/Output --report-patch-base %S --linker=%clang_cxx -debug main.cpp.exe --report-name test --reporters Patches --reporters IDE; test $? = 0; ls -R %S/Output/test-patches; cat %S/Output/test-patches/killed-Output_sandbox_main_cpp-cxx_eq_to_ne-L2-C12.patch) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output; (unset TERM; %mull_cxx -mutators=cxx_eq_to_ne -linker-flags="%sysroot" --git-project-root %S/Output --report-patch-base %S --linker=%clang_cxx -debug main.cpp.exe --report-name test --reporters Patches --reporters IDE; test $? = 0; ls -R %S/Output/test-patches; cd %S/Output/test-patches; cat `ls`) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output; (unset TERM; %mull_runner --report-patch-base %S -debug ./main.cpp-ir.exe --report-name test-ir --reporters Patches --reporters IDE; test $? = 0; ls -R %S/Output/test-ir-patches; cd %S/Output/test-ir-patches; cat `ls`) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[debug] Writing Patchfile: {{.*}}
-CHECK:[info] Patchfiles can be found at './test-patches'
+CHECK:[info] Patchfiles can be found at './test{{.*}}-patches'
 CHECK:{{.*}}main_cpp{{.*}}
 CHECK:--- a/Output/sandbox/main.cpp 0
 CHECK:+{{\s+}}return a != b;

--- a/tests-lit/tests/patch-reporter/reporter_path_base/mull.yml
+++ b/tests-lit/tests/patch-reporter/reporter_path_base/mull.yml
@@ -1,0 +1,2 @@
+mutators:
+  - cxx_eq_to_ne

--- a/tests-lit/tests/patch-reporter/shift/main.cpp
+++ b/tests-lit/tests/patch-reporter/shift/main.cpp
@@ -16,11 +16,13 @@ RUN: cd %S/Output/sandbox
 
 /// We cd to the the test directory and compile using relative paths.
 RUN: cd %S; %clang_cxx %sysroot -fembed-bitcode -g -O0 Output/sandbox/main.cpp -o Output/main.cpp.exe
+RUN: cd %S; %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g Output/sandbox/main.cpp -o Output/main.cpp-ir.exe
 
-RUN: cd %S/Output && echo $PATH; (unset TERM; %mull_cxx -mutators=cxx_bitwise -linker-flags="%sysroot" --linker=%clang_cxx -debug main.cpp.exe --report-name test --reporters Patches --reporters IDE; test $? = 0; ls -R %S/Output/test-patches; cat %S/Output/test-patches/killed-Output_sandbox_main_cpp-cxx_lshift_to_rshift-L2-C12.patch) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output; (unset TERM; %mull_cxx -mutators=cxx_bitwise -linker-flags="%sysroot" --linker=%clang_cxx -debug main.cpp.exe --report-name test --reporters Patches --reporters IDE; test $? = 0; ls -R %S/Output/test-patches; cd %S/Output/test-patches; cat `ls`) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output; (unset TERM; %mull_runner -debug ./main.cpp-ir.exe --report-name test-ir --reporters Patches --reporters IDE; test $? = 0; ls -R %S/Output/test-ir-patches; cd %S/Output/test-ir-patches; cat `ls`) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[debug] Writing Patchfile: {{.*}}
-CHECK:[info] Patchfiles can be found at './test-patches'
+CHECK:[info] Patchfiles can be found at './test{{.*}}-patches'
 CHECK:killed-{{.*}}main_cpp{{.*}}
 CHECK:--- a/{{.*}}/Output/sandbox/main.cpp 0
 CHECK:+++ b/{{.*}}/Output/sandbox/main.cpp 0

--- a/tests-lit/tests/patch-reporter/shift/mull.yml
+++ b/tests-lit/tests/patch-reporter/shift/mull.yml
@@ -1,0 +1,2 @@
+mutators:
+  - cxx_bitwise

--- a/tests-lit/tests/runner/external-test-program/main.c
+++ b/tests-lit/tests/runner/external-test-program/main.c
@@ -40,6 +40,7 @@ int main(int argc, char **argv) {
 // clang-format off
 
 // RUN: %clang_cc %sysroot %s -fembed-bitcode -g -o %s.exe
+// RUN: %clang_cc %sysroot %s %pass_mull_ir_frontend -g -o %s-ir.exe
 
 // RUN: %mull_cxx -linker=%clang_cc -linker-flags="%sysroot" -keep-executable -mutate-only -output=%s.mutated.exe -mutators=cxx_add_to_sub -mutators=cxx_mul_to_div %s.exe | %filecheck %s --dump-input=fail --match-full-lines --check-prefix=CHECK-MUTATE
 // CHECK-MUTATE: [info] Mutate-only mode on:{{.*}}
@@ -47,6 +48,7 @@ int main(int argc, char **argv) {
 // CHECK-MUTATE-NOT: Running mutants
 
 // RUN: %mull_runner %s.mutated.exe -ide-reporter-show-killed -test-program %python3 -- %S/test.py %s.mutated.exe "first test case" | %filecheck %s --dump-input=fail --match-full-lines --check-prefix=CHECK-TEST1
+// RUN: %mull_runner %s-ir.exe -ide-reporter-show-killed -test-program %python3 -- %S/test.py %s.mutated.exe "first test case" | %filecheck %s --dump-input=fail --match-full-lines --check-prefix=CHECK-TEST1
 // CHECK-TEST1: [info] Killed mutants (1/2):
 // CHECK-TEST1: {{.*}}/main.c:5:12: warning: Killed: Replaced + with - [cxx_add_to_sub]
 // CHECK-TEST1:   return a + b;
@@ -57,6 +59,7 @@ int main(int argc, char **argv) {
 // CHECK-TEST1:            ^
 
 // RUN: %mull_runner %s.mutated.exe -ide-reporter-show-killed -test-program %python3 -- %S/test.py %s.mutated.exe "second test case" | %filecheck %s --dump-input=fail --match-full-lines --check-prefix=CHECK-TEST2
+// RUN: %mull_runner %s-ir.exe -ide-reporter-show-killed -test-program %python3 -- %S/test.py %s.mutated.exe "second test case" | %filecheck %s --dump-input=fail --match-full-lines --check-prefix=CHECK-TEST2
 // CHECK-TEST2: [info] Killed mutants (1/2):
 // CHECK-TEST2: {{.*}}/main.c:9:12: warning: Killed: Replaced * with / [cxx_mul_to_div]
 // CHECK-TEST2:   return a * b;

--- a/tests-lit/tests/runner/external-test-program/mull.yml
+++ b/tests-lit/tests/runner/external-test-program/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_add_to_sub
+  - cxx_mul_to_div

--- a/tests-lit/tests/runner/mutants-from-dylib/mull.yml
+++ b/tests-lit/tests/runner/mutants-from-dylib/mull.yml
@@ -1,0 +1,4 @@
+mutators:
+  - cxx_add_to_sub
+compilerFlags:
+  - "-DSHARED_LIB"

--- a/tests-lit/tests/runner/mutants-from-dylib/test.c
+++ b/tests-lit/tests/runner/mutants-from-dylib/test.c
@@ -20,10 +20,14 @@ int main() {
 
 /*
 
+RUN: %clang_cc %sysroot -DSHARED_LIB -fPIC -shared %s %pass_mull_ir_frontend -g -o %S/shared-ir.lib
+RUN: cd %S; %clang_cc %sysroot -DTEST_BIN ./test.c %S/shared-ir.lib -o ./test-ir.exe
+
 RUN: %clang_cc %sysroot -DSHARED_LIB -fPIC -shared %s -fembed-bitcode -g -o %S/shared.lib
 RUN: unset TERM; %mull_cxx -mutate-only --compilation-flags=-DSHARED_LIB -linker=%clang_cc -linker-flags="%sysroot -shared -fPIC" --output=%S/mutated.lib %S/shared.lib
 RUN: cd %S; %clang_cc %sysroot -DTEST_BIN ./test.c ./mutated.lib -o ./test.exe
 RUN: cd /; unset TERM; %mull_runner -ld-search-path=%S -ide-reporter-show-killed %S/test.exe | %filecheck %s --dump-input=fail --match-full-lines --check-prefix=CHECK
+RUN: cd /; unset TERM; %mull_runner -ld-search-path=%S -ide-reporter-show-killed %S/test-ir.exe | %filecheck %s --dump-input=fail --match-full-lines --check-prefix=CHECK
 CHECK:{{.*}}test.c:5:12: warning: Killed: Replaced + with - [cxx_add_to_sub]
 CHECK:  return a + b;
 CHECK:           ^

--- a/tests-lit/tests/tutorials/hello-world/step-1-version/sample.cpp
+++ b/tests-lit/tests/tutorials/hello-world/step-1-version/sample.cpp
@@ -1,5 +1,7 @@
+// clang-format off
 /**
 RUN: %mull_cxx -version 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: %mull_runner -version 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK:Mull: LLVM-based mutation testing
 CHECK:https://github.com/mull-project/mull
 CHECK:{{^Version: \d+\.\d+.\d+(-pr[0-9]+|-trunk[0-9]+)?$}}

--- a/tests-lit/tests/tutorials/hello-world/step-2-2-no-mutations-found/sample.cpp
+++ b/tests-lit/tests/tutorials/hello-world/step-2-2-no-mutations-found/sample.cpp
@@ -2,8 +2,10 @@
 
 /**
 RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g -O0 %s -o %s.exe
+RUN: cd / && %clang_cxx %sysroot %pass_mull_ir_frontend -g -O0 %s -o %s-ir.exe
 RUN: cd %CURRENT_DIR
 RUN: (unset TERM; %mull_cxx -linker=%clang_cc -linker-flags="%sysroot" %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK-NOT:{{.*No bitcode: x86_64.*}}
 CHECK:[info] No mutants found. Mutation score: infinitely high
 **/

--- a/tests-lit/tests/tutorials/hello-world/step-3-one-survived-mutation/mull.yml
+++ b/tests-lit/tests/tutorials/hello-world/step-3-one-survived-mutation/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_ge_to_lt
+  - cxx_ge_to_gt

--- a/tests-lit/tests/tutorials/hello-world/step-3-one-survived-mutation/sample.cpp
+++ b/tests-lit/tests/tutorials/hello-world/step-3-one-survived-mutation/sample.cpp
@@ -1,13 +1,15 @@
 // clang-format off
 
 /**
+RUN: cd %S && %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g %s -o %s-ir.exe
 RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g -O0 %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK:[info] Killed mutants (1/2):
-CHECK:{{^.*}}sample.cpp:15:11: warning: Killed: Replaced >= with < [cxx_ge_to_lt]{{$}}
+CHECK:{{^.*}}sample.cpp:17:11: warning: Killed: Replaced >= with < [cxx_ge_to_lt]{{$}}
 CHECK:[info] Survived mutants (1/2):
-CHECK:{{^.*}}sample.cpp:15:11: warning: Survived: Replaced >= with > [cxx_ge_to_gt]{{$}}
+CHECK:{{^.*}}sample.cpp:17:11: warning: Survived: Replaced >= with > [cxx_ge_to_gt]{{$}}
 CHECK:[info] Mutation score: 50%
 **/
 

--- a/tests-lit/tests/tutorials/hello-world/step-4-no-survived-mutations/mull.yml
+++ b/tests-lit/tests/tutorials/hello-world/step-4-no-survived-mutations/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_ge_to_lt
+  - cxx_ge_to_gt

--- a/tests-lit/tests/tutorials/hello-world/step-4-no-survived-mutations/sample.cpp
+++ b/tests-lit/tests/tutorials/hello-world/step-4-no-survived-mutations/sample.cpp
@@ -1,12 +1,14 @@
 // clang-format off
 
 /**
+RUN: cd %S && %clang_cc %sysroot -O0 %pass_mull_ir_frontend -g %s -o %s-ir.exe
 RUN: cd / && %clang_cc %sysroot -fembed-bitcode -g -O0 %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -mutators=cxx_ge_to_lt -mutators=cxx_ge_to_gt -ide-reporter-show-killed %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK:[info] Killed mutants (2/2):
-CHECK:{{^.*}}sample.cpp:15:11: warning: Killed: Replaced >= with > [cxx_ge_to_gt]{{$}}
-CHECK:{{^.*}}sample.cpp:15:11: warning: Killed: Replaced >= with < [cxx_ge_to_lt]{{$}}
+CHECK:{{^.*}}sample.cpp:17:11: warning: Killed: Replaced >= with > [cxx_ge_to_gt]{{$}}
+CHECK:{{^.*}}sample.cpp:17:11: warning: Killed: Replaced >= with < [cxx_ge_to_lt]{{$}}
 CHECK:[info] All mutations have been killed
 CHECK:[info] Mutation score: 100%
 **/

--- a/tests-lit/tests/white-ast-search/_special_cases/01_mutation_in_header_file/mull.yml
+++ b/tests-lit/tests/white-ast-search/_special_cases/01_mutation_in_header_file/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_add_to_sub
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/_special_cases/01_mutation_in_header_file/sample.cpp
+++ b/tests-lit/tests/white-ast-search/_special_cases/01_mutation_in_header_file/sample.cpp
@@ -7,15 +7,18 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+RUN: (unset TERM; %mull_cxx -mutate-only -output=%s-mutated.exe -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Add to Sub": {{.*}}sum.h:4:12 (end: 4:13)
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Add to Sub": {{.*}}sum.h:4:12 (end: 4:13)
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sum.h:4:12: warning: Killed: Replaced + with - [cxx_add_to_sub]{{$}}

--- a/tests-lit/tests/white-ast-search/arithmetic/01_add_to_sub/mull.yml
+++ b/tests-lit/tests/white-ast-search/arithmetic/01_add_to_sub/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_add_to_sub
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/arithmetic/01_add_to_sub/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic/01_add_to_sub/sample.cpp
@@ -9,15 +9,18 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+RUN: (unset TERM; %mull_cxx -mutate-only -output %s-mutated.exe -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_add_to_sub -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Add to Sub": {{.*}}sample.cpp:2:12 (end: 2:13)
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Add to Sub": {{.*}}sample.cpp:2:12 (end: 2:13)
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced + with - [cxx_add_to_sub]{{$}}

--- a/tests-lit/tests/white-ast-search/arithmetic/02_sub_to_add/mull.yml
+++ b/tests-lit/tests/white-ast-search/arithmetic/02_sub_to_add/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_sub_to_add
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/arithmetic/02_sub_to_add/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic/02_sub_to_add/sample.cpp
@@ -9,15 +9,18 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_sub_to_add -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+RUN: (unset TERM; %mull_cxx -mutate-only -output=%s-mutated.exe -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_sub_to_add -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Sub to Add": {{.*}}sample.cpp:2:12 (end: 2:13)
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Sub to Add": {{.*}}sample.cpp:2:12 (end: 2:13)
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced - with + [cxx_sub_to_add]{{$}}

--- a/tests-lit/tests/white-ast-search/arithmetic/03_mul_to_div/mull.yml
+++ b/tests-lit/tests/white-ast-search/arithmetic/03_mul_to_div/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_mul_to_div
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/arithmetic/03_mul_to_div/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic/03_mul_to_div/sample.cpp
@@ -9,15 +9,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_mul_to_div -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Mul to Div": {{.*}}sample.cpp:2:12 (end: 2:13)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_mul_to_div -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Mul to Div": {{.*}}sample.cpp:2:12 (end: 2:13)
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced * with / [cxx_mul_to_div]{{$}}

--- a/tests-lit/tests/white-ast-search/arithmetic/04_div_to_mul/mull.yml
+++ b/tests-lit/tests/white-ast-search/arithmetic/04_div_to_mul/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_div_to_mul
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/arithmetic/04_div_to_mul/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic/04_div_to_mul/sample.cpp
@@ -9,15 +9,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_div_to_mul -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Div to Mul": {{.*}}sample.cpp:2:12 (end: 2:13)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_div_to_mul -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Div to Mul": {{.*}}sample.cpp:2:12 (end: 2:13)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced / with * [cxx_div_to_mul]{{$}}

--- a/tests-lit/tests/white-ast-search/arithmetic/05_rem_to_div/mull.yml
+++ b/tests-lit/tests/white-ast-search/arithmetic/05_rem_to_div/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_rem_to_div
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/arithmetic/05_rem_to_div/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic/05_rem_to_div/sample.cpp
@@ -9,15 +9,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_rem_to_div -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Rem to Div": {{.*}}sample.cpp:2:12 (end: 2:13)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_rem_to_div -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Rem to Div": {{.*}}sample.cpp:2:12 (end: 2:13)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced % with / [cxx_rem_to_div]{{$}}

--- a/tests-lit/tests/white-ast-search/arithmetic/06_unary_minus_to_noop/mull.yml
+++ b/tests-lit/tests/white-ast-search/arithmetic/06_unary_minus_to_noop/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_minus_to_noop
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/arithmetic/06_unary_minus_to_noop/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic/06_unary_minus_to_noop/sample.cpp
@@ -9,15 +9,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_minus_to_noop -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Unary Minus to Noop": {{.*}}sample.cpp:2:10 (end: 2:12)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_minus_to_noop -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Unary Minus to Noop": {{.*}}sample.cpp:2:10 (end: 2:12)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:10: warning: Killed: Replaced -x with x [cxx_minus_to_noop]{{$}}

--- a/tests-lit/tests/white-ast-search/arithmetic_assignment/01_add_assign_to_sub_assign/mull.yml
+++ b/tests-lit/tests/white-ast-search/arithmetic_assignment/01_add_assign_to_sub_assign/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_add_assign_to_sub_assign
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/arithmetic_assignment/01_add_assign_to_sub_assign/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic_assignment/01_add_assign_to_sub_assign/sample.cpp
@@ -10,15 +10,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_add_assign_to_sub_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Add-Assign to Sub-Assign": {{.*}}sample.cpp:2:5 (end: 2:7)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_add_assign_to_sub_assign -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Add-Assign to Sub-Assign": {{.*}}sample.cpp:2:5 (end: 2:7)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:5: warning: Killed: Replaced += with -= [cxx_add_assign_to_sub_assign]{{$}}

--- a/tests-lit/tests/white-ast-search/arithmetic_assignment/02_sub_assign_to_add_assign/mull.yml
+++ b/tests-lit/tests/white-ast-search/arithmetic_assignment/02_sub_assign_to_add_assign/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_sub_assign_to_add_assign
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/arithmetic_assignment/02_sub_assign_to_add_assign/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic_assignment/02_sub_assign_to_add_assign/sample.cpp
@@ -10,15 +10,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_sub_assign_to_add_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Sub-Assign to Add-Assign": {{.*}}sample.cpp:2:5 (end: 2:7)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_sub_assign_to_add_assign -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Sub-Assign to Add-Assign": {{.*}}sample.cpp:2:5 (end: 2:7)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:5: warning: Killed: Replaced -= with += [cxx_sub_assign_to_add_assign]{{$}}

--- a/tests-lit/tests/white-ast-search/arithmetic_assignment/03_mul_assign_to_div_assign/mull.yml
+++ b/tests-lit/tests/white-ast-search/arithmetic_assignment/03_mul_assign_to_div_assign/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_mul_assign_to_div_assign
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/arithmetic_assignment/03_mul_assign_to_div_assign/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic_assignment/03_mul_assign_to_div_assign/sample.cpp
@@ -10,15 +10,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_mul_assign_to_div_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Mul-Assign to Div-Assign": {{.*}}sample.cpp:2:5 (end: 2:7)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_mul_assign_to_div_assign -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Mul-Assign to Div-Assign": {{.*}}sample.cpp:2:5 (end: 2:7)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:5: warning: Killed: Replaced *= with /= [cxx_mul_assign_to_div_assign]{{$}}

--- a/tests-lit/tests/white-ast-search/arithmetic_assignment/04_div_assign_to_mul_assign/mull.yml
+++ b/tests-lit/tests/white-ast-search/arithmetic_assignment/04_div_assign_to_mul_assign/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_div_assign_to_mul_assign
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/arithmetic_assignment/04_div_assign_to_mul_assign/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic_assignment/04_div_assign_to_mul_assign/sample.cpp
@@ -10,15 +10,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_div_assign_to_mul_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Div-Assign to Mul-Assign": {{.*}}sample.cpp:2:5 (end: 2:7)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_div_assign_to_mul_assign -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Div-Assign to Mul-Assign": {{.*}}sample.cpp:2:5 (end: 2:7)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:5: warning: Killed: Replaced /= with *= [cxx_div_assign_to_mul_assign]{{$}}

--- a/tests-lit/tests/white-ast-search/arithmetic_assignment/05_rem_assign_to_div_assign/mull.yml
+++ b/tests-lit/tests/white-ast-search/arithmetic_assignment/05_rem_assign_to_div_assign/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_rem_assign_to_div_assign
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/arithmetic_assignment/05_rem_assign_to_div_assign/sample.cpp
+++ b/tests-lit/tests/white-ast-search/arithmetic_assignment/05_rem_assign_to_div_assign/sample.cpp
@@ -10,15 +10,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_rem_assign_to_div_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Rem-Assign to Div-Assign": {{.*}}sample.cpp:2:5 (end: 2:7)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_rem_assign_to_div_assign -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Rem-Assign to Div-Assign": {{.*}}sample.cpp:2:5 (end: 2:7)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:5: warning: Killed: Replaced %= with /= [cxx_rem_assign_to_div_assign]{{$}}

--- a/tests-lit/tests/white-ast-search/bitwise/01_and_to_or/mull.yml
+++ b/tests-lit/tests/white-ast-search/bitwise/01_and_to_or/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_and_to_or
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/bitwise/01_and_to_or/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise/01_and_to_or/sample.cpp
@@ -9,15 +9,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_and_to_or -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Bitwise And to Or": {{.*}}sample.cpp:2:12 (end: 2:13)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_and_to_or -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Bitwise And to Or": {{.*}}sample.cpp:2:12 (end: 2:13)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced & with | [cxx_and_to_or]{{$}}

--- a/tests-lit/tests/white-ast-search/bitwise/02_or_to_and/mull.yml
+++ b/tests-lit/tests/white-ast-search/bitwise/02_or_to_and/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_or_to_and
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/bitwise/02_or_to_and/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise/02_or_to_and/sample.cpp
@@ -9,15 +9,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_or_to_and -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Bitwise Or to And": {{.*}}sample.cpp:2:12 (end: 2:13)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_or_to_and -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Bitwise Or to And": {{.*}}sample.cpp:2:12 (end: 2:13)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced | with & [cxx_or_to_and]{{$}}

--- a/tests-lit/tests/white-ast-search/bitwise/03_xor_to_or/mull.yml
+++ b/tests-lit/tests/white-ast-search/bitwise/03_xor_to_or/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_xor_to_or
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/bitwise/03_xor_to_or/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise/03_xor_to_or/sample.cpp
@@ -9,15 +9,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -workers=1 -debug -mutators=cxx_xor_to_or -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Bitwise Xor to Or": {{.*}}sample.cpp:2:12 (end: 2:13)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -workers=1 -debug -mutators=cxx_xor_to_or -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Bitwise Xor to Or": {{.*}}sample.cpp:2:12 (end: 2:13)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced ^ with | [cxx_xor_to_or]{{$}}

--- a/tests-lit/tests/white-ast-search/bitwise/04_left_shift_to_right_shift/mull.yml
+++ b/tests-lit/tests/white-ast-search/bitwise/04_left_shift_to_right_shift/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_lshift_to_rshift
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/bitwise/04_left_shift_to_right_shift/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise/04_left_shift_to_right_shift/sample.cpp
@@ -9,15 +9,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_lshift_to_rshift -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Left Shift to Right Shift": {{.*}}sample.cpp:2:12 (end: 2:14)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_lshift_to_rshift -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Left Shift to Right Shift": {{.*}}sample.cpp:2:12 (end: 2:14)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced << with >> [cxx_lshift_to_rshift]{{$}}

--- a/tests-lit/tests/white-ast-search/bitwise/05_right_shift_to_left_shift/mull.yml
+++ b/tests-lit/tests/white-ast-search/bitwise/05_right_shift_to_left_shift/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_rshift_to_lshift
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/bitwise/05_right_shift_to_left_shift/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise/05_right_shift_to_left_shift/sample.cpp
@@ -9,15 +9,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_rshift_to_lshift -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Right Shift to Left Shift": {{.*}}sample.cpp:2:12 (end: 2:14)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_rshift_to_lshift -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Right Shift to Left Shift": {{.*}}sample.cpp:2:12 (end: 2:14)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced >> with << [cxx_rshift_to_lshift]{{$}}

--- a/tests-lit/tests/white-ast-search/bitwise_assignment/01_and_assign_to_or_assign/mull.yml
+++ b/tests-lit/tests/white-ast-search/bitwise_assignment/01_and_assign_to_or_assign/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_and_assign_to_or_assign
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/bitwise_assignment/01_and_assign_to_or_assign/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise_assignment/01_and_assign_to_or_assign/sample.cpp
@@ -11,15 +11,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_and_assign_to_or_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Bitwise And-Assign to Or-Assign": {{.*}}sample.cpp:3:5 (end: 3:7)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_and_assign_to_or_assign -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Bitwise And-Assign to Or-Assign": {{.*}}sample.cpp:3:5 (end: 3:7)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:3:5: warning: Killed: Replaced &= with |= [cxx_and_assign_to_or_assign]{{$}}

--- a/tests-lit/tests/white-ast-search/bitwise_assignment/02_or_to_and/mull.yml
+++ b/tests-lit/tests/white-ast-search/bitwise_assignment/02_or_to_and/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_or_assign_to_and_assign
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/bitwise_assignment/02_or_to_and/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise_assignment/02_or_to_and/sample.cpp
@@ -11,15 +11,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_or_assign_to_and_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Bitwise Or-Assign to And-Assign": {{.*}}sample.cpp:3:5 (end: 3:7)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_or_assign_to_and_assign -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Bitwise Or-Assign to And-Assign": {{.*}}sample.cpp:3:5 (end: 3:7)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:3:5: warning: Killed: Replaced |= with &= [cxx_or_assign_to_and_assign]{{$}}

--- a/tests-lit/tests/white-ast-search/bitwise_assignment/03_xor_to_or/mull.yml
+++ b/tests-lit/tests/white-ast-search/bitwise_assignment/03_xor_to_or/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_xor_assign_to_or_assign
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/bitwise_assignment/03_xor_to_or/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise_assignment/03_xor_to_or/sample.cpp
@@ -11,15 +11,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -workers=1 -debug -mutators=cxx_xor_assign_to_or_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Bitwise Xor-Assign to Or-Assign": {{.*}}sample.cpp:3:5 (end: 3:7)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -workers=1 -debug -mutators=cxx_xor_assign_to_or_assign -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Bitwise Xor-Assign to Or-Assign": {{.*}}sample.cpp:3:5 (end: 3:7)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:3:5: warning: Killed: Replaced ^= with |= [cxx_xor_assign_to_or_assign]{{$}}

--- a/tests-lit/tests/white-ast-search/bitwise_assignment/04_left_shift_to_right_shift/mull.yml
+++ b/tests-lit/tests/white-ast-search/bitwise_assignment/04_left_shift_to_right_shift/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_lshift_assign_to_rshift_assign
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/bitwise_assignment/04_left_shift_to_right_shift/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise_assignment/04_left_shift_to_right_shift/sample.cpp
@@ -11,15 +11,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_lshift_assign_to_rshift_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Left Shift-Assign to Right Shift-Assign": {{.*}}sample.cpp:3:5 (end: 3:8)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_lshift_assign_to_rshift_assign -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Left Shift-Assign to Right Shift-Assign": {{.*}}sample.cpp:3:5 (end: 3:8)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:3:5: warning: Killed: Replaced <<= with >>= [cxx_lshift_assign_to_rshift_assign]{{$}}

--- a/tests-lit/tests/white-ast-search/bitwise_assignment/05_right_shift_to_left_shift/mull.yml
+++ b/tests-lit/tests/white-ast-search/bitwise_assignment/05_right_shift_to_left_shift/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_rshift_assign_to_lshift_assign
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/bitwise_assignment/05_right_shift_to_left_shift/sample.cpp
+++ b/tests-lit/tests/white-ast-search/bitwise_assignment/05_right_shift_to_left_shift/sample.cpp
@@ -11,15 +11,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_rshift_assign_to_lshift_assign -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Right Shift-Assign to Left Shift-Assign": {{.*}}sample.cpp:3:5 (end: 3:8)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_rshift_assign_to_lshift_assign -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Right Shift-Assign to Left Shift-Assign": {{.*}}sample.cpp:3:5 (end: 3:8)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:3:5: warning: Killed: Replaced >>= with <<= [cxx_rshift_assign_to_lshift_assign]{{$}}

--- a/tests-lit/tests/white-ast-search/boundary/01_greater_than_to_greater_than_or_equal/mull.yml
+++ b/tests-lit/tests/white-ast-search/boundary/01_greater_than_to_greater_than_or_equal/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_gt_to_ge
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/boundary/01_greater_than_to_greater_than_or_equal/sample.cpp
+++ b/tests-lit/tests/white-ast-search/boundary/01_greater_than_to_greater_than_or_equal/sample.cpp
@@ -9,15 +9,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_gt_to_ge -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Greater Than to Greater or Equal": {{.*}}sample.cpp:2:12 (end: 2:13)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_gt_to_ge -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Greater Than to Greater or Equal": {{.*}}sample.cpp:2:12 (end: 2:13)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced > with >= [cxx_gt_to_ge]{{$}}

--- a/tests-lit/tests/white-ast-search/boundary/02_less_than_to_less_than_or_equal/mull.yml
+++ b/tests-lit/tests/white-ast-search/boundary/02_less_than_to_less_than_or_equal/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_lt_to_le
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/boundary/02_less_than_to_less_than_or_equal/sample.cpp
+++ b/tests-lit/tests/white-ast-search/boundary/02_less_than_to_less_than_or_equal/sample.cpp
@@ -9,15 +9,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_lt_to_le -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Less Than to Less Or Equal": {{.*}}sample.cpp:2:12 (end: 2:13)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_lt_to_le -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Less Than to Less Or Equal": {{.*}}sample.cpp:2:12 (end: 2:13)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced < with <= [cxx_lt_to_le]{{$}}

--- a/tests-lit/tests/white-ast-search/boundary/03_greater_or_equal_to_greater_than/mull.yml
+++ b/tests-lit/tests/white-ast-search/boundary/03_greater_or_equal_to_greater_than/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_ge_to_gt
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/boundary/03_greater_or_equal_to_greater_than/sample.cpp
+++ b/tests-lit/tests/white-ast-search/boundary/03_greater_or_equal_to_greater_than/sample.cpp
@@ -9,15 +9,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_ge_to_gt -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Greater Or Equal to Greater Than": {{.*}}sample.cpp:2:12 (end: 2:14)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_ge_to_gt -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Greater Or Equal to Greater Than": {{.*}}sample.cpp:2:12 (end: 2:14)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced >= with > [cxx_ge_to_gt]{{$}}

--- a/tests-lit/tests/white-ast-search/boundary/04_less_or_equal_to_less_than/mull.yml
+++ b/tests-lit/tests/white-ast-search/boundary/04_less_or_equal_to_less_than/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_le_to_lt
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/boundary/04_less_or_equal_to_less_than/sample.cpp
+++ b/tests-lit/tests/white-ast-search/boundary/04_less_or_equal_to_less_than/sample.cpp
@@ -9,15 +9,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_le_to_lt -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Less Or Equal to Less Than": {{.*}}sample.cpp:2:12 (end: 2:14)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_le_to_lt -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Less Or Equal to Less Than": {{.*}}sample.cpp:2:12 (end: 2:14)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced <= with < [cxx_le_to_lt]{{$}}

--- a/tests-lit/tests/white-ast-search/boundary/05_greater_than_to_2_mutations/mull.yml
+++ b/tests-lit/tests/white-ast-search/boundary/05_greater_than_to_2_mutations/mull.yml
@@ -1,0 +1,4 @@
+mutators:
+  - cxx_gt_to_ge
+  - cxx_gt_to_le
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/boundary/05_greater_than_to_2_mutations/sample.cpp
+++ b/tests-lit/tests/white-ast-search/boundary/05_greater_than_to_2_mutations/sample.cpp
@@ -9,16 +9,21 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -workers=1 -debug -mutators=cxx_gt_to_ge -mutators=cxx_gt_to_le -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Greater Than to Greater or Equal": {{.*}}sample.cpp:2:12 (end: 2:13)
-CHECK:[debug] CXXJunkDetector: mutation "Greater Than to Less Or Equal": {{.*}}sample.cpp:2:12 (end: 2:13)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -workers=1 -debug -mutators=cxx_gt_to_ge -mutators=cxx_gt_to_le -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Greater Than to Greater or Equal": {{.*}}sample.cpp:2:12 (end: 2:13)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Greater Than to Less Or Equal": {{.*}}sample.cpp:2:12 (end: 2:13)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (2/2):
 CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced > with >= [cxx_gt_to_ge]{{$}}

--- a/tests-lit/tests/white-ast-search/comparison/01_equal_to_not_equal/mull.yml
+++ b/tests-lit/tests/white-ast-search/comparison/01_equal_to_not_equal/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_eq_to_ne
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/comparison/01_equal_to_not_equal/sample.cpp
+++ b/tests-lit/tests/white-ast-search/comparison/01_equal_to_not_equal/sample.cpp
@@ -9,15 +9,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_eq_to_ne -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Equal to Not Equal": {{.*}}sample.cpp:2:12 (end: 2:14)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_eq_to_ne -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Equal to Not Equal": {{.*}}sample.cpp:2:12 (end: 2:14)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced == with != [cxx_eq_to_ne]{{$}}

--- a/tests-lit/tests/white-ast-search/comparison/02_not_equal_to_equal/mull.yml
+++ b/tests-lit/tests/white-ast-search/comparison/02_not_equal_to_equal/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_ne_to_eq
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/comparison/02_not_equal_to_equal/sample.cpp
+++ b/tests-lit/tests/white-ast-search/comparison/02_not_equal_to_equal/sample.cpp
@@ -9,15 +9,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -workers=1 -debug -mutators=cxx_ne_to_eq -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Not Equal to Equal": {{.*}}sample.cpp:2:12 (end: 2:14)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -workers=1 -debug -mutators=cxx_ne_to_eq -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Not Equal to Equal": {{.*}}sample.cpp:2:12 (end: 2:14)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced != with == [cxx_ne_to_eq]{{$}}

--- a/tests-lit/tests/white-ast-search/comparison/03_greater_than_to_less_than_or_equal/mull.yml
+++ b/tests-lit/tests/white-ast-search/comparison/03_greater_than_to_less_than_or_equal/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_gt_to_le
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/comparison/03_greater_than_to_less_than_or_equal/sample.cpp
+++ b/tests-lit/tests/white-ast-search/comparison/03_greater_than_to_less_than_or_equal/sample.cpp
@@ -9,15 +9,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_gt_to_le -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Greater Than to Less Or Equal": {{.*}}sample.cpp:2:12 (end: 2:13)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_gt_to_le -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Greater Than to Less Or Equal": {{.*}}sample.cpp:2:12 (end: 2:13)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced > with <= [cxx_gt_to_le]{{$}}

--- a/tests-lit/tests/white-ast-search/comparison/04_less_than_to_greater_than_or_equal/mull.yml
+++ b/tests-lit/tests/white-ast-search/comparison/04_less_than_to_greater_than_or_equal/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_lt_to_ge
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/comparison/04_less_than_to_greater_than_or_equal/sample.cpp
+++ b/tests-lit/tests/white-ast-search/comparison/04_less_than_to_greater_than_or_equal/sample.cpp
@@ -9,15 +9,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_lt_to_ge -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Less Than to Greater Or Equal": {{.*}}sample.cpp:2:12 (end: 2:13)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_lt_to_ge -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Less Than to Greater Or Equal": {{.*}}sample.cpp:2:12 (end: 2:13)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced < with >= [cxx_lt_to_ge]{{$}}

--- a/tests-lit/tests/white-ast-search/comparison/05_greater_or_equal_to_less_than/mull.yml
+++ b/tests-lit/tests/white-ast-search/comparison/05_greater_or_equal_to_less_than/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_ge_to_lt
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/comparison/05_greater_or_equal_to_less_than/sample.cpp
+++ b/tests-lit/tests/white-ast-search/comparison/05_greater_or_equal_to_less_than/sample.cpp
@@ -9,15 +9,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_ge_to_lt -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Greater Or Equal to Less Than": {{.*}}sample.cpp:2:12 (end: 2:14)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_ge_to_lt -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Greater Or Equal to Less Than": {{.*}}sample.cpp:2:12 (end: 2:14)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced >= with < [cxx_ge_to_lt]{{$}}

--- a/tests-lit/tests/white-ast-search/comparison/06_less_or_equal_to_greater_than/mull.yml
+++ b/tests-lit/tests/white-ast-search/comparison/06_less_or_equal_to_greater_than/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_le_to_gt
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/comparison/06_less_or_equal_to_greater_than/sample.cpp
+++ b/tests-lit/tests/white-ast-search/comparison/06_less_or_equal_to_greater_than/sample.cpp
@@ -9,15 +9,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_le_to_gt -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Less Or Equal To Greater Than": {{.*}}sample.cpp:2:12 (end: 2:14)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_le_to_gt -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Less Or Equal To Greater Than": {{.*}}sample.cpp:2:12 (end: 2:14)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:12: warning: Killed: Replaced <= with > [cxx_le_to_gt]{{$}}

--- a/tests-lit/tests/white-ast-search/const_assignment/01_init_const/mull.yml
+++ b/tests-lit/tests/white-ast-search/const_assignment/01_init_const/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_init_const
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/const_assignment/01_init_const/sample.cpp
+++ b/tests-lit/tests/white-ast-search/const_assignment/01_init_const/sample.cpp
@@ -12,15 +12,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_init_const -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Init Const": {{.*}}sample.cpp:4:7 (end: 4:10)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_init_const -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Init Const": {{.*}}sample.cpp:4:7 (end: 4:10)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:4:7: warning: Killed: Replaced 'T a = b' with 'T a = 42' [cxx_init_const]{{$}}

--- a/tests-lit/tests/white-ast-search/const_assignment/02_assign_const/mull.yml
+++ b/tests-lit/tests/white-ast-search/const_assignment/02_assign_const/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_assign_const
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/const_assignment/02_assign_const/sample.cpp
+++ b/tests-lit/tests/white-ast-search/const_assignment/02_assign_const/sample.cpp
@@ -13,15 +13,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_assign_const -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Assign Const": {{.*}}sample.cpp:5:7 (end: 5:8)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_assign_const -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Assign Const": {{.*}}sample.cpp:5:7 (end: 5:8)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:5:7: warning: Killed: Replaced 'a = b' with 'a = 42' [cxx_assign_const]{{$}}

--- a/tests-lit/tests/white-ast-search/experimental/remove_void/01_basic/mull.yml
+++ b/tests-lit/tests/white-ast-search/experimental/remove_void/01_basic/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_remove_void_call
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/experimental/remove_void/01_basic/sample.cpp
+++ b/tests-lit/tests/white-ast-search/experimental/remove_void/01_basic/sample.cpp
@@ -16,15 +16,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -workers=1 -debug -mutators=cxx_remove_void_call -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Remove Void": {{.*}}sample.cpp:7:3 (end: 7:17)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -workers=1 -debug -mutators=cxx_remove_void_call -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Remove Void": {{.*}}sample.cpp:7:3 (end: 7:17)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:7:3: warning: Killed: Removed the call to the function [cxx_remove_void_call]{{$}}

--- a/tests-lit/tests/white-ast-search/experimental/replace_call/01_basic/mull.yml
+++ b/tests-lit/tests/white-ast-search/experimental/replace_call/01_basic/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_replace_scalar_call
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/experimental/replace_call/01_basic/sample.cpp
+++ b/tests-lit/tests/white-ast-search/experimental/replace_call/01_basic/sample.cpp
@@ -15,15 +15,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -workers=1 -debug -mutators=cxx_replace_scalar_call -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Replace Call": {{.*}}sample.cpp:6:13 (end: 6:21)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -workers=1 -debug -mutators=cxx_replace_scalar_call -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Replace Call": {{.*}}sample.cpp:6:13 (end: 6:21)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:6:13: warning: Killed: Replaced call to a function with 42 [cxx_replace_scalar_call]{{$}}

--- a/tests-lit/tests/white-ast-search/logical/01_and_to_or/mull.yml
+++ b/tests-lit/tests/white-ast-search/logical/01_and_to_or/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_logical_and_to_or
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/logical/01_and_to_or/sample.cpp
+++ b/tests-lit/tests/white-ast-search/logical/01_and_to_or/sample.cpp
@@ -13,15 +13,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_logical_and_to_or -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Logical And to Or": {{.*}}sample.cpp:2:9 (end: 2:11)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_logical_and_to_or -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Logical And to Or": {{.*}}sample.cpp:2:9 (end: 2:11)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:9: warning: Killed: Replaced && with || [cxx_logical_and_to_or]{{$}}

--- a/tests-lit/tests/white-ast-search/logical/02_or_to_and/mull.yml
+++ b/tests-lit/tests/white-ast-search/logical/02_or_to_and/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_logical_or_to_and
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/logical/02_or_to_and/sample.cpp
+++ b/tests-lit/tests/white-ast-search/logical/02_or_to_and/sample.cpp
@@ -13,15 +13,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_logical_or_to_and -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Logical Or to And": {{.*}}sample.cpp:2:9 (end: 2:11)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -debug -mutators=cxx_logical_or_to_and -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Logical Or to And": {{.*}}sample.cpp:2:9 (end: 2:11)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:9: warning: Killed: Replaced || with && [cxx_logical_or_to_and]{{$}}

--- a/tests-lit/tests/white-ast-search/logical/cxx_remove_negation/01_unary_negated_to_unary/mull.yml
+++ b/tests-lit/tests/white-ast-search/logical/cxx_remove_negation/01_unary_negated_to_unary/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - cxx_remove_negation
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/logical/cxx_remove_negation/01_unary_negated_to_unary/sample.cpp
+++ b/tests-lit/tests/white-ast-search/logical/cxx_remove_negation/01_unary_negated_to_unary/sample.cpp
@@ -9,17 +9,22 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -workers=1 -debug -mutators=cxx_remove_negation -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -workers=1 -debug -mutators=cxx_remove_negation -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
 
 TODO: IDE reporter reports location "!a" but we would rather want to see the location of '!'.
-CHECK:[debug] CXXJunkDetector: mutation "Remove Unary Negation": {{.*}}sample.cpp:2:10 (end: 2:12)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Remove Unary Negation": {{.*}}sample.cpp:2:10 (end: 2:12)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:10: warning: Killed: Replaced !a with a [cxx_remove_negation]{{$}}

--- a/tests-lit/tests/white-ast-search/scalar/01_return_value/mull.yml
+++ b/tests-lit/tests/white-ast-search/scalar/01_return_value/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - scalar_value_mutator
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/scalar/01_return_value/sample.cpp
+++ b/tests-lit/tests/white-ast-search/scalar/01_return_value/sample.cpp
@@ -9,15 +9,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -workers=1 -debug -mutators=scalar_value_mutator -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Scalar Value": {{.*}}sample.cpp:2:3 (end: 2:9)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -workers=1 -debug -mutators=scalar_value_mutator -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Scalar Value": {{.*}}sample.cpp:2:3 (end: 2:9)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:2:3: warning: Killed: Replaced scalar with 0 or 42 [scalar_value_mutator]{{$}}

--- a/tests-lit/tests/white-ast-search/scalar/02_binary_operand/mull.yml
+++ b/tests-lit/tests/white-ast-search/scalar/02_binary_operand/mull.yml
@@ -1,0 +1,3 @@
+mutators:
+  - scalar_value_mutator
+debugEnabled: true

--- a/tests-lit/tests/white-ast-search/scalar/02_binary_operand/sample.cpp
+++ b/tests-lit/tests/white-ast-search/scalar/02_binary_operand/sample.cpp
@@ -11,15 +11,20 @@ int main() {
 // clang-format off
 
 /**
-RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
 RUN: cd %CURRENT_DIR
 RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_commands.json
-RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -workers=1 -debug -mutators=scalar_value_mutator -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
-CHECK-NOT:{{^.*[Ee]rror.*$}}
-CHECK-NOT:{{^.*[Ww]arning.*$}}
+RUN: cd / && %clang_cxx %sysroot -fembed-bitcode -g %s -o %s.exe
+RUN: cd %S && %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
 
-CHECK:[info] Applying filter: junk (threads: 1)
-CHECK:[debug] CXXJunkDetector: mutation "Scalar Value": {{.*}}sample.cpp:4:12 (end: 4:13)
+RUN: (unset TERM; %mull_cxx -linker=%clang_cxx -linker-flags="%sysroot" -workers=1 -debug -mutators=scalar_value_mutator -mutate-only -output=%s-mutated.exe -reporters=IDE -ide-reporter-show-killed -compdb-path %S/compile_commands.json %s.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTATE
+CHECK-MUTATE-NOT:{{^.*[Ee]rror.*$}}
+CHECK-MUTATE-NOT:{{^.*[Ww]arning.*$}}
+
+CHECK-MUTATE:[info] Applying filter: junk (threads: 1)
+CHECK-MUTATE:[debug] CXXJunkDetector: mutation "Scalar Value": {{.*}}sample.cpp:4:12 (end: 4:13)
+
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-mutated.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner -debug -reporters=IDE -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Killed mutants (1/1):
 CHECK:{{^.*}}sample.cpp:4:12: warning: Killed: Replaced scalar with 0 or 42 [scalar_value_mutator]{{$}}

--- a/tests-lit/tests/xclude-regex/invalid_regex/mull.yml
+++ b/tests-lit/tests/xclude-regex/invalid_regex/mull.yml
@@ -1,0 +1,6 @@
+mutators:
+  - cxx_eq_to_ne
+includePaths:
+  - "*cpp"
+excludePaths:
+  - "Output/.***"

--- a/tests-lit/tests/xclude-regex/invalid_regex/sample.cpp
+++ b/tests-lit/tests/xclude-regex/invalid_regex/sample.cpp
@@ -16,8 +16,9 @@ RUN: cd %S/Output/sandbox
 
 /// We cd to the the test directory and compile using relative paths.
 RUN: cd %S; %clang_cxx %sysroot -fembed-bitcode -g -O0 Output/sandbox/sample.cpp -o Output/sample.cpp.exe
+RUN: cd %S; %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g Output/sandbox/sample.cpp -o Output/sample.cpp-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
-RUN: cd %S/Output && echo $PATH; (unset TERM; %mull_cxx -mutators=cxx_eq_to_ne -linker-flags="%sysroot" --linker=%clang_cxx -debug sample.cpp.exe --reporters IDE --include-path=*cpp --exclude-path=Output/.***; test $? == 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output; (unset TERM; %mull_cxx -mutators=cxx_eq_to_ne -linker-flags="%sysroot" --linker=%clang_cxx -debug sample.cpp.exe --reporters IDE --include-path=*cpp --exclude-path=Output/.***; test $? == 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[warning] Invalid regex for exclude-path:{{.*}}
 CHECK:[warning] Invalid regex for include-path:{{.*}}

--- a/tests-lit/tests/xclude-regex/valid_regex/mull.yml
+++ b/tests-lit/tests/xclude-regex/valid_regex/mull.yml
@@ -1,0 +1,6 @@
+mutators:
+  - cxx_eq_to_ne
+includePaths:
+  - ".*cpp"
+excludePaths:
+  - "Output/.*"

--- a/tests-lit/tests/xclude-regex/valid_regex/sample.cpp
+++ b/tests-lit/tests/xclude-regex/valid_regex/sample.cpp
@@ -16,6 +16,7 @@ RUN: cd %S/Output/sandbox
 
 /// We cd to the the test directory and compile using relative paths.
 RUN: cd %S; %clang_cxx %sysroot -fembed-bitcode -g -O0 Output/sandbox/sample.cpp -o Output/sample.cpp.exe
+RUN: cd %S; %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g Output/sandbox/sample.cpp -o Output/sample.cpp-ir.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 RUN: cd %S/Output && echo $PATH; (unset TERM; %mull_cxx -mutators=cxx_eq_to_ne -linker-flags="%sysroot" --linker=%clang_cxx -debug sample.cpp.exe --reporters IDE --include-path=.*cpp --exclude-path=Output/.*; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 

--- a/tests/JunkDetection/CompilationDatabaseTests.cpp
+++ b/tests/JunkDetection/CompilationDatabaseTests.cpp
@@ -51,8 +51,7 @@ TEST(CompilationDatabaseFromFile, loadsFromValidFiles) {
       { "/foo/bar/foobar.cpp", "/foo/bar/./foobar.cpp", "/foo/bar/buzz/../foobar.cpp" });
   for (const std::string &file : files) {
     for (auto &path : databasePaths) {
-      const CompilationDatabase database =
-          CompilationDatabase::fromFile(diagnostics, path, "", {});
+      const CompilationDatabase database = CompilationDatabase::fromFile(diagnostics, path, "", {});
 
       auto compilationFlags = database.compilationFlagsForFile(file);
       ASSERT_EQ(compilationFlags.size(), size_t(5));

--- a/tests/MutationTestingElementsReporterTest.cpp
+++ b/tests/MutationTestingElementsReporterTest.cpp
@@ -56,7 +56,7 @@ TEST(MutationTestingElementsReporterTest, integrationTest) {
   functionsUnderTest.back().selectInstructions({});
 
   std::vector<MutationPoint *> mutationPoints =
-      mutationsFinder.getMutationPoints(diagnostics, program, functionsUnderTest);
+      mutationsFinder.getMutationPoints(diagnostics, functionsUnderTest);
 
   ASSERT_EQ(1U, mutationPoints.size());
 

--- a/tests/SQLiteReporterTest.cpp
+++ b/tests/SQLiteReporterTest.cpp
@@ -52,7 +52,7 @@ TEST(SQLiteReporter, integrationTest) {
       { FunctionUnderTest(reachableFunction, program.bitcode().front().get()) });
   functionsUnderTest.back().selectInstructions({});
   std::vector<MutationPoint *> mutationPoints =
-      mutationsFinder.getMutationPoints(diagnostics, program, functionsUnderTest);
+      mutationsFinder.getMutationPoints(diagnostics, functionsUnderTest);
 
   ASSERT_EQ(1U, mutationPoints.size());
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(mull-cxx)
 add_subdirectory(mull-cxx-frontend)
+add_subdirectory(mull-cxx-ir-frontend)
 add_subdirectory(mull-runner)

--- a/tools/mull-cxx-ir-frontend/CMakeLists.txt
+++ b/tools/mull-cxx-ir-frontend/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(mull-cxx-ir-frontend-${LLVM_VERSION_MAJOR} SHARED mull-cxx-ir-frontend.cpp)
+target_link_libraries(mull-cxx-ir-frontend-${LLVM_VERSION_MAJOR} PRIVATE LLVM mull)
+target_include_directories(mull-cxx-ir-frontend-${LLVM_VERSION_MAJOR} PRIVATE ${MULL_INCLUDE_DIRS})
+target_include_directories(mull-cxx-ir-frontend-${LLVM_VERSION_MAJOR} SYSTEM PRIVATE ${LLVM_INCLUDE_DIRS})
+set_target_properties(mull-cxx-ir-frontend-${LLVM_VERSION_MAJOR} PROPERTIES COMPILE_FLAGS ${MULL_CXX_FLAGS})
+set_target_properties(mull-cxx-ir-frontend-${LLVM_VERSION_MAJOR} PROPERTIES LIBRARY_OUTPUT_NAME mull-ir-frontend-${LLVM_VERSION_MAJOR})
+set_target_properties(mull-cxx-ir-frontend-${LLVM_VERSION_MAJOR} PROPERTIES PREFIX "")
+set_target_properties(mull-cxx-ir-frontend-${LLVM_VERSION_MAJOR} PROPERTIES SUFFIX "")

--- a/tools/mull-cxx-ir-frontend/mull-cxx-ir-frontend.cpp
+++ b/tools/mull-cxx-ir-frontend/mull-cxx-ir-frontend.cpp
@@ -1,0 +1,33 @@
+#include <llvm/IR/Module.h>
+#include <llvm/Passes/PassBuilder.h>
+#include <llvm/Passes/PassPlugin.h>
+#include <llvm/Support/raw_ostream.h>
+#include <mull/Driver.h>
+
+namespace {
+
+class MullIRFrontend : public llvm::PassInfoMixin<MullIRFrontend> {
+public:
+  llvm::PreservedAnalyses run(llvm::Module &module, llvm::ModuleAnalysisManager &mam) {
+    mull::mutateBitcode(module);
+    module.print(llvm::errs(), nullptr);
+    return llvm::PreservedAnalyses::none();
+  }
+};
+
+extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo llvmGetPassPluginInfo() {
+  return { LLVM_PLUGIN_API_VERSION,
+           "mull-ir-frontend",
+           LLVM_VERSION_STRING,
+           [](llvm::PassBuilder &PB) {
+             PB.registerPipelineStartEPCallback(
+                 [](llvm::ModulePassManager &modulePassManager
+#if LLVM_VERSION_MAJOR > 11
+                    ,
+                    llvm::PassBuilder::OptimizationLevel optimizationLevel
+#endif
+                 ) { modulePassManager.addPass(MullIRFrontend()); });
+           } };
+}
+
+} // namespace


### PR DESCRIPTION
This PR introduces an IR Frontend: a shared library that can be directly integrated into the build system.
Example:
```shell
> clang++ -fexperimental-new-pass-manager -fpass-plugin=/usr/lib/mull-ir-frontend-12 main.cpp
> mull-runner-12 a.out # a.out has all the mutations
```

Notes:
 - it doesn't work with Clang 8 (and earlier)
 - Clang 8/9/10/11 requires optimization level to be not `-O0` (e.g. `-O1`, `-O2`). Any newer version of Clang work without optimizations as well
 - with the plugin in place we can deprecate and remove `mull-cxx`, thus simplifying Mull
 - most of the tests were extended to replicate `mull-cxx` behaviour
 
TODO:
 - rewrite `Hacking on Mull` doc
 - rewrite the tutorials to use the new approach
 - add a deprecation notice to the `mull-cxx`
 - add docs for the configuration