### PR TITLE
Add (optional) tracing to mutated programs

### DIFF
--- a/include/mull/Config/Configuration.h
+++ b/include/mull/Config/Configuration.h
@@ -53,6 +53,8 @@ struct Configuration {
   std::string gitDiffRef;
   std::string gitProjectRoot;
 
+  DebugConfig debug{};
+
   Configuration();
 
   static std::string findConfig(Diagnostics &diagnostics);

--- a/include/mull/Config/ConfigurationOptions.h
+++ b/include/mull/Config/ConfigurationOptions.h
@@ -17,4 +17,11 @@ struct ParallelizationConfig {
   bool exceedsHardware();
 };
 
+struct DebugConfig {
+  bool printIR = false;
+  bool printIRBefore = false;
+  bool printIRAfter = false;
+  bool traceMutants = false;
+};
+
 } // namespace mull

--- a/include/mull/Parallelization/Tasks/MutantPreparationTasks.h
+++ b/include/mull/Parallelization/Tasks/MutantPreparationTasks.h
@@ -7,6 +7,7 @@ namespace mull {
 
 class MutationPoint;
 class progress_counter;
+struct Configuration;
 
 class CloneMutatedFunctionsTask {
 public:
@@ -44,13 +45,15 @@ public:
   using Out = std::vector<int>;
   using iterator = In::const_iterator;
 
-  InsertMutationTrampolinesTask() = default;
+  explicit InsertMutationTrampolinesTask(const Configuration &configuration)
+      : configuration(configuration) {}
 
   void operator()(iterator begin, iterator end, Out &storage,
                   progress_counter &counter);
-  static void insertTrampolines(Bitcode &bitcode);
+  static void insertTrampolines(Bitcode &bitcode, const Configuration &configuration);
 
 private:
+  const Configuration &configuration;
 };
 
 } // namespace mull

--- a/lib/Config/ConfigurationParser.cpp
+++ b/lib/Config/ConfigurationParser.cpp
@@ -25,6 +25,15 @@ template <> struct llvm::yaml::MappingTraits<ParallelizationConfig> {
   }
 };
 
+template <> struct llvm::yaml::MappingTraits<DebugConfig> {
+  static void mapping(llvm::yaml::IO &io, DebugConfig &config) {
+    io.mapOptional("printIR", config.printIR);
+    io.mapOptional("printIRAfter", config.printIRAfter);
+    io.mapOptional("printIRBefore", config.printIRBefore);
+    io.mapOptional("traceMutants", config.traceMutants);
+  }
+};
+
 template <> struct llvm::yaml::MappingTraits<Configuration> {
   static void mapping(llvm::yaml::IO &io, Configuration &config) {
     io.mapOptional("debugEnabled", config.debugEnabled);
@@ -56,6 +65,7 @@ template <> struct llvm::yaml::MappingTraits<Configuration> {
     io.mapOptional("gitProjectRoot", config.gitProjectRoot);
     io.mapOptional("includePaths", config.includePaths);
     io.mapOptional("excludePaths", config.excludePaths);
+    io.mapOptional("debug", config.debug);
   }
 };
 

--- a/tests-lit/tests/debug/printIRAfter/main.c
+++ b/tests-lit/tests/debug/printIRAfter/main.c
@@ -1,0 +1,13 @@
+// clang-format off
+
+int sum(int a, int b) {
+  return a + b;
+}
+
+int main() {
+  return sum(0, 0);
+}
+
+// RUN: %clang_cc %pass_mull_ir_frontend -g %s -o %s.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+// CHECK:define{{.*}}@sum{{.*}}
+// CHECK:define{{.*}}cxx_add_to_sub{{.*}}

--- a/tests-lit/tests/debug/printIRAfter/mull.yml
+++ b/tests-lit/tests/debug/printIRAfter/mull.yml
@@ -1,0 +1,4 @@
+mutators:
+  - cxx_add_to_sub
+debug:
+  printIRAfter: true

--- a/tests-lit/tests/debug/printIRBefore/main.c
+++ b/tests-lit/tests/debug/printIRBefore/main.c
@@ -1,0 +1,13 @@
+// clang-format off
+
+int sum(int a, int b) {
+  return a + b;
+}
+
+int main() {
+  return sum(0, 0);
+}
+
+// RUN: %clang_cc %pass_mull_ir_frontend -g %s -o %s.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+// CHECK:define{{.*}}@sum{{.*}}
+// CHECK-NOT:define{{.*}}cxx_add_to_sub{{.*}}

--- a/tests-lit/tests/debug/printIRBefore/mull.yml
+++ b/tests-lit/tests/debug/printIRBefore/mull.yml
@@ -1,0 +1,4 @@
+mutators:
+  - cxx_add_to_sub
+debug:
+  printIRBefore: true

--- a/tests-lit/tests/debug/traceMutants/main.c
+++ b/tests-lit/tests/debug/traceMutants/main.c
@@ -1,0 +1,23 @@
+// clang-format off
+
+int sum(int a, int b) {
+  return a + b;
+}
+
+int main() {
+  return sum(0, 0);
+}
+
+// RUN: %clang_cc %pass_mull_ir_frontend -g %s -o %s.exe
+// RUN: %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK
+// RUN: env "cxx_add_to_sub:%s:4:12=1" %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTANT
+
+// CHECK:mull-trace: entering sum
+// CHECK:mull-trace: checking for cxx_add_to_sub:{{.*}}/main.c:4:12
+// CHECK:mull-trace: jumping over to original sum
+// CHECK:mull-trace: trampoline call sum
+
+// CHECK-MUTANT:mull-trace: entering sum
+// CHECK-MUTANT:mull-trace: checking for cxx_add_to_sub:{{.*}}/main.c:4:12
+// CHECK-MUTANT:mull-trace: jumping over to cxx_add_to_sub:{{.*}}/main.c:4:12
+// CHECK-MUTANT:mull-trace: trampoline call sum

--- a/tests-lit/tests/debug/traceMutants/mull.yml
+++ b/tests-lit/tests/debug/traceMutants/mull.yml
@@ -1,0 +1,4 @@
+mutators:
+  - cxx_add_to_sub
+debug:
+  traceMutants: true

--- a/tests/MutationPointTests.cpp
+++ b/tests/MutationPointTests.cpp
@@ -91,6 +91,7 @@ TEST(MutationPoint, ReplaceCallMutator_applyMutation) {
 TEST(MutationPoint, OriginalValuePresent) {
   Diagnostics diagnostics;
   BitcodeLoader loader;
+  Configuration configuration{};
   auto bitcode =
       loader.loadBitcodeAtPath(fixtures::mutators_replace_assignment_module_bc_path(), diagnostics);
 
@@ -116,7 +117,7 @@ TEST(MutationPoint, OriginalValuePresent) {
 
   CloneMutatedFunctionsTask::cloneFunctions(*bitcode);
   DeleteOriginalFunctionsTask::deleteFunctions(*bitcode);
-  InsertMutationTrampolinesTask::insertTrampolines(*bitcode);
+  InsertMutationTrampolinesTask::insertTrampolines(*bitcode, configuration);
 
   for (auto *mutation : mutationPoints) {
     mutation->applyMutation();

--- a/tools/mull-cxx-ir-frontend/mull-cxx-ir-frontend.cpp
+++ b/tools/mull-cxx-ir-frontend/mull-cxx-ir-frontend.cpp
@@ -9,9 +9,7 @@ namespace {
 class MullIRFrontend : public llvm::PassInfoMixin<MullIRFrontend> {
 public:
   llvm::PreservedAnalyses run(llvm::Module &module, llvm::ModuleAnalysisManager &mam) {
-    //    module.print(llvm::errs(), nullptr);
     mull::mutateBitcode(module);
-    //    module.print(llvm::errs(), nullptr);
     return llvm::PreservedAnalyses::none();
   }
 };


### PR DESCRIPTION
Very useful for debugging!
Adds the following options to `mull.yml`:

```
debug:
  printIRBefore: true/false # print IR before transformations
  printIRAfter: true/false # print IR after transformations
  traceMutants: true/false # add various printfs to each mutated function
```