### PR TITLE
Add slow verification for debugging

### DIFF
--- a/include/mull/Config/Configuration.h
+++ b/include/mull/Config/Configuration.h
@@ -12,6 +12,7 @@ extern int MullDefaultTimeoutMilliseconds;
 class Diagnostics;
 
 struct Configuration {
+  std::string pathOnDisk;
   bool debugEnabled;
   bool quiet;
   bool silent;

--- a/include/mull/Config/ConfigurationOptions.h
+++ b/include/mull/Config/ConfigurationOptions.h
@@ -22,6 +22,7 @@ struct DebugConfig {
   bool coverage = false;
   bool gitDiff = false;
   bool filters = false;
+  bool slowIRVerification = false;
 };
 
 } // namespace mull

--- a/include/mull/Parallelization/Tasks/ApplyMutationTask.h
+++ b/include/mull/Parallelization/Tasks/ApplyMutationTask.h
@@ -7,16 +7,21 @@
 namespace mull {
 class progress_counter;
 class MutationPoint;
+struct Configuration;
+class Diagnostics;
 
 class ApplyMutationTask {
 public:
+  explicit ApplyMutationTask(const Configuration &config, Diagnostics &diagnostics);
   using In = const std::vector<MutationPoint *>;
   using Out = std::vector<int>;
   using iterator = In::const_iterator;
 
-  ApplyMutationTask() = default;
-
   void operator()(iterator begin, iterator end, Out &storage,
                   progress_counter &counter);
+
+private:
+  const Configuration &config;
+  Diagnostics &diagnostics;
 };
 } // namespace mull

--- a/lib/Config/Configuration.cpp
+++ b/lib/Config/Configuration.cpp
@@ -5,7 +5,7 @@ namespace mull {
 int MullDefaultTimeoutMilliseconds = 3000;
 
 Configuration::Configuration()
-    : debugEnabled(false), quiet(true), silent(false), dryRunEnabled(false),
+    : pathOnDisk(), debugEnabled(false), quiet(true), silent(false), dryRunEnabled(false),
       captureTestOutput(true), captureMutantOutput(true), includeNotCovered(false),
       junkDetectionDisabled(false), timeout(MullDefaultTimeoutMilliseconds),
       diagnostics(IDEDiagnosticsKind::None),

--- a/lib/Config/ConfigurationParser.cpp
+++ b/lib/Config/ConfigurationParser.cpp
@@ -34,6 +34,7 @@ template <> struct llvm::yaml::MappingTraits<DebugConfig> {
     io.mapOptional("coverage", config.coverage);
     io.mapOptional("gitDiff", config.gitDiff);
     io.mapOptional("filters", config.filters);
+    io.mapOptional("slowIRVerification", config.slowIRVerification);
   }
 };
 
@@ -94,5 +95,6 @@ Configuration Configuration::loadFromDisk(Diagnostics &diagnostics, const std::s
   llvm::yaml::Input input(bufferOrError.get()->getMemBufferRef());
   Configuration configuration;
   input >> configuration;
+  configuration.pathOnDisk = path;
   return configuration;
 }

--- a/lib/Parallelization/Tasks/ApplyMutationTask.cpp
+++ b/lib/Parallelization/Tasks/ApplyMutationTask.cpp
@@ -1,9 +1,16 @@
 #include "mull/Parallelization/Tasks/ApplyMutationTask.h"
 
+#include "mull/Config/Configuration.h"
+#include "mull/Diagnostics/Diagnostics.h"
 #include "mull/MutationPoint.h"
 #include "mull/Parallelization/Progress.h"
+#include <llvm/IR/Verifier.h>
+#include <sstream>
 
 using namespace mull;
+
+ApplyMutationTask::ApplyMutationTask(const Configuration &config, Diagnostics &diagnostics)
+    : config(config), diagnostics(diagnostics) {}
 
 void ApplyMutationTask::operator()(iterator begin, iterator end, Out &storage,
                                    progress_counter &counter) {
@@ -11,5 +18,29 @@ void ApplyMutationTask::operator()(iterator begin, iterator end, Out &storage,
     auto point = *it;
     point->recordMutation();
     point->applyMutation();
+    if (config.debug.slowIRVerification) {
+      auto module = point->getBitcode()->getModule();
+      std::string error;
+      llvm::raw_string_ostream errorStream(error);
+      if (llvm::verifyModule(*module, &errorStream)) {
+        std::stringstream message;
+        std::string mutator = point->getMutatorIdentifier();
+        message << "Uh oh! Mull corrupted LLVM module.\n"
+                << "Please, report the following error message here "
+                   "https://github.com/mull-project/mull/issues\n"
+                << "Underlying error message:\n"
+                << errorStream.str() << "\n"
+                << "The module was corrupted by '" << mutator << "' mutator.\n"
+                << "To disable it, add the following:\n"
+                   "ignoreMutators:\n"
+                << "  - " << mutator << "\n"
+                << "to the config file";
+        if (!config.pathOnDisk.empty()) {
+          message << " (" << config.pathOnDisk << ")";
+        }
+        message << "\n";
+        diagnostics.error(message.str());
+      }
+    }
   }
 }

--- a/tests-lit/tests/command_line_input_validation/valid_input/01_executable_is_dot_slash_relative_path_binary/main.c
+++ b/tests-lit/tests/command_line_input_validation/valid_input/01_executable_is_dot_slash_relative_path_binary/main.c
@@ -8,6 +8,6 @@ int main(int argc, char **argv) {
 
 // clang-format off
 
-// RUN: %clang_cc %pass_mull_ir_frontend  %s -g -o %s.exe
+// RUN: %clang_cc %sysroot %pass_mull_ir_frontend  %s -g -o %s.exe
 // RUN: %mull_runner main.c.exe -ide-reporter-show-killed | %filecheck %s --dump-input=fail --match-full-lines
 // CHECK: [info] Killed mutants (1/1):

--- a/tests-lit/tests/debug/printIRAfter/main.c
+++ b/tests-lit/tests/debug/printIRAfter/main.c
@@ -8,6 +8,6 @@ int main() {
   return sum(0, 0);
 }
 
-// RUN: %clang_cc %pass_mull_ir_frontend -g %s -o %s.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+// RUN: %clang_cc %sysroot %pass_mull_ir_frontend -g %s -o %s.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 // CHECK:define{{.*}}@sum{{.*}}
 // CHECK:define{{.*}}cxx_add_to_sub{{.*}}

--- a/tests-lit/tests/debug/printIRBefore/main.c
+++ b/tests-lit/tests/debug/printIRBefore/main.c
@@ -8,6 +8,6 @@ int main() {
   return sum(0, 0);
 }
 
-// RUN: %clang_cc %pass_mull_ir_frontend -g %s -o %s.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+// RUN: %clang_cc %sysroot %pass_mull_ir_frontend -g %s -o %s.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 // CHECK:define{{.*}}@sum{{.*}}
 // CHECK-NOT:define{{.*}}cxx_add_to_sub{{.*}}

--- a/tests-lit/tests/debug/traceMutants/main.c
+++ b/tests-lit/tests/debug/traceMutants/main.c
@@ -8,7 +8,7 @@ int main() {
   return sum(0, 0);
 }
 
-// RUN: %clang_cc %pass_mull_ir_frontend -g %s -o %s.exe
+// RUN: %clang_cc %sysroot %pass_mull_ir_frontend -g %s -o %s.exe
 // RUN: %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK
 // RUN: env "cxx_add_to_sub:%s:4:12=1" %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-MUTANT
 

--- a/tests-lit/tests/filters/blockaddress/main.c
+++ b/tests-lit/tests/filters/blockaddress/main.c
@@ -14,7 +14,7 @@ out:
   return 0;
 }
 
-// RUN: %clang_cc %pass_mull_ir_frontend -g %s -o %s.exe
+// RUN: %clang_cc %sysroot %pass_mull_ir_frontend -g %s -o %s.exe
 // RUN: %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK1
 // CHECK1:label1
 // RUN: %s.exe x | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK2

--- a/tests-lit/tests/filters/variadic-functions/main.c
+++ b/tests-lit/tests/filters/variadic-functions/main.c
@@ -43,7 +43,7 @@ int main() {
   return 0;
 }
 
-// RUN: %clang_cc %pass_mull_ir_frontend -g %s -o %s.exe
+// RUN: %clang_cc %sysroot %pass_mull_ir_frontend -g %s -o %s.exe
 // RUN: %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 // CHECK:_est
 // CHECK-NEXT:t_st


### PR DESCRIPTION
Mull verifies that the module is valid before applying any mutations, and after applying all the mutations.
it is now possible to add verification after each mutation to find the exact offensive mutation operator.
Verifying the module after each mutation adds significant overhead, so this option is disabled by default and can be enabled via the config file:
```yml
debug:
  slowIRVerification: true
```