### PR TITLE
Fall back on clang-cpp.so if libclangTooling.so is unavailable

### DIFF
--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -28,3 +28,49 @@ macro(add_mull_executable)
     RUNTIME DESTINATION bin
   )
 endmacro()
+
+function(determine_clang_component_lib lib_out component)
+  # Assume the component comes as a separate lib
+  # until otherwise proven
+  set(${lib_out} ${component} PARENT_SCOPE)
+
+  # Check whether the LLVM shared library was built
+  if("${LLVM_LINK_LLVM_DYLIB}" STREQUAL "ON" AND NOT "${LLVM_DYLIB_COMPONENTS}" STREQUAL "")
+    # The LLVM_DYLIB_COMPONENTS variable lists the components included in the
+    # shared library. According to https://llvm.org/docs/BuildingADistribution.html,
+    # it is a list of semi-colon separated names of LLVM components or special
+    # purpose names. The latter are
+    #
+    # 1. all - All available LLVM component libraries included
+    # 2. Native - The LLVM target for the native system
+    # 3. AllTargetsAsmParsers - All included target ASM parser libraries
+    # 4. AllTargetsDescs - All included target description libraries
+    # 5. AllTargetsDisassemblers - All included target dissassembler libraries
+    # 6. AllTargetsInfos - All included target info libraries
+    #
+    # I can't find any relevant reference to Native in the LLVM source tree
+    # so we leave that out for now
+    if("${LLVM_DYLIB_COMPONENTS}" STREQUAL "all")
+      # Dylib includes all components, linking against it is a safe bet
+      set(${lib_out} clang-cpp PARENT_SCOPE)
+    elseif(${component} IN_LIST LLVM_DYLIB_COMPONENTS)
+      # Component listed in DYLIB_COMPONENTS, included
+      set(${lib_out} clang-cpp PARENT_SCOPE)
+    else()
+      # Look through remaining special purpose names. Based on llvm/cmake/modules/LLVM-Config.cmake
+      # in the LLVM repo, the targets correspond to the following
+      #
+      # AllTargetsAsmParsers - All components ending in AsmParser
+      # AllTargetsDescs - All components ending in Desc
+      # AllTargetsDisassemblers - All components ending in Disassembler
+      # AllTargetsInfos - All components ending in Info
+      set(suffixes AsmParser Desc Disassembler Info)
+
+      foreach(s ${suffixes})
+        if(${component} MATCHES ".*${s}$" AND "${LLVM_DYLIB_COMPONENTS}" STREQUAL "AllTargets${s}s")
+          set(${lib_out} clang-cpp PARENT_SCOPE)
+        endif()
+      endforeach()
+    endif()
+  endif()
+endfunction()

--- a/infrastructure/Vagrantfile
+++ b/infrastructure/Vagrantfile
@@ -29,24 +29,6 @@ Vagrant.configure(2) do |config|
     end
   end
 
-  config.vm.define "ubuntu16" do |cfg|
-    cfg.vm.box = "ubuntu/xenial64"
-    cfg.ssh.insert_key = false
-
-    configure_vm("ubuntu16", cfg)
-
-    cfg.vm.provision "shell", inline: "apt-get update && apt-get install -y python"
-
-    cfg.vm.provision "ansible" do |ansible|
-      ansible.verbose = "v"
-      ansible.playbook = "ubuntu-playbook.yaml"
-      ansible.extra_vars = {
-        llvm_version: ENV['LLVM_VERSION'] || '6.0.0',
-        gitref: ENV['GITREF'] || 'main',
-      }
-    end
-  end
-
   config.vm.define "ubuntu18" do |cfg|
     cfg.vm.box = "ubuntu/bionic64"
     cfg.ssh.insert_key = false

--- a/infrastructure/Vagrantfile
+++ b/infrastructure/Vagrantfile
@@ -65,6 +65,23 @@ Vagrant.configure(2) do |config|
     end
   end
 
+  config.vm.define "ubuntu20.04" do |cfg|
+    cfg.vm.box = "ubuntu/focal64"
+    cfg.ssh.insert_key = false
+
+    configure_vm("ubuntu20.04", cfg)
+
+    cfg.vm.provision "shell", inline: "apt-get update && apt-get install -y python"
+
+    cfg.vm.provision "ansible" do |ansible|
+      ansible.verbose = "v"
+      ansible.playbook = "ubuntu-playbook.yaml"
+      ansible.extra_vars = {
+        llvm_version: ENV['LLVM_VERSION'] || '12.0.0',
+        gitref: ENV['gitref'] || 'main',
+      }
+    end
+  end
 
   config.vm.define "fedora" do |cfg|
     cfg.vm.box = "fedora/29-cloud-base"

--- a/infrastructure/Vagrantfile
+++ b/infrastructure/Vagrantfile
@@ -61,6 +61,7 @@ Vagrant.configure(2) do |config|
       ansible.extra_vars = {
         llvm_version: ENV['LLVM_VERSION'] || '10.0.0',
         gitref: ENV['GITREF'] || 'main',
+        checkout: ENV['checkout'] || 'true'
       }
     end
   end
@@ -79,6 +80,7 @@ Vagrant.configure(2) do |config|
       ansible.extra_vars = {
         llvm_version: ENV['LLVM_VERSION'] || '12.0.0',
         gitref: ENV['gitref'] || 'main',
+        checkout: ENV['checkout'] || 'true'
       }
     end
   end

--- a/infrastructure/Vagrantfile
+++ b/infrastructure/Vagrantfile
@@ -35,7 +35,7 @@ Vagrant.configure(2) do |config|
 
     configure_vm("ubuntu16", cfg)
 
-    cfg.vm.provision "shell", inline: "apt-get install -y python"
+    cfg.vm.provision "shell", inline: "apt-get update && apt-get install -y python"
 
     cfg.vm.provision "ansible" do |ansible|
       ansible.verbose = "v"
@@ -53,7 +53,7 @@ Vagrant.configure(2) do |config|
 
     configure_vm("ubuntu18", cfg)
 
-    cfg.vm.provision "shell", inline: "apt-get install -y python"
+    cfg.vm.provision "shell", inline: "apt-get update && apt-get install -y python"
 
     cfg.vm.provision "ansible" do |ansible|
       ansible.verbose = "v"
@@ -64,7 +64,7 @@ Vagrant.configure(2) do |config|
       }
     end
   end
-  
+
 
   config.vm.define "fedora" do |cfg|
     cfg.vm.box = "fedora/29-cloud-base"

--- a/infrastructure/Vagrantfile
+++ b/infrastructure/Vagrantfile
@@ -59,7 +59,7 @@ Vagrant.configure(2) do |config|
       ansible.verbose = "v"
       ansible.playbook = "ubuntu-playbook.yaml"
       ansible.extra_vars = {
-        llvm_version: ENV['LLVM_VERSION'] || '8.0.0',
+        llvm_version: ENV['LLVM_VERSION'] || '10.0.0',
         gitref: ENV['GITREF'] || 'main',
       }
     end

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -115,10 +115,12 @@ set_source_files_properties(${mull_header_dirs} PROPERTIES HEADER_FILE_ONLY ON)
 find_package(Threads REQUIRED)
 find_package(SQLite3 REQUIRED)
 
+determine_clang_component_lib(clang_tooling_lib clangTooling)
+
 target_link_libraries(mull
   LLVM
   SQLite::SQLite3
-  clangTooling
+  "${clang_tooling_lib}"
   Threads::Threads
   irm
   mull-cxx-mutators

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,11 +45,14 @@ get_filename_component(factory_include_dir ${FACTORY_HEADER} DIRECTORY)
 
 add_executable(mull-tests EXCLUDE_FROM_ALL ${mull_unittests_sources})
 gtest_discover_tests(mull-tests)
+
+determine_clang_component_lib(clang_codegen_lib clangCodeGen)
+
 target_link_libraries(mull-tests
   mull
   google-test
   json11
-  clangCodeGen
+  "${clang_codegen_lib}"
 )
 
 target_include_directories(mull-tests PUBLIC

--- a/tests/MutationPointTests.cpp
+++ b/tests/MutationPointTests.cpp
@@ -123,7 +123,7 @@ TEST(MutationPoint, OriginalValuePresent) {
     mutation->applyMutation();
   }
 
-  for (auto i = 0; i < mutationPoints.size(); i++) {
+  for (auto i = 0u; i < mutationPoints.size(); i++) {
     auto mutation = mutationPoints[i];
     std::string s;
     llvm::raw_string_ostream stream(s);


### PR DESCRIPTION
I ran into some linking issues when building Mull on Arch due to libclangTooling.so being unavaiable. After doing some digging I came upon [this bug report](https://bugs.archlinux.org/task/66283) related to Arch's packaging of clang. Turns out its not a bug at all and that they are simply building clang without `BUILD_SHARED_LIBS=on`. When this flag is not passed, the symbols end up in libclang-cpp.so instead. 

This change makes the build system handle both options by first attempting to find libclangTooling.so and, if it's missing, fall back on libclang-cpp.so instead.