### PR TITLE
Disallow surviving mutants in strict mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tests-lit/tests/**/*.ll
 
 .DS_Store
 
+tags

--- a/docs/command-line/generated/mull-runner-cli-options.rst
+++ b/docs/command-line/generated/mull-runner-cli-options.rst
@@ -28,6 +28,8 @@
 
 --strict		Enables Strict Mode: all warning messages are treated as fatal errors
 
+--allow-surviving	Do not treat mutants surviving as an error
+
 --no-test-output		Does not capture output from test runs
 
 --no-mutant-output		Does not capture output from mutant runs

--- a/infrastructure/Vagrantfile
+++ b/infrastructure/Vagrantfile
@@ -3,6 +3,8 @@
 # to upgrade instead of disabling the requirement below.
 Vagrant.require_version ">= 1.7.0"
 
+mull_version = %x(git describe --tags --dirty | tr -d '\n')
+
 def configure_vm(name, config)
   config.vm.provider "virtualbox" do |v|
     v.memory = 8192
@@ -25,6 +27,7 @@ Vagrant.configure(2) do |config|
       ansible.extra_vars = {
         llvm_version: ENV['LLVM_VERSION'] || '6.0.0',
         gitref: ENV['GITREF'] || 'main',
+        mull_version: ENV['mull_version'] || "#{mull_version}"
       }
     end
   end
@@ -43,7 +46,8 @@ Vagrant.configure(2) do |config|
       ansible.extra_vars = {
         llvm_version: ENV['LLVM_VERSION'] || '10.0.0',
         gitref: ENV['GITREF'] || 'main',
-        checkout: ENV['checkout'] || 'true'
+        checkout: ENV['checkout'] || 'true',
+        mull_version: ENV['mull_version'] || "#{mull_version}"
       }
     end
   end
@@ -62,7 +66,8 @@ Vagrant.configure(2) do |config|
       ansible.extra_vars = {
         llvm_version: ENV['LLVM_VERSION'] || '12.0.0',
         gitref: ENV['gitref'] || 'main',
-        checkout: ENV['checkout'] || 'true'
+        checkout: ENV['checkout'] || 'true',
+        mull_version: ENV['mull_version'] || "#{mull_version}"
       }
     end
   end
@@ -82,6 +87,7 @@ Vagrant.configure(2) do |config|
       ansible.extra_vars = {
         llvm_version: ENV['LLVM_VERSION'] || '6.0.0',
         gitref: ENV['GITREF'] || 'main',
+        mull_version: ENV['mull_version'] || "#{mull_version}"
       }
     end
   end
@@ -106,6 +112,7 @@ Vagrant.configure(2) do |config|
         ansible_python_interpreter: '/usr/local/bin/python',
         make_program: 'gmake',
         gitref: ENV['GITREF'] || 'main',
+        mull_version: ENV['mull_version'] || "#{mull_version}"
       }
     end
   end
@@ -123,6 +130,7 @@ Vagrant.configure(2) do |config|
         llvm_version: ENV['LLVM_VERSION'] || '8.0.0',
         gitref: ENV['GITREF'] || 'main',
         SDKROOT: '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk',
+        mull_version: ENV['mull_version'] || "#{mull_version}"
       }
     end
 

--- a/infrastructure/helpers/integration-tests.yaml
+++ b/infrastructure/helpers/integration-tests.yaml
@@ -43,7 +43,7 @@
     chdir: "{{ working_dir }}/integration/fmt.build.dir"
 
 - name: Run Mull against fmt
-  command: mull-runner-{{ llvm_major }} {{ working_dir }}/integration/fmt.build.dir/bin/core-test
+  command: mull-runner-{{ llvm_major }} --allow-surviving {{ working_dir }}/integration/fmt.build.dir/bin/core-test
 
 - name: Clone OpenSSL
   git:
@@ -96,4 +96,4 @@
     LD_LIBRARY_PATH: "{{ working_dir }}/integration/openssl"
 
 - name: Run Mull against OpenSSL
-  command: mull-runner-{{ llvm_major }} {{ working_dir }}/integration/openssl/test/bio_enc_test
+  command: mull-runner-{{ llvm_major }} --allow-surviving {{ working_dir }}/integration/openssl/test/bio_enc_test

--- a/infrastructure/helpers/lit-tests.yaml
+++ b/infrastructure/helpers/lit-tests.yaml
@@ -3,8 +3,12 @@
   command: ninja tests-lit
   args:
     chdir: "{{ debug_build_dir }}"
+  environment:
+    PATH: /home/vagrant/.local/bin:{{ ansible_env.PATH }}
 
 - name: Run LIT tests (Release)
   command: ninja tests-lit
   args:
     chdir: "{{ release_build_dir }}"
+  environment:
+    PATH: /home/vagrant/.local/bin:{{ ansible_env.PATH }}

--- a/tests-lit/tests/filters/coverage/01/main.c
+++ b/tests-lit/tests/filters/coverage/01/main.c
@@ -11,7 +11,7 @@ int main(int argc, char **argv) {
 
 // clang-format off
 // RUN: %clang_cc %sysroot %s %pass_mull_ir_frontend -g -o %s.exe
-// RUN: unset TERM; %mull_runner %s.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-NO-COVERAGE
+// RUN: unset TERM; %mull_runner --allow-surviving %s.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-NO-COVERAGE
 // CHECK-NO-COVERAGE:[info] Survived mutants (1/1):
 // CHECK-NO-COVERAGE:{{^.*}}main.c:2:5: warning: Survived: Replaced + with - [cxx_add_to_sub]
 // CHECK-NO-COVERAGE:[info] Mutation score: 0%

--- a/tests-lit/tests/filters/coverage/partial-covered-functions/main.c
+++ b/tests-lit/tests/filters/coverage/partial-covered-functions/main.c
@@ -23,7 +23,7 @@ int main(){
 }
 // clang-format off
 // RUN: %clang_cc %sysroot %s %pass_mull_ir_frontend -g -o %s.exe
-// RUN: unset TERM; %mull_runner %s.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-NO-COVERAGE
+// RUN: unset TERM; %mull_runner --allow-surviving %s.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-NO-COVERAGE
 // CHECK-NO-COVERAGE:[info] Survived mutants (4/4):
 // CHECK-NO-COVERAGE:{{^.*}}main.c:5:16: warning: Survived: Replaced + with - [cxx_add_to_sub]
 // CHECK-NO-COVERAGE:{{^.*}}main.c:10:11: warning: Survived: Replaced + with - [cxx_add_to_sub]
@@ -32,10 +32,10 @@ int main(){
 // CHECK-NO-COVERAGE:[info] Mutation score: 0%
 
 // RUN: %clang_cc %sysroot %s %pass_mull_ir_frontend -g -fprofile-instr-generate -fcoverage-mapping -o %s-cov.exe
-// RUN: unset TERM; %mull_runner -include-not-covered %s-cov.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-COVERAGE
+// RUN: unset TERM; %mull_runner --allow-surviving -include-not-covered %s-cov.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-COVERAGE
 // RUN: env LLVM_PROFILE_FILE=%s.profraw %s-cov.exe
 // RUN: %llvm_profdata merge %s.profraw -o %s.profdata
-// RUN: unset TERM; %mull_runner -coverage-info %s.profdata -include-not-covered %s-cov.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-COVERAGE
+// RUN: unset TERM; %mull_runner --allow-surviving -coverage-info %s.profdata -include-not-covered %s-cov.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-COVERAGE
 // CHECK-COVERAGE:[info] Survived mutants (2/4):
 // CHECK-COVERAGE:{{^.*}}main.c:10:11: warning: Survived: Replaced + with - [cxx_add_to_sub]
 // CHECK-COVERAGE:{{^.*}}main.c:14:21: warning: Survived: Replaced + with - [cxx_add_to_sub]

--- a/tests-lit/tests/filters/junk-detection/00_error_compilation_flags_database_does_not_match_real_flags/sample.cpp
+++ b/tests-lit/tests/filters/junk-detection/00_error_compilation_flags_database_does_not_match_real_flags/sample.cpp
@@ -18,10 +18,10 @@ RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.with_flag.json.template > %S/compi
 
 RUN: cd %CURRENT_DIR
 RUN: cd / && env MULL_CONFIG=%S/mull.no_junk.yml %clang_cxx -O0 %sysroot %pass_mull_ir_frontend -g -DFLAG=1 %s -o %s-ir-no-junk.exe
-RUN: %mull_runner -reporters=IDE %s-ir-no-junk.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
+RUN: %mull_runner --allow-surviving -reporters=IDE %s-ir-no-junk.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
 
 RUN: cd %S && env MULL_CONFIG=%S/mull.no_flag.yml %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g -DFLAG=1 %s -o %s-ir-no-flag.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-NO-FLAG-MUTATE
-RUN: %mull_runner %s-ir-no-flag.exe -reporters=IDE -ide-reporter-show-killed 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-NO-FLAG
+RUN: %mull_runner --allow-surviving %s-ir-no-flag.exe -reporters=IDE -ide-reporter-show-killed 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-NO-FLAG
 
 RUN: cd %S && env MULL_CONFIG=%S/mull.with_flag.yml %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g -DFLAG=1 %s -o %s-ir-with-flag.exe 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAG-MUTATE
 RUN: %mull_runner %s-ir-with-flag.exe -reporters=IDE -ide-reporter-show-killed 2>&1 | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-JUNK-DETECTION-WITH-FLAG

--- a/tests-lit/tests/filters/junk-detection/01_junk_detection/sample.cpp
+++ b/tests-lit/tests/filters/junk-detection/01_junk_detection/sample.cpp
@@ -14,7 +14,7 @@ RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/Output/compile_
 RUN: sed -e "s:%CC:%clang_cc:g" %S/Output/compile_commands.json.temp > %S/compile_commands.json
 RUN: cd %CURRENT_DIR
 RUN: env MULL_CONFIG=%S/mull.no_junk.yml %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g %s -o %s-ir-no-junk.exe
-RUN: %mull_runner -workers=1 -reporters=IDE %s-ir-no-junk.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
+RUN: %mull_runner --allow-surviving -workers=1 -reporters=IDE %s-ir-no-junk.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
 WITHOUT-JUNK-DETECTION:{{^.*}}[info] Running mutants (threads: 1){{$}}
 WITHOUT-JUNK-DETECTION:{{^.*}}sample.cpp:2:13: warning: Survived: Removed the call to the function [cxx_remove_void_call]{{$}}
 WITHOUT-JUNK-DETECTION-NOT:[info] Mutation score: 100%

--- a/tests-lit/tests/filters/junk-detection/02_junk_detection_using_extra_flags/sample.cpp
+++ b/tests-lit/tests/filters/junk-detection/02_junk_detection_using_extra_flags/sample.cpp
@@ -15,7 +15,7 @@ int main() {
 /**
 RUN: cd %CURRENT_DIR
 RUN: cd / && env MULL_CONFIG=%S/mull.no_junk.yml %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g -DFLAG=1 %s -o %s-ir-no-junk.exe
-RUN: %mull_runner -reporters=IDE %s-ir-no-junk.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
+RUN: %mull_runner --allow-surviving -reporters=IDE %s-ir-no-junk.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
 
 WITHOUT-JUNK-DETECTION:{{^.*}}sample.cpp:5:13: warning: Survived: Removed the call to the function [cxx_remove_void_call]{{$}}
 

--- a/tests-lit/tests/filters/junk-detection/03_junk_detection_merging_comp_db_and_extra_flags/sample.cpp
+++ b/tests-lit/tests/filters/junk-detection/03_junk_detection_merging_comp_db_and_extra_flags/sample.cpp
@@ -21,7 +21,7 @@ RUN: sed -e "s:%PWD:%S:g" %S/compile_commands.json.template > %S/compile_command
 RUN: cd %CURRENT_DIR
 
 RUN: cd / && env MULL_CONFIG=%S/mull.no_junk.yml %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g -DFLAG_VIA_COMP_DB=1 -DFLAG_VIA_EXTRA_FLAGS=1 %s -o %s-ir-no-junk.exe
-RUN: %mull_runner %s-ir-no-junk.exe -reporters=IDE | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
+RUN: %mull_runner --allow-surviving %s-ir-no-junk.exe -reporters=IDE | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-JUNK-DETECTION
 
 WITHOUT-JUNK-DETECTION:{{^.*}}sample.cpp:9:13: warning: Survived: Removed the call to the function [cxx_remove_void_call]{{$}}
 

--- a/tests-lit/tests/filters/junk-detection/04_junk_detection_using_bitcode_compilation_flags_via_record_command_line_flag/sample.cpp
+++ b/tests-lit/tests/filters/junk-detection/04_junk_detection_using_bitcode_compilation_flags_via_record_command_line_flag/sample.cpp
@@ -16,7 +16,7 @@ int main() {
 RUN: cd %CURRENT_DIR
 
 RUN: cd / && env MULL_CONFIG=%S/mull.no_junk.yml %clang_cxx %sysroot %pass_mull_ir_frontend -g -DFLAG=1 %s -o %s-ir-no-junk.exe
-RUN: (unset TERM; %mull_runner -reporters=IDE -ide-reporter-show-killed %s-ir-no-junk.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-RECORD-COMMAND-LINE
+RUN: (unset TERM; %mull_runner --allow-surviving -reporters=IDE -ide-reporter-show-killed %s-ir-no-junk.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-RECORD-COMMAND-LINE
 WITHOUT-RECORD-COMMAND-LINE-MUTATE-NOT:Found compilation flags in the input bitcode
 WITHOUT-RECORD-COMMAND-LINE:{{^.*}}sample.cpp:5:13: warning: Survived: Removed the call to the function [cxx_remove_void_call]{{$}}
 

--- a/tests-lit/tests/mutations/logical/and_or_combined/01/main.c
+++ b/tests-lit/tests/mutations/logical/and_or_combined/01/main.c
@@ -86,7 +86,7 @@ int main() {
 // clang-format off
 
 // RUN: %clang_cc %sysroot -O0 %pass_mull_ir_frontend -g %s -o %s-ir.exe
-// RUN: unset TERM; %mull_runner -ide-reporter-show-killed -reporters=IDE %s-ir.exe | %filecheck %s --dump-input=fail
+// RUN: unset TERM; %mull_runner --allow-surviving -ide-reporter-show-killed -reporters=IDE %s-ir.exe | %filecheck %s --dump-input=fail
 // CHECK:[info] Killed mutants (4/8):
 // CHECK:{{.*}}main.c:6:23: warning: Killed: Replaced || with && [cxx_logical_or_to_and]
 // CHECK:  if (a < b && (b < c || a < c)) {

--- a/tests-lit/tests/mutations/logical/cxx_logical_and_to_or/01/main.c
+++ b/tests-lit/tests/mutations/logical/cxx_logical_and_to_or/01/main.c
@@ -92,7 +92,7 @@ int main() {
 // clang-format off
 
 // RUN: %clang_cc %sysroot -O0 %pass_mull_ir_frontend -g %s -o %s-ir.exe
-// RUN: unset TERM; %mull_runner -ide-reporter-show-killed -reporters=IDE %s-ir.exe | %filecheck %s --dump-input=fail
+// RUN: unset TERM; %mull_runner --allow-surviving -ide-reporter-show-killed -reporters=IDE %s-ir.exe | %filecheck %s --dump-input=fail
 // CHECK:[info] Killed mutants (2/5):
 // CHECK:{{.*}}main.c:8:13: warning: Killed: Replaced && with || [cxx_logical_and_to_or]
 // CHECK:  if (a < b && b < c) {

--- a/tests-lit/tests/mutations/logical/cxx_logical_or_to_and/01/main.c
+++ b/tests-lit/tests/mutations/logical/cxx_logical_or_to_and/01/main.c
@@ -92,7 +92,7 @@ int main() {
 // clang-format off
 
 // RUN: %clang_cc %sysroot -O0 %pass_mull_ir_frontend -g %s -o %s-ir.exe
-// RUN: unset TERM; %mull_runner -ide-reporter-show-killed -reporters=IDE %s-ir.exe | %filecheck %s --dump-input=fail
+// RUN: unset TERM; %mull_runner --allow-surviving -ide-reporter-show-killed -reporters=IDE %s-ir.exe | %filecheck %s --dump-input=fail
 // CHECK:[info] Killed mutants (2/5):
 // CHECK:{{.*}}8:13: warning: Killed: Replaced || with && [cxx_logical_or_to_and]
 // CHECK:  if (a < b || b < c) {

--- a/tests-lit/tests/mutations/logical/cxx_remove_negation/main.cpp
+++ b/tests-lit/tests/mutations/logical/cxx_remove_negation/main.cpp
@@ -15,7 +15,7 @@ int main() {
 
 /**
 RUN: %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g %s -o %s-ir.exe
-RUN: unset TERM; %mull_runner -workers=1 --ide-reporter-show-killed -reporters=IDE %s-ir.exe | %filecheck %s --dump-input=fail
+RUN: unset TERM; %mull_runner --allow-surviving -workers=1 --ide-reporter-show-killed -reporters=IDE %s-ir.exe | %filecheck %s --dump-input=fail
 CHECK:[info] Running mutants (threads: 1)
 CHECK:{{^       \[################################\] 2/2\. Finished .*}}
 CHECK:[info] Killed mutants (1/2):
@@ -24,5 +24,6 @@ CHECK:[info] Survived mutants (1/2):
 CHECK:{{^.*}}main.cpp:6:10: warning: Survived: Replaced !a with a [cxx_remove_negation]{{$}}
 CHECK:[info] Mutation score: 50%
 CHECK:[info] Total execution time: {{.*}}
+CHECK:[info] Surviving mutants: 1
 CHECK-EMPTY:
 **/

--- a/tests-lit/tests/mutations/logical/phi_nodes/main.c
+++ b/tests-lit/tests/mutations/logical/phi_nodes/main.c
@@ -9,7 +9,7 @@ int main() {
 }
 
 // RUN: %clang_cc %sysroot -O0 %pass_mull_ir_frontend -g %s -o %s.exe
-// RUN: unset TERM; %mull_runner -reporters=IDE %s.exe | %filecheck %s --dump-input=fail
+// RUN: unset TERM; %mull_runner --allow-surviving -reporters=IDE %s.exe | %filecheck %s --dump-input=fail
 // CHECK:[info] Survived mutants (3/3):
 // CHECK-NEXT:{{.*}}main.c:5:9: warning: Survived: Replaced && with || [cxx_logical_and_to_or]
 // CHECK-NEXT:  a = a && a && a;

--- a/tests-lit/tests/mutations/math/cxx_add_to_sub/03_no_ret/sample.cpp
+++ b/tests-lit/tests/mutations/math/cxx_add_to_sub/03_no_ret/sample.cpp
@@ -11,6 +11,6 @@ int main() {
 
 /**
 RUN: %clang_cxx %sysroot %pass_mull_ir_frontend -g -O0 %s -o %s-ir.exe
-RUN: unset TERM; %mull_runner -reporters=IDE %s-ir.exe | %filecheck %s --dump-input=fail
+RUN: unset TERM; %mull_runner --allow-surviving -reporters=IDE %s-ir.exe | %filecheck %s --dump-input=fail
 CHECK-NOT:[error]
 **/

--- a/tests-lit/tests/options/-ide-reporter-show-killed/02_one_survived/sample.cpp
+++ b/tests-lit/tests/options/-ide-reporter-show-killed/02_one_survived/sample.cpp
@@ -7,8 +7,8 @@ RUN: %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s.exe
 /// 1) when -reporters=IDE is not provided
 /// 2) when -reporters=IDE is provided
 
-RUN: (unset TERM; %mull_runner %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
-RUN: (unset TERM; %mull_runner -reporters=IDE %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
+RUN: (unset TERM; %mull_runner --allow-surviving %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
+RUN: (unset TERM; %mull_runner --allow-surviving -reporters=IDE %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
 WITHOUT-OPTION:[info] Running mutants (threads: 1)
 WITHOUT-OPTION:{{^       \[################################\] 1/1\. Finished .*}}
 WITHOUT-OPTION:[info] Survived mutants (1/1):
@@ -17,8 +17,8 @@ WITHOUT-OPTION-NEXT:  int result = a + b;
 WITHOUT-OPTION-NEXT:                 ^
 WITHOUT-OPTION-NEXT:[info] Mutation score: 0%
 
-RUN: (unset TERM; %mull_runner -ide-reporter-show-killed %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
-RUN: (unset TERM; %mull_runner -reporters=IDE -ide-reporter-show-killed %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
+RUN: (unset TERM; %mull_runner --allow-surviving -ide-reporter-show-killed %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
+RUN: (unset TERM; %mull_runner --allow-surviving -reporters=IDE -ide-reporter-show-killed %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
 WITH-OPTION:[info] Running mutants (threads: 1)
 WITH-OPTION:{{^       \[################################\] 1/1\. Finished .*}}
 WITH-OPTION:[info] Survived mutants (1/1):

--- a/tests-lit/tests/options/-ide-reporter-show-killed/03_one_surviving_one_killed/sample.cpp
+++ b/tests-lit/tests/options/-ide-reporter-show-killed/03_one_surviving_one_killed/sample.cpp
@@ -7,8 +7,8 @@ RUN: %clang_cxx %sysroot %pass_mull_ir_frontend -g %s -o %s.exe
 /// 1) when -reporters=IDE is not provided
 /// 2) when -reporters=IDE is provided
 
-RUN: (unset TERM; %mull_runner %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
-RUN: (unset TERM; %mull_runner -reporters=IDE %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
+RUN: (unset TERM; %mull_runner --allow-surviving %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
+RUN: (unset TERM; %mull_runner --allow-surviving -reporters=IDE %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITHOUT-OPTION)
 WITHOUT-OPTION:[info] Running mutants (threads: 2)
 WITHOUT-OPTION:{{^       \[################################\] 2/2\. Finished .*}}
 WITHOUT-OPTION:[info] Survived mutants (1/2):
@@ -17,8 +17,8 @@ WITHOUT-OPTION-NEXT:  result = result + 0;
 WITHOUT-OPTION-NEXT:                  ^
 WITHOUT-OPTION-NEXT:[info] Mutation score: 50%
 
-RUN: (unset TERM; %mull_runner -ide-reporter-show-killed %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
-RUN: (unset TERM; %mull_runner -reporters=IDE -ide-reporter-show-killed %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
+RUN: (unset TERM; %mull_runner --allow-surviving -ide-reporter-show-killed %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
+RUN: (unset TERM; %mull_runner --allow-surviving -reporters=IDE -ide-reporter-show-killed %s.exe | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=WITH-OPTION)
 WITH-OPTION:[info] Running mutants (threads: 2)
 WITH-OPTION:{{^       \[################################\] 2/2\. Finished .*}}
 WITH-OPTION:[info] Killed mutants (1/2):

--- a/tests-lit/tests/reporters/github-reporter/equality/main.cpp
+++ b/tests-lit/tests/reporters/github-reporter/equality/main.cpp
@@ -18,7 +18,7 @@ RUN: cd %S/Output/sandbox
 /// We cd to the the test directory and compile using relative paths.
 RUN: cd %S; %clang_cxx %sysroot -g -O0 %pass_mull_ir_frontend Output/sandbox/main.cpp -o Output/main.cpp-ir.exe
 
-RUN: cd %S/Output && echo $PATH; (unset TERM; %mull_runner main.cpp-ir.exe --report-name test --reporters GithubAnnotations --reporters IDE; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output && echo $PATH; (unset TERM; %mull_runner --allow-surviving main.cpp-ir.exe --report-name test --reporters GithubAnnotations --reporters IDE; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Github Annotations:
 CHECK:{{::}}warning file={{.*}}/main.cpp,line=2,col=12,endLine=2,endColumn=14::[cxx_eq_to_ne] Replaced == with !=

--- a/tests-lit/tests/reporters/github-reporter/shift/main.cpp
+++ b/tests-lit/tests/reporters/github-reporter/shift/main.cpp
@@ -18,7 +18,7 @@ RUN: cd %S/Output/sandbox
 /// We cd to the the test directory and compile using relative paths.
 RUN: cd %S; %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g Output/sandbox/main.cpp -o Output/main.cpp-ir.exe
 
-RUN: cd %S/Output && echo $PATH; (unset TERM; %mull_runner main.cpp-ir.exe --report-name test --reporters GithubAnnotations --reporters IDE; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: cd %S/Output && echo $PATH; (unset TERM; %mull_runner --allow-surviving main.cpp-ir.exe --report-name test --reporters GithubAnnotations --reporters IDE; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 
 CHECK:[info] Github Annotations:
 CHECK:{{::}}warning file={{.*}}/main.cpp,line=2,col=12,endLine=2,endColumn=14::[cxx_lshift_to_rshift] Replaced << with >>

--- a/tests-lit/tests/reporters/invalid-paths/main.c
+++ b/tests-lit/tests/reporters/invalid-paths/main.c
@@ -12,7 +12,7 @@ int main() {
 RUN: cp %s Output/main.c
 RUN: %clang_cc %sysroot -g -O0 %pass_mull_ir_frontend Output/main.c -o Output/main.exe
 RUN: rm Output/main.c
-RUN: %mull_runner Output/main.exe -reporters IDE -reporters Patches -reporters Elements | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: %mull_runner --allow-surviving Output/main.exe -reporters IDE -reporters Patches -reporters Elements | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK:[warning] IDEReporter: Cannot report 'cxx_add_to_sub:{{.*}}/Output/main.c:2:12': cannot read {{.*}}Output/main.c
 CHECK:[warning] PatchesReporter: Cannot report 'cxx_add_to_sub:{{.*}}/Output/main.c:2:12': cannot read {{.*}}Output/main.c
 CHECK:[warning] ElementsReporter: Cannot report 'cxx_add_to_sub:{{.*}}/Output/main.c:2:12': cannot read {{.*}}Output/main.c

--- a/tests-lit/tests/reporters/sqlite-reporter/equality/main.cpp
+++ b/tests-lit/tests/reporters/sqlite-reporter/equality/main.cpp
@@ -15,7 +15,7 @@ int main() {
 /**
 RUN: %clang_cxx %sysroot -g -O0 %pass_mull_ir_frontend %s -o Output/main.cpp.exe
 RUN: rm -f test.sqlite
-RUN: %mull_runner Output/main.cpp.exe --report-name test --reporters SQLite
+RUN: %mull_runner --allow-surviving Output/main.cpp.exe --report-name test --reporters SQLite
 RUN: sqlite3 ./test.sqlite -line "select * from information order by key" | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines --check-prefix=CHECK-INFO
 CHECK-INFO:  key = Build Date
 CHECK-INFO:  key = Commit

--- a/tests-lit/tests/runner/external-test-program/main.c
+++ b/tests-lit/tests/runner/external-test-program/main.c
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
 
 // RUN: %clang_cc %sysroot %s %pass_mull_ir_frontend -g -o %s-ir.exe
 
-// RUN: %mull_runner %s-ir.exe -ide-reporter-show-killed -test-program %python3 -- %S/test.py %s-ir.exe "first test case" | %filecheck %s --dump-input=fail --match-full-lines --check-prefix=CHECK-TEST1
+// RUN: %mull_runner %s-ir.exe --allow-surviving -ide-reporter-show-killed -test-program %python3 -- %S/test.py %s-ir.exe "first test case" | %filecheck %s --dump-input=fail --match-full-lines --check-prefix=CHECK-TEST1
 // CHECK-TEST1: [info] Killed mutants (1/2):
 // CHECK-TEST1: {{.*}}/main.c:5:12: warning: Killed: Replaced + with - [cxx_add_to_sub]
 // CHECK-TEST1:   return a + b;
@@ -51,7 +51,7 @@ int main(int argc, char **argv) {
 // CHECK-TEST1:   return a * b;
 // CHECK-TEST1:            ^
 
-// RUN: %mull_runner %s-ir.exe -ide-reporter-show-killed -test-program %python3 -- %S/test.py %s-ir.exe "second test case" | %filecheck %s --dump-input=fail --match-full-lines --check-prefix=CHECK-TEST2
+// RUN: %mull_runner %s-ir.exe --allow-surviving -ide-reporter-show-killed -test-program %python3 -- %S/test.py %s-ir.exe "second test case" | %filecheck %s --dump-input=fail --match-full-lines --check-prefix=CHECK-TEST2
 // CHECK-TEST2: [info] Killed mutants (1/2):
 // CHECK-TEST2: {{.*}}/main.c:9:12: warning: Killed: Replaced * with / [cxx_mul_to_div]
 // CHECK-TEST2:   return a * b;

--- a/tests-lit/tests/tutorials/hello-world/step-1-version/sample.cpp
+++ b/tests-lit/tests/tutorials/hello-world/step-1-version/sample.cpp
@@ -4,7 +4,7 @@ RUN: %mull_runner -version 2>&1 | %filecheck %s --dump-input=fail --strict-white
 CHECK:Mull: Practical mutation testing for C and C++
 CHECK:Home: https://github.com/mull-project/mull
 CHECK:Docs: https://mull.readthedocs.io
-CHECK:{{^Version: \d+\.\d+.\d+(-pr[0-9]+|-trunk[0-9]+)?$}}
+CHECK:{{^Version: \d+\.\d+.\d+(-pr[0-9]+|-trunk[0-9]+|-\d+-g[a-zA-Z0-9]+(-dirty)?)?$}}
 CHECK:{{^Commit: [a-h0-9]+$}}
 CHECK:{{^Date: .*$}}
 CHECK:{{^LLVM: \d+\.\d+.\d+$}}

--- a/tests-lit/tests/tutorials/hello-world/step-3-one-survived-mutation/sample.cpp
+++ b/tests-lit/tests/tutorials/hello-world/step-3-one-survived-mutation/sample.cpp
@@ -2,7 +2,7 @@
 
 /**
 RUN: cd %S && %clang_cxx %sysroot -O0 %pass_mull_ir_frontend -g %s -o %s-ir.exe
-RUN: (unset TERM; %mull_runner -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
+RUN: (unset TERM; %mull_runner --allow-surviving -ide-reporter-show-killed %s-ir.exe 2>&1; test $? = 0) | %filecheck %s --dump-input=fail --strict-whitespace --match-full-lines
 CHECK:[info] Killed mutants (1/2):
 CHECK:{{^.*}}sample.cpp:14:11: warning: Killed: Replaced >= with < [cxx_ge_to_lt]{{$}}
 CHECK:[info] Survived mutants (1/2):

--- a/tools/CLIOptions/CLIOptions.h
+++ b/tools/CLIOptions/CLIOptions.h
@@ -139,6 +139,14 @@ opt<bool> StrictModeEnabled( \
     init(false), \
     cat(MullCategory)) \
 
+#define AllowSurvivingEnabled_() \
+opt<bool> AllowSurvivingEnabled( \
+    "allow-surviving", \
+    desc("Do not treat mutants surviving as an error"), \
+    Optional, \
+    init(false), \
+    cat(MullCategory)) \
+
 #define NoTestOutput_() \
 opt<bool> NoTestOutput( \
     "no-test-output", \

--- a/tools/mull-runner/mull-runner-cli.h
+++ b/tools/mull-runner/mull-runner-cli.h
@@ -13,6 +13,7 @@ DumpMutators_();
 ReportersOption_();
 DebugEnabled_();
 StrictModeEnabled_();
+AllowSurvivingEnabled_();
 Timeout_();
 Workers_();
 NoOutput_();
@@ -45,6 +46,7 @@ void dumpCLIInterface(mull::Diagnostics &diagnostics) {
       &IDEReporterShowKilled,
       &DebugEnabled,
       &StrictModeEnabled,
+      &AllowSurvivingEnabled,
 
       &NoTestOutput,
       &NoMutantOutput,


### PR DESCRIPTION
The --help for strict mode states that "all warning messages are treated as fatal errors". While this is indeed true for anything that goes through Diagnostics::warning, there are a few messages presented as warnings that are not written via said function. The one (and at least so far only) concrete example I have come across are warnings written in printMutant in IDEReporter.cpp which emits messages similar to

```text
<file>:144:17: warning: Survived: Replaced > with >= [cxx_gt_to_ge]
    if(currsize > size) {
                ^
```

Given the description for the --strict flag, it would seem as though the above should be considered a fatal error too. 

The warnings written in printMutant are currently written through fprintf. While it would be simple to change this this to use Diagnostics::warning instead, that doesn't seem to be the best approach. Seeing as all the mutants have already run, all that would achieve is cut parts of the report.

Instead of omitting useful information, this checks the number of surviving mutants at the very end of mull-runner's main. If any survived, this is logged this via Diagnostics::warning. This way, mull-runner will exit with a non-zero status if there are surviving mutants in strict mode. If not in strict mode, mull-runner always exits with status 0.

This change would, of course, alter the behavior of the --strict flag which I could see being a deal breaker. If that is the case, perhaps it'd be better to add another command line argument to achieve the intended results. Either way, I'd personally find it very useful to have a way of forcing Mull to exit with an error when there are surviving mutants.

Please let me know if you'd prefer this to be handled differently