### PR TITLE
Add support for LLVM 17

### DIFF
--- a/include/mull/Reporters/SourceManager.h
+++ b/include/mull/Reporters/SourceManager.h
@@ -2,6 +2,7 @@
 
 #include "mull/SourceLocation.h"
 
+#include <cstdint>
 #include <map>
 #include <utility>
 #include <vector>

--- a/lib/Filters/CoverageFilter.cpp
+++ b/lib/Filters/CoverageFilter.cpp
@@ -4,6 +4,10 @@
 #include "mull/Mutant.h"
 #include <llvm/ProfileData/Coverage/CoverageMapping.h>
 
+#if LLVM_VERSION_MAJOR >= 17
+#include <llvm/Support/VirtualFileSystem.h>
+#endif
+
 using namespace mull;
 
 static std::unique_ptr<llvm::coverage::CoverageMapping>
@@ -17,8 +21,13 @@ loadCoverage(const Configuration &configuration, Diagnostics &diagnostics,
   for (auto &object : objects) {
     objectFiles.emplace_back(object);
   }
+
   llvm::Expected<std::unique_ptr<llvm::coverage::CoverageMapping>> maybeMapping =
-      llvm::coverage::CoverageMapping::load(objectFiles, profileName);
+    llvm::coverage::CoverageMapping::load(objectFiles, profileName
+#if LLVM_VERSION_MAJOR >= 17
+      , *llvm::vfs::getRealFileSystem()
+#endif
+    );
   if (!maybeMapping) {
     std::string error;
     llvm::raw_string_ostream os(error);

--- a/lib/JunkDetection/CXX/ASTStorage.cpp
+++ b/lib/JunkDetection/CXX/ASTStorage.cpp
@@ -250,7 +250,7 @@ ThreadSafeASTUnit *ASTStorage::findAST(const std::string &sourceFile) {
     diagnostics.warning(message.str());
   }
 
-  auto threadSafeAST = new ThreadSafeASTUnit(std::unique_ptr<clang::ASTUnit>(ast));
+  auto threadSafeAST = new ThreadSafeASTUnit(std::unique_ptr<clang::ASTUnit>(std::move(ast)));
   astUnits[sourceFile] = std::unique_ptr<ThreadSafeASTUnit>(threadSafeAST);
   return threadSafeAST;
 }

--- a/lib/Path.cpp
+++ b/lib/Path.cpp
@@ -1,5 +1,6 @@
 #include "mull/Path.h"
 
+#include <limits.h>
 #include <llvm/Support/Path.h>
 #include <llvm/Support/FileSystem.h>
 

--- a/tests/Helpers/InMemoryCompiler.cpp
+++ b/tests/Helpers/InMemoryCompiler.cpp
@@ -52,7 +52,7 @@ std::unique_ptr<llvm::Module> InMemoryCompiler::compile(const std::string &code,
   auto &headerSearchOptions = compilerInvocation.getHeaderSearchOpts();
   headerSearchOptions.Verbose = false;
   auto &codeGenOptions = compilerInvocation.getCodeGenOpts();
-  codeGenOptions.setDebugInfo(clang::codegenoptions::FullDebugInfo);
+  codeGenOptions.setDebugInfo(llvm::codegenoptions::FullDebugInfo);
   codeGenOptions.DebugColumnInfo = 1;
   codeGenOptions.DebugCompilationDir = "/";
   codeGenOptions.MainFileName = "/in-memory-file.cc";

--- a/tests/Helpers/InMemoryCompiler.cpp
+++ b/tests/Helpers/InMemoryCompiler.cpp
@@ -52,7 +52,13 @@ std::unique_ptr<llvm::Module> InMemoryCompiler::compile(const std::string &code,
   auto &headerSearchOptions = compilerInvocation.getHeaderSearchOpts();
   headerSearchOptions.Verbose = false;
   auto &codeGenOptions = compilerInvocation.getCodeGenOpts();
-  codeGenOptions.setDebugInfo(llvm::codegenoptions::FullDebugInfo);
+  codeGenOptions.setDebugInfo(
+#if LLVM_VERSION_MAJOR >= 17
+    llvm::codegenoptions::FullDebugInfo
+#else
+    clang::codegenoptions::FullDebugInfo
+#endif
+  );
   codeGenOptions.DebugColumnInfo = 1;
   codeGenOptions.DebugCompilationDir = "/";
   codeGenOptions.MainFileName = "/in-memory-file.cc";

--- a/tools/mull-cxx-frontend/src/ASTNodeFactory.cpp
+++ b/tools/mull-cxx-frontend/src/ASTNodeFactory.cpp
@@ -164,7 +164,9 @@ clang::SectionAttr *ASTNodeFactory::createSectionAttr(std::string sectionName) {
   return clang::SectionAttr::Create(context,
                                     sectionName,
                                     clang::SourceRange(),
+#if LLVM_VERSION_MAJOR < 17
                                     clang::AttributeCommonInfo::Syntax::AS_GNU,
+#endif
                                     clang::SectionAttr::Spelling::SpellingNotCalculated);
 }
 

--- a/tools/mull-runner/MergeInstProfile.cpp
+++ b/tools/mull-runner/MergeInstProfile.cpp
@@ -5,11 +5,19 @@
 #include <llvm/ProfileData/InstrProfWriter.h>
 #include <llvm/Support/raw_ostream.h>
 
+#if LLVM_VERSION_MAJOR >= 17
+#include <llvm/Support/VirtualFileSystem.h>
+#endif
+
 using namespace std::string_literals;
 
 bool mull::mergeRawInstProfile(Diagnostics &diagnostics, const std::string &input,
                                const std::string &output) {
-  auto maybeReader = llvm::InstrProfReader::create(input);
+  auto maybeReader = llvm::InstrProfReader::create(input
+#if LLVM_VERSION_MAJOR >= 17
+      , *llvm::vfs::getRealFileSystem()
+#endif
+  );
   if (!maybeReader) {
     diagnostics.warning("cannot read raw profile data: "s +
                         llvm::toString(maybeReader.takeError()));


### PR DESCRIPTION
This PR adds support to build Mull with LLVM 17.

I have not yet updated any documentation or ci infrastructure. Please see if this can be incorporated into Mull, if any further modifications are required I can do so. This PR supports our [devcontainer](https://github.com/philips-software/amp-devcontainer) use-case.