### PR TITLE
Add a mutation score threshold so that we can still pass without kill…

### DIFF
--- a/tests-lit/tests/runner/mutation-score-threshold/mull.yml
+++ b/tests-lit/tests/runner/mutation-score-threshold/mull.yml
@@ -1,0 +1,5 @@
+mutators:
+  - cxx_init_const
+  - cxx_add_to_sub
+
+quiet: false

--- a/tests-lit/tests/runner/mutation-score-threshold/test.c
+++ b/tests-lit/tests/runner/mutation-score-threshold/test.c
@@ -1,0 +1,17 @@
+int sum(int a, int b) {
+  return a + b;
+}
+
+int main() {
+  int r = sum(2, 5) == 7;
+  return !r;
+}
+
+// clang-format off
+
+/*
+
+RUN: %clang_cc %sysroot %s %pass_mull_ir_frontend -g -o %S/test.exe
+
+RUN: cd /; unset TERM; %mull_runner --mutation-score-threshold 49 %S/test.exe
+*/

--- a/tools/CLIOptions/CLIOptions.h
+++ b/tools/CLIOptions/CLIOptions.h
@@ -147,6 +147,14 @@ opt<bool> AllowSurvivingEnabled( \
     init(false), \
     cat(MullCategory)) \
 
+#define MutationScoreThreshold_() \
+opt<unsigned> MutationScoreThreshold( \
+    "mutation-score-threshold", \
+    desc("If mutation score falls under this threshold, and allow-surviving is not enabled, an error result code is returned"), \
+    Optional, \
+    init(100), \
+    cat(MullCategory)) \
+
 #define NoTestOutput_() \
 opt<bool> NoTestOutput( \
     "no-test-output", \

--- a/tools/mull-runner/mull-runner-cli.h
+++ b/tools/mull-runner/mull-runner-cli.h
@@ -14,6 +14,7 @@ ReportersOption_();
 DebugEnabled_();
 StrictModeEnabled_();
 AllowSurvivingEnabled_();
+MutationScoreThreshold_();
 Timeout_();
 Workers_();
 NoOutput_();

--- a/tools/mull-runner/mull-runner.cpp
+++ b/tools/mull-runner/mull-runner.cpp
@@ -275,10 +275,6 @@ int main(int argc, char **argv) {
     stringstream << "Surviving mutants: " << surviving;
     diagnostics.info(stringstream.str());
 
-    std::stringstream mutationScoreMsg;
-    mutationScoreMsg << "Mutation score threshold: " << tool::MutationScoreThreshold;
-    diagnostics.info(mutationScoreMsg.str());
-
     if ((!tool::AllowSurvivingEnabled) && (tool::MutationScoreThreshold > score)) {
       return 1;
     }


### PR DESCRIPTION
Add a mutation score threshold so that we can still pass without killing every single mutant.

Motivation:
I want to use mull in my CI/CD pipeline to make sure incoming pull requests meet a minimum testing standard.

Currently, mull can be configured to pass (return exit code 0) if a) all mutants are killed or b) all surviving mutants are ignored.  This is accomplished via the "--allow-surviving" command line option.

I'd like a more granular option.  I might like to have (nearly) all mutations enabled, but killing every single mutant may not be worth it to me, especially if they are inside code that isn't critical like formatting log messages or rare catch blocks.  I'd prefer to pass/fail based on a mutation score threshold.

Hence this pull request.