### PR TITLE
Remove LLVM 13 support on macOS

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -16,8 +16,6 @@ jobs:
       matrix:
         include:
           - OS_NAME: "macos"
-            LLVM_VERSION: 13
-          - OS_NAME: "macos"
             LLVM_VERSION: 14
           - OS_NAME: "macos"
             LLVM_VERSION: 15

--- a/infrastructure/generator.py
+++ b/infrastructure/generator.py
@@ -7,7 +7,7 @@ import shutil
 
 SUPPORTED_PLATFORMS = {
     "ubuntu": {"20.04": [12], "22.04": [13, 14, 15], "24.04": [14, 15, 16, 17, 18]},
-    "macos": {"latest": [13, 14, 15, 16, 17, 18]},
+    "macos": {"latest": [14, 15, 16, 17, 18]},
 }
 
 


### PR DESCRIPTION
LLVM 13 was removed from Homebrew on 31.12.2024