### PR TITLE
Support for building with LLVM 19

### DIFF
--- a/lib/JunkDetection/CXX/ASTStorage.cpp
+++ b/lib/JunkDetection/CXX/ASTStorage.cpp
@@ -77,7 +77,7 @@ const clang::FileEntry *ThreadSafeASTUnit::findFileEntry(const std::string &file
   const clang::FileEntry *file = nullptr;
   for (auto it = begin; it != end; it++) {
 #if LLVM_VERSION_MAJOR >= 18
-    llvm::StringRef currentSourceFilePath = it->first.getFileEntry().getName();
+    llvm::StringRef currentSourceFilePath = it->first.getName();
 #else
     llvm::StringRef currentSourceFilePath = it->first->getName();
 #endif

--- a/lib/JunkDetection/CXX/CompilationDatabase.cpp
+++ b/lib/JunkDetection/CXX/CompilationDatabase.cpp
@@ -79,7 +79,11 @@ static void resolveResourceDir(Diagnostics &diagnostics, CompilationDatabase::Da
     }
     bool needsResourceDir = true;
     for (auto &flag : flags) {
+#if LLVM_VERSION_MAJOR < 18
       if (llvm::StringRef(flag).endswith("-resource-dir")) {
+#else
+      if (llvm::StringRef(flag).ends_with("-resource-dir")) {
+#endif
         needsResourceDir = false;
       }
     }

--- a/lib/MutationPoint.cpp
+++ b/lib/MutationPoint.cpp
@@ -5,6 +5,7 @@
 
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Function.h>
+#include <llvm/IR/Module.h>
 #include <llvm/Transforms/Utils/Cloning.h>
 #include <llvm/Transforms/Utils/ModuleUtils.h>
 

--- a/tools/mull-reporter/mull-reporter.cpp
+++ b/tools/mull-reporter/mull-reporter.cpp
@@ -7,6 +7,7 @@
 #include "mull/Version.h"
 
 #include <llvm/Support/FileSystem.h>
+#include <llvm/Support/ManagedStatic.h>
 
 #include <algorithm>
 #include <memory>

--- a/tools/mull-runner/DynamicLibraries.cpp
+++ b/tools/mull-runner/DynamicLibraries.cpp
@@ -43,7 +43,7 @@ void librariesFromElf(const ELFObjectFile<T> &file, std::vector<std::string> &li
     llvm::StringRef name = getSectionName(elfSection);
     // FIXME: the dynamic string table should be taken based on .dynamic
     // section's sh_link value
-    if (elfSection.getType() == llvm::ELF::SHT_STRTAB && name.equals(".dynstr")) {
+    if (elfSection.getType() == llvm::ELF::SHT_STRTAB && name == ".dynstr") {
       stringTableIterator = it;
     }
     if (elfSection.getType() == llvm::ELF::SHT_DYNAMIC) {

--- a/tools/mull-runner/DynamicLibraries.cpp
+++ b/tools/mull-runner/DynamicLibraries.cpp
@@ -161,7 +161,12 @@ bool mull::hasCoverage(mull::Diagnostics &diagnostics, const std::string &path) 
   }
 
   for (auto &section : objectFile->sections()) {
+#if LLVM_VERSION_MAJOR < 18
     if (getSectionName(section).endswith("llvm_covmap")) {
+#else
+
+    if (getSectionName(section).ends_with("llvm_covmap")) {
+#endif
       return true;
     }
   }

--- a/tools/mull-runner/MutantExtractor.cpp
+++ b/tools/mull-runner/MutantExtractor.cpp
@@ -37,7 +37,7 @@ std::vector<std::string> MutantExtractor::extractMutants(const std::string &exec
   }
   for (auto &section : objectFile->sections()) {
     llvm::StringRef name = getSectionName(section);
-    if (name.equals(".mull_mutants")) {
+    if (name == ".mull_mutants") {
       llvm::Expected<llvm::StringRef> content = section.getContents();
       if (!content) {
         return {};

--- a/tools/mull-runner/mull-runner.cpp
+++ b/tools/mull-runner/mull-runner.cpp
@@ -14,6 +14,7 @@
 #include "mull/Version.h"
 
 #include <llvm/Support/FileSystem.h>
+#include <llvm/Support/ManagedStatic.h>
 
 #include <algorithm>
 #include <memory>


### PR DESCRIPTION
I ran into some trouble when wanting to use Mull with LLVM 19. Can't claim there is too much interesting in it the incompatibilities - mostly a few functions that have been either renamed or removed, and a few headers that now need to be included explicitly.

I won't claim that there changes include everything required for full LLVM 19 compatibility. I have, for example, made no effort to update the CI so this is definitely not on par with the work done when adding LLVM 18 support. Still, it ought to at least be a decent start. If you're interested in it, you're more than welcome to use it.