### PR TITLE
Improve error messaging for file not found. 

### DIFF
--- a/lib/Reporters/SourceManager.cpp
+++ b/lib/Reporters/SourceManager.cpp
@@ -1,5 +1,7 @@
 #include "mull/Reporters/SourceManager.h"
 
+#include <string.h>
+
 #include <cassert>
 
 using namespace mull;
@@ -51,7 +53,7 @@ LineOffset &SourceManager::getLineOffset(const std::string &filePath) {
 
   FILE *file = fopen(filePath.c_str(), "rb");
   if (!file) {
-    perror("SourceManager");
+    fprintf(stderr, "SourceManager (path =  %s): %s\n", filePath.c_str(), strerror(errno));
   }
   std::vector<uint32_t> offsets;
   uint32_t offset = 0;


### PR DESCRIPTION
When a file is not found in the compilation unit, mull errors out with "SourceManager: File or Directory Not Found".

This now adds the missing file name, to ease debugging.