### PR TITLE
Fix deadlock when mull-runner executes a command with large stdout/stderr

### DIFF
--- a/rust/mull-tools/BUILD.bazel
+++ b/rust/mull-tools/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@available_llvm_versions//:mull_llvm_versions.bzl", "AVAILABLE_LLVM_VERSIONS", "EXACT_VERSION_MAPPING")
-load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
 
 [
     rust_binary(
@@ -63,3 +63,36 @@ load("@rules_rust//rust:defs.bzl", "rust_binary")
     )
     for llvm_version in AVAILABLE_LLVM_VERSIONS
 ]
+
+rust_test(
+    name = "runner-tests",
+    size = "small",
+    srcs = [
+        "dynamic_libraries.rs",
+        "init_cli.rs",
+        "mull-runner.rs",
+        "mutant_extractor.rs",
+        "reporting.rs",
+        "runner.rs",
+    ],
+    crate_root = "mull-runner.rs",
+    proc_macro_deps = [
+        "@crates//:indoc",
+    ],
+    rustc_env = {
+        "MULL_LLVM_VERSION": "0",
+        "MULL_VERSION": "0.0.0-test",
+    },
+    deps = [
+        "//rust/mull-core",
+        "//rust/mull-filters",
+        "//rust/mull-reporters",
+        "//rust/mull-state",
+        "//rust/mull-tasks",
+        "@crates//:clap",
+        "@crates//:libc",
+        "@crates//:object",
+        "@crates//:serde_yaml",
+        "@crates//:wait-timeout",
+    ],
+)

--- a/rust/mull-tools/runner.rs
+++ b/rust/mull-tools/runner.rs
@@ -41,21 +41,39 @@ pub fn run_program(
         }
     };
 
-    // Capture whatever output is available (None if Stdio::null was used)
-    let mut stdout = String::new();
-    let mut stderr = String::new();
-    let capture = |child: &mut std::process::Child, stdout: &mut String, stderr: &mut String| {
-        if let Some(mut out) = child.stdout.take() {
-            let _ = out.read_to_string(stdout);
-        }
-        if let Some(mut err) = child.stderr.take() {
-            let _ = err.read_to_string(stderr);
-        }
+    // Drain stdout/stderr in background threads to prevent pipe deadlock.
+    // If the child writes enough to fill the OS pipe buffer (~64KB) before
+    // exiting, it will block on write() and wait_timeout will never return.
+    let stdout_thread = child.stdout.take().map(|mut out| {
+        std::thread::spawn(move || {
+            let mut buf = String::new();
+            let _ = out.read_to_string(&mut buf);
+            buf
+        })
+    });
+    let stderr_thread = child.stderr.take().map(|mut err| {
+        std::thread::spawn(move || {
+            let mut buf = String::new();
+            let _ = err.read_to_string(&mut buf);
+            buf
+        })
+    });
+
+    let join_output = |stdout_thread: Option<std::thread::JoinHandle<String>>,
+                       stderr_thread: Option<std::thread::JoinHandle<String>>|
+     -> (String, String) {
+        let stdout = stdout_thread
+            .map(|t| t.join().unwrap_or_default())
+            .unwrap_or_default();
+        let stderr = stderr_thread
+            .map(|t| t.join().unwrap_or_default())
+            .unwrap_or_default();
+        (stdout, stderr)
     };
 
     match child.wait_timeout(timeout) {
         Ok(Some(status)) => {
-            capture(&mut child, &mut stdout, &mut stderr);
+            let (stdout, stderr) = join_output(stdout_thread, stderr_thread);
             ExecutionResult {
                 status: if status.success() {
                     ExecutionStatus::Passed
@@ -69,10 +87,10 @@ pub fn run_program(
             }
         }
         Ok(None) => {
-            // Timed out - kill first, then capture whatever was buffered
+            // Timed out - kill first, then join reader threads
             let _ = child.kill();
             let _ = child.wait();
-            capture(&mut child, &mut stdout, &mut stderr);
+            let (stdout, stderr) = join_output(stdout_thread, stderr_thread);
             ExecutionResult {
                 status: ExecutionStatus::Timedout,
                 exit_status: -1,
@@ -81,13 +99,16 @@ pub fn run_program(
                 stderr_output: stderr,
             }
         }
-        Err(e) => ExecutionResult {
-            status: ExecutionStatus::Failed,
-            exit_status: -1,
-            running_time: start.elapsed().as_millis() as i64,
-            stdout_output: String::new(),
-            stderr_output: format!("Wait error: {}", e),
-        },
+        Err(e) => {
+            let (stdout, stderr) = join_output(stdout_thread, stderr_thread);
+            ExecutionResult {
+                status: ExecutionStatus::Failed,
+                exit_status: -1,
+                running_time: start.elapsed().as_millis() as i64,
+                stdout_output: stdout,
+                stderr_output: format!("Wait error: {}\n{}", e, stderr),
+            }
+        }
     }
 }
 

--- a/rust/mull-tools/runner.rs
+++ b/rust/mull-tools/runner.rs
@@ -90,3 +90,40 @@ pub fn run_program(
         },
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    /// Verify that run_program does not deadlock when a child process writes
+    /// more output than the OS pipe buffer (typically ~64KB) before exiting.
+    ///
+    /// Without draining stdout/stderr in background threads before calling
+    /// wait_timeout(), the child blocks on write() once the pipe buffer fills
+    /// while the parent blocks on wait() — neither can proceed. This test
+    /// would hang until the timeout fires on an unfixed implementation.
+    #[test]
+    fn large_stdout_does_not_deadlock() {
+        // `seq 1 50000` emits ~290KB of text, well above the ~64KB pipe buffer.
+        let result = run_program(
+            "seq",
+            &["1".to_string(), "50000".to_string()],
+            &[],
+            Duration::from_secs(10),
+            true,
+        );
+        assert_ne!(
+            result.status,
+            ExecutionStatus::Timedout,
+            "run_program timed out — likely a pipe deadlock: child blocked on \
+             write() while parent blocked on wait()"
+        );
+        assert_eq!(result.status, ExecutionStatus::Passed);
+        assert!(
+            result.stdout_output.len() > 64 * 1024,
+            "expected > 64KB of stdout, got {} bytes",
+            result.stdout_output.len()
+        );
+    }
+}


### PR DESCRIPTION
When running a large test suite through mull-runner, it became stuck. The root cause was the `child.wait_timeout` never finishing because the stdout or stderr pipe filled up.

The fix I chose here was to use background threads to read stderr, stdout. They will be short lived threads. Another solution would be to use non blocking IO and polling, but that's trickier to get right, and seems like overkill for this specific function.